### PR TITLE
Add get_field_to & use expected as deserialize_result

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [async_simple](https://github.com/alibaba/async_simple)
 
 Very easy-to-use, coroutine-based, high performance rpc framework with C++20. coro_rpc is a header only library.
 
-English Introduction(TODO) | [中文简介](./src/coro_rpc/doc/基于协程和编译期反射的高性能rpc库--coro_rpc.md)  
+English Introduction(TODO) | [中文简介](./src/coro_rpc/doc/struct_pack_CN.md)  
 
 English API(TODO) | [中文API](./src/coro_rpc/doc/coro_rpc_doc.hpp)
 
@@ -29,7 +29,7 @@ English API(TODO) | [中文API](./src/coro_rpc/doc/coro_rpc_doc.hpp)
 
 Based on compile-time reflection, very easy to use, high performance serialization library, struct_pack is a header only library, it is used by coro_rpc now.
 
-English Introduction(TODO) | [中文简介](./src//struct_pack/doc/struct_pack%EF%BC%9A%E4%B8%80%E4%B8%AA%E6%9B%B4%E5%BF%AB%E6%9B%B4%E5%A5%BD%E7%94%A8%E7%9A%84%E5%BA%8F%E5%88%97%E5%8C%96%E5%BA%93.md)
+English Introduction(TODO) | [中文简介](./src//struct_pack/doc/Introduction_CN.md)
 
 English API(TODO) | [中文API](./src/struct_pack/doc/struct_pack_doc.hpp)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [async_simple](https://github.com/alibaba/async_simple)
 
 Very easy-to-use, coroutine-based, high performance rpc framework with C++20. coro_rpc is a header only library.
 
-English Introduction(TODO) | [中文简介](./src/coro_rpc/doc/struct_pack_CN.md)  
+English Introduction(TODO) | [中文简介](./src/coro_rpc/doc/基于协程和编译期反射的高性能rpc库--coro_rpc.md)  
 
 English API(TODO) | [中文API](./src/coro_rpc/doc/coro_rpc_doc.hpp)
 

--- a/src/struct_pack/doc/Introduction_CN.md
+++ b/src/struct_pack/doc/Introduction_CN.md
@@ -28,11 +28,10 @@ std::vector<char> result = serialize(person1);
 ## 反序列化
 
 ```c++
-person person2;
 // 1行代码反序列化
-auto ec = deserialize_to<person>(person2, buffer.data(), buffer.size());
-assert(ec == std::errc{});
-assert(p1 == p2);
+auto person2 = deserialize<person>(buffer);
+assert(person2); //person2.has_value()==true
+assert(person2.value()==person1);
 ```
 
 ## 部分反序列化
@@ -41,9 +40,9 @@ assert(p1 == p2);
 
 ```c++
 // 只反序列化person的第2个字段
-auto [err, name] = get_field<person, 1>(buffer.data(), buffer.size());
-
-assert(name == "hello struct pack");
+auto name = get_field<person, 1>(buffer.data(), buffer.size());
+assert(name); //name.has_value()==true
+assert(name.value() == "hello struct pack");
 ```
 
 ## 支持序列化所有的STL容器、自定义容器和optional
@@ -81,8 +80,9 @@ struct nested_object {
 
 nested_object nested{.id = 2, .name = "tom", .p = {20, "tom"}, .o = {}};
 auto buffer = serialize(nested);
-auto [err, nested1] = deserialize(buffer.data(), buffer.size());
-assert(nested==nested1);
+auto nested2 = deserialize(buffer.data(), buffer.size());
+assert(nested2)
+assert(nested2==nested1);
 ```
 
 自定义容器的序列化

--- a/src/struct_pack/examples/serialize/serialize.cpp
+++ b/src/struct_pack/examples/serialize/serialize.cpp
@@ -66,23 +66,23 @@ void basic_usage() {
   auto buffer = struct_pack::serialize(p);
   // api 1. deserialize object to return value
   {
-    auto [ec, p2] =
-        struct_pack::deserialize<person>(buffer.data(), buffer.size());
-    assert(ec == std::errc{});
-    assert(p == p2);
+    auto p2 = struct_pack::deserialize<person>(buffer.data(), buffer.size());
+    assert(p2);  // no error
+    assert(p2.value() == p2);
   }
   // api 2. deserialize object to reference
   {
     person p2;
-    [[maybe_unused]] auto ec = struct_pack::deserialize_to(p2, buffer.data(), buffer.size());
+    [[maybe_unused]] auto ec =
+        struct_pack::deserialize_to(p2, buffer.data(), buffer.size());
     assert(ec == std::errc{});
     assert(p == p2);
   }
   // api 3. partial deserialize
   {
-    auto [err, name] =
-        struct_pack::get_field<person, 1>(buffer.data(), buffer.size());
-    assert(p.name == name);
+    auto name = struct_pack::get_field<person, 1>(buffer.data(), buffer.size());
+    assert(name);  // no error
+    assert(p.name == name.value());
   }
 }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What is changing

### The return value of `struct_pack::deserialize(...)` is changing to `struct_pack::expected`
`struct_pack::expected` is easier for use.
If you don't want to check error explicitly. it will throw exception when you access value。
Otherwise, you can use `if (result) {...}` to instead of  `if (err==std::errc{}) {...}`。

### Add `struct_pack::get_field_to`
Like get_field, but return value by reference.

