### PR TITLE
add deserialize varadic support & it's document

### DIFF
--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -277,69 +277,99 @@ template <typename T, detail::struct_pack_byte Byte>
   return ret;
 }
 
-template <typename T, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE expected<T, std::errc> deserialize(
-    const View &v) {
-  expected<T, std::errc> ret;
-  if (auto errc = deserialize_to(ret.value(), v); errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+template <typename T, typename... Args, detail::deserialize_view View>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const View &v) {
+  if constexpr (sizeof...(Args) > 0) {
+    return deserialize<std::tuple<T, Args...>>(v);
   }
-  return ret;
+  else {
+    expected<T, std::errc> ret;
+    if (auto errc = deserialize_to(ret.value(), v); errc != std::errc{}) {
+      ret = unexpected<std::errc>{errc};
+    }
+    return ret;
+  }
 }
 
-template <typename T, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE expected<T, std::errc> deserialize(
-    const Byte *data, size_t size) {
-  expected<T, std::errc> ret;
-  if (auto errc = deserialize_to(ret.value(), data, size);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+template <typename T, typename... Args, detail::struct_pack_byte Byte>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const Byte *data,
+                                                  size_t size) {
+  if constexpr (sizeof...(Args) > 0) {
+    return deserialize<std::tuple<T, Args...>>(data, size);
   }
-  return ret;
+  else {
+    expected<T, std::errc> ret;
+    if (auto errc = deserialize_to(ret.value(), data, size);
+        errc != std::errc{}) {
+      ret = unexpected<std::errc>{errc};
+    }
+    return ret;
+  }
 }
 
-template <typename T, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE expected<T, std::errc> deserialize(
-    const View &v, size_t &consume_len) {
-  expected<T, std::errc> ret;
-  if (auto errc = deserialize_to(ret.value(), v, consume_len);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+template <typename T, typename... Args, detail::deserialize_view View>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const View &v,
+                                                  size_t &consume_len) {
+  if constexpr (sizeof...(Args) > 0) {
+    return deserialize<std::tuple<T, Args...>>(v, consume_len);
   }
-  return ret;
+  else {
+    expected<T, std::errc> ret;
+    if (auto errc = deserialize_to(ret.value(), v, consume_len);
+        errc != std::errc{}) {
+      ret = unexpected<std::errc>{errc};
+    }
+    return ret;
+  }
 }
 
-template <typename T, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE expected<T, std::errc> deserialize(
-    const Byte *data, size_t size, size_t &consume_len) {
-  expected<T, std::errc> ret;
-  if (auto errc = deserialize_to(ret.value(), data, size, consume_len);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+template <typename T, typename... Args, detail::struct_pack_byte Byte>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const Byte *data, size_t size,
+                                                  size_t &consume_len) {
+  if constexpr (sizeof...(Args) > 0) {
+    return deserialize<std::tuple<T, Args...>>(data, size, consume_len);
   }
-  return ret;
+  else {
+    expected<T, std::errc> ret;
+    if (auto errc = deserialize_to(ret.value(), data, size, consume_len);
+        errc != std::errc{}) {
+      ret = unexpected<std::errc>{errc};
+    }
+    return ret;
+  }
 }
 
-template <typename T, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE expected<T, std::errc> deserialize_with_offset(
-    const View &v, size_t &offset) {
-  expected<T, std::errc> ret;
-  if (auto errc = deserialize_to_with_offset(ret.value(), v, offset);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+template <typename T, typename... Args, detail::deserialize_view View>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize_with_offset(const View &v,
+                                                              size_t &offset) {
+  if constexpr (sizeof...(Args) > 0) {
+    return deserialize<std::tuple<T, Args...>>(v, offset);
   }
-  return ret;
+  else {
+    expected<T, std::errc> ret;
+    if (auto errc = deserialize_to_with_offset(ret.value(), v, offset);
+        errc != std::errc{}) {
+      ret = unexpected<std::errc>{errc};
+    }
+    return ret;
+  }
 }
 
-template <typename T, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE expected<T, std::errc> deserialize_with_offset(
-    const Byte *data, size_t size, size_t &offset) {
-  expected<T, std::errc> ret;
-  if (auto errc = deserialize_to_with_offset(ret.value(), data, size, offset);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+template <typename T, typename... Args, detail::struct_pack_byte Byte>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize_with_offset(const Byte *data,
+                                                              size_t size,
+                                                              size_t &offset) {
+  if constexpr (sizeof...(Args) > 0) {
+    return deserialize<std::tuple<T, Args...>>(data, size, offset);
   }
-  return ret;
+  else {
+    expected<T, std::errc> ret;
+    if (auto errc = deserialize_to_with_offset(ret.value(), data, size, offset);
+        errc != std::errc{}) {
+      ret = unexpected<std::errc>{errc};
+    }
+    return ret;
+  }
 }
 
 template <typename T, size_t I, typename Field, detail::deserialize_view View>

--- a/src/struct_pack/doc/Introduction_CN.md
+++ b/src/struct_pack/doc/Introduction_CN.md
@@ -1,28 +1,34 @@
 # 目录
 - [目录](#目录)
 - [struct_pack简介](#struct_pack简介)
-- [基本用法](#基本用法)
   - [序列化](#序列化)
+    - [基本用法](#基本用法)
+    - [指定序列化返回的容器类型](#指定序列化返回的容器类型)
+    - [将序列化结果保存到已有的容器尾部](#将序列化结果保存到已有的容器尾部)
+    - [将序列化结果保存到指针指向的内存中。](#将序列化结果保存到指针指向的内存中)
+    - [多参数序列化](#多参数序列化)
   - [反序列化](#反序列化)
-  - [部分反序列化](#部分反序列化)
+    - [基本用法](#基本用法-1)
+    - [从指针指向的内存中反序列化](#从指针指向的内存中反序列化)
+    - [反序列化（将结果保存到已有的对象中）](#反序列化将结果保存到已有的对象中)
+    - [多参数反序列化](#多参数反序列化)
+    - [部分反序列化](#部分反序列化)
   - [支持序列化所有的STL容器、自定义容器和optional](#支持序列化所有的stl容器自定义容器和optional)
-- [benchmark](#benchmark)
-  - [测试方法](#测试方法)
-  - [测试对象](#测试对象)
-  - [测试环境](#测试环境)
-  - [测试结果](#测试结果)
-- [向前/向后兼容性](#向前向后兼容性)
-- [为什么struct_pack更快？](#为什么struct_pack更快)
-- [附录](#附录)
-  - [测试代码](#测试代码)
+  - [benchmark](#benchmark)
+    - [测试方法](#测试方法)
+    - [测试对象](#测试对象)
+    - [测试环境](#测试环境)
+    - [测试结果](#测试结果)
+  - [向前/向后兼容性](#向前向后兼容性)
+  - [为什么struct_pack更快？](#为什么struct_pack更快)
+  - [附录](#附录)
+    - [测试代码](#测试代码)
 
 # struct_pack简介
 
 struct_pack是一个以零成本抽象，高度易用为特色序列化库。通常情况下只需一行代码即可完成复杂结构体的序列化/反序列化。用户无需定义任何DSL，宏或模板代码，struct_pack可通过编译期反射自动支持对C++结构体的序列化。其综合性能比protobuf，msgpack大幅提升(详细可以看benchmark部分)。
 
-# 基本用法
-
-以一个简单的对象为例展示struc_pack的基本用法。
+下面，我们以一个简单的对象为例展示struc_pack的基本用法。
 
 ```c++
 struct person {
@@ -31,19 +37,52 @@ struct person {
   int age;
   double salary;
 };
+
+person person1{.id = 1, .name = "hello struct pack", .age = 20, .salary = 1024.42};
 ```
 
 ## 序列化
+### 基本用法 
 
 ```c++
-// 初始化一个person对象
-person person1{.id = 1, .name = "hello struct pack", .age = 20, .salary = 1024.42};
-
 // 1行代码序列化
-std::vector<char> result = serialize(person1);
+std::vector<char> result = struct_pack::serialize(person1);
+```
+
+### 指定序列化返回的容器类型
+
+```c++
+auto result = struct_pack::serialize<std::string>(person1);
+//指定使用std::string而不是std::vector<char>
+```
+
+### 将序列化结果保存到已有的容器尾部
+
+```c++
+std::string result="The next line is struct_pack serialize result.\n";
+auto result = struct_pack::serialize_to(result,person1);
+//将结果保存到已有的容器尾部。
+```
+
+### 将序列化结果保存到指针指向的内存中。
+
+```c++
+auto sz=struct_pack::get_needed_siarray(person1);
+std::unique_ptr array=std::make_unique<char[]>(sz);
+auto result = struct_pack::serialize_to(array.get(),sz,person1);
+//将结果保存指针指向的内存中。
+```
+
+### 多参数序列化
+
+```c++
+auto result=struct_pack::serialize(person1.id,person1.name,person1.age,person1.salary);
+//serialize as std::tuple<int,std::string,double>
 ```
 
 ## 反序列化
+
+### 基本用法
 
 ```c++
 // 1行代码反序列化
@@ -52,7 +91,39 @@ assert(person2); //person2.has_value()==true
 assert(person2.value()==person1);
 ```
 
-## 部分反序列化
+### 从指针指向的内存中反序列化
+
+```c++
+// 1行代码反序列化
+auto person2 = deserialize<person>(buffer.data(),buffer.size());
+assert(person2); //person2.has_value()==true
+assert(person2.value()==person1);
+```
+
+### 反序列化（将结果保存到已有的对象中）
+
+```c++
+// 1行代码反序列化
+person person2;
+std::errc ec = deserialize_to(person2, buffer);
+assert(ec==std::errc{}); //person2.has_value()==true
+assert(person2==person1);
+```
+
+### 多参数反序列化
+
+```c++
+auto person2 = deserialize<int64_t,std::string,int,double>(buffer);
+assert(person2);//person2.has_value()==true
+auto &&[id,name,age,salary]=person2.value();
+assert(person1.id==id);
+assert(person1.name==name);
+assert(person1.age==age);
+assert(person1.salary==salary);
+```
+
+
+### 部分反序列化
 
 有时候只想反序列化对象的某个特定的字段而不是全部，这时候就可以用部分反序列化功能了，这样可以避免全部反序列化，大幅提升效率。
 
@@ -121,13 +192,13 @@ auto buffer1 = serialize(map1);
 auto buffer2 = serialize(map2);
 ```
 
-# benchmark
+## benchmark
 
-## 测试方法
+### 测试方法
 
 待序列化的对象已经预先初始化，存储序列化结果的内存已经预先分配。对每个测试用例。我们运行一百万次序列化/反序列化，对结果取平均值。
 
-## 测试对象
+### 测试对象
 
 1. 含有整形、浮点型和字符串类型person对象
 
@@ -180,17 +251,17 @@ struct rect {
 };
 ```
 
-## 测试环境
+### 测试环境
 
 Compiler: Alibaba Clang 13
 
 CPU: (Intel(R) Xeon(R) Platinum 8163 CPU @ 2.50GHz)
 
-## 测试结果
+### 测试结果
 
 ![](./images/struct_pack_bench.png)
 
-# 向前/向后兼容性
+## 向前/向后兼容性
 
 当对象增加新的字段时，怎么保证兼容新旧对象的解析呢？当用户需要添加字段时，只需要在**新对象末尾**
 增加新的 `struct_pack::compatible<T>` 字段即可。<br />以person对象为例：
@@ -211,7 +282,7 @@ struct person1 {
 
 struct_pack保证这两个类可以通过序列化和反序列化实现安全的相互转换，从而实现了向前/向后的兼容性。
 
-# 为什么struct_pack更快？
+## 为什么struct_pack更快？
 
 1. 精简的类型信息，高效的类型校验。MD5计算在编译期完成，运行时只需要比较32bit的hash值是否相同即可。
 2. struct_pack是一个模板库，鼓励编译器积极的内联函数。
@@ -219,8 +290,8 @@ struct_pack保证这两个类可以通过序列化和反序列化实现安全的
 5. struct_pack的内存布局更接近于C++结构体原始的内存布局，减少了序列化反序列化的工作量。
 6. 编译期类型计算允许struct_pack根据不同的类型生成不同的代码。因此我们可以根据不同的类型的特点做优化。例如对于连续容器可以直接memcpy，对于string_view反序列化时可以采用零拷贝优化。
 
-# 附录
+## 附录
 
-## 测试代码
+### 测试代码
 
 请见 [benchmark.cpp](../benchmark/benchmark.cpp)

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -789,11 +789,21 @@ TEST_CASE("testing exceptions") {
   }
 }
 
-TEST_CASE("testing serialize varadic params") {
+TEST_CASE("testing serialize/deserialize varadic params") {
   {
     auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
-    auto res = struct_pack::deserialize<std::tuple<int, int, int, int, int>>(
-        ret.data(), ret.size());
+    auto res = struct_pack::deserialize<int, int, int, int, int>(ret.data(),
+                                                                 ret.size());
+    CHECK(res);
+    CHECK(std::get<0>(res.value()) == 1);
+    CHECK(std::get<1>(res.value()) == 2);
+    CHECK(std::get<2>(res.value()) == 3);
+    CHECK(std::get<3>(res.value()) == 4);
+    CHECK(std::get<4>(res.value()) == 5);
+  }
+  {
+    auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
+    auto res = struct_pack::deserialize<int, int, int, int, int>(ret);
     CHECK(res);
     CHECK(std::get<0>(res.value()) == 1);
     CHECK(std::get<1>(res.value()) == 2);
@@ -808,10 +818,35 @@ TEST_CASE("testing serialize varadic params") {
         std::array<std::vector<int>, 3>{
             {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
         std::variant<int, float, double>{1.4});
-    auto res = struct_pack::deserialize<std::tuple<
-        int, float, double, int, unsigned long long, std::string,
-        std::array<std::vector<int>, 3>, std::variant<int, float, double>>>(
-        ret.data(), ret.size());
+    auto res =
+        struct_pack::deserialize<int, float, double, int, unsigned long long,
+                                 std::string, std::array<std::vector<int>, 3>,
+                                 std::variant<int, float, double>>(ret.data(),
+                                                                   ret.size());
+    CHECK(res);
+    auto &values = res.value();
+    CHECK(std::get<0>(values) == 42);
+    CHECK(std::get<1>(values) == 2.71828f);
+    CHECK(std::get<2>(values) == 3.1415926);
+    CHECK(std::get<3>(values) == 71086291);
+    CHECK(std::get<4>(values) == 1145141919810Ull);
+    CHECK(std::get<5>(values) == std::string{"Hello"});
+    CHECK(std::get<6>(values) ==
+          std::array<std::vector<int>, 3>{
+              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
+    CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
+  }
+  {
+    auto ret = struct_pack::serialize(
+        42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
+        std::string{"Hello"},
+        std::array<std::vector<int>, 3>{
+            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
+        std::variant<int, float, double>{1.4});
+    auto res =
+        struct_pack::deserialize<int, float, double, int, unsigned long long,
+                                 std::string, std::array<std::vector<int>, 3>,
+                                 std::variant<int, float, double>>(ret);
     CHECK(res);
     auto &values = res.value();
     CHECK(std::get<0>(values) == 42);
@@ -828,8 +863,20 @@ TEST_CASE("testing serialize varadic params") {
   {
     std::vector<char> ret;
     struct_pack::serialize_to(ret, 1, 2, 3, 4, 5);
-    auto res = struct_pack::deserialize<std::tuple<int, int, int, int, int>>(
-        ret.data(), ret.size());
+    auto res = struct_pack::deserialize<int, int, int, int, int>(ret.data(),
+                                                                 ret.size());
+    CHECK(res);
+    auto &values = res.value();
+    CHECK(std::get<0>(values) == 1);
+    CHECK(std::get<1>(values) == 2);
+    CHECK(std::get<2>(values) == 3);
+    CHECK(std::get<3>(values) == 4);
+    CHECK(std::get<4>(values) == 5);
+  }
+  {
+    std::vector<char> ret;
+    struct_pack::serialize_to(ret, 1, 2, 3, 4, 5);
+    auto res = struct_pack::deserialize<int, int, int, int, int>(ret);
     CHECK(res);
     auto &values = res.value();
     CHECK(std::get<0>(values) == 1);
@@ -846,10 +893,36 @@ TEST_CASE("testing serialize varadic params") {
         std::array<std::vector<int>, 3>{
             {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
         std::variant<int, float, double>{1.4});
-    auto res = struct_pack::deserialize<std::tuple<
-        int, float, double, int, unsigned long long, std::string,
-        std::array<std::vector<int>, 3>, std::variant<int, float, double>>>(
-        ret.data(), ret.size());
+    auto res =
+        struct_pack::deserialize<int, float, double, int, unsigned long long,
+                                 std::string, std::array<std::vector<int>, 3>,
+                                 std::variant<int, float, double>>(ret.data(),
+                                                                   ret.size());
+    CHECK(res);
+    auto &values = res.value();
+    CHECK(std::get<0>(values) == 42);
+    CHECK(std::get<1>(values) == 2.71828f);
+    CHECK(std::get<2>(values) == 3.1415926);
+    CHECK(std::get<3>(values) == 71086291);
+    CHECK(std::get<4>(values) == 1145141919810Ull);
+    CHECK(std::get<5>(values) == std::string{"Hello"});
+    CHECK(std::get<6>(values) ==
+          std::array<std::vector<int>, 3>{
+              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
+    CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
+  }
+  {
+    std::vector<char> ret;
+    struct_pack::serialize_to(
+        ret, 42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
+        std::string{"Hello"},
+        std::array<std::vector<int>, 3>{
+            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
+        std::variant<int, float, double>{1.4});
+    auto res =
+        struct_pack::deserialize<int, float, double, int, unsigned long long,
+                                 std::string, std::array<std::vector<int>, 3>,
+                                 std::variant<int, float, double>>(ret);
     CHECK(res);
     auto &values = res.value();
     CHECK(std::get<0>(values) == 42);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What is changing

struct_pack::deserialize now support varadic parameters.

Add document & test. 

## Example

```cpp
struct_pack::deserialize<int,double,std::string>(buffer);
// as same as:
// struct_pack::deserialize<std::tuple<int,double,std::string>>(buffer);
```