### PR TITLE
add deserialize variadic support & it's document

### DIFF
--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -227,52 +227,53 @@ serialize_with_offset(std::size_t offset, const Args &...args) {
   return buffer;
 }
 
-template <typename T, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t, const View &v) {
-  detail::unpacker in(v.data(), v.size());
-  return in.deserialize(t);
-}
-
-template <typename T, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t,
-                                                          const Byte *data,
-                                                          size_t size) {
-  detail::unpacker in(data, size);
-  return in.deserialize(t);
-}
-
-template <typename T, detail::deserialize_view View>
+template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t, const View &v,
-                                                          size_t &consume_len) {
+                                                          Args &...args) {
   detail::unpacker in(v.data(), v.size());
-  return in.deserialize(t, consume_len);
+  return in.deserialize(t, args...);
 }
 
-template <typename T, detail::struct_pack_byte Byte>
+template <typename T, typename... Args, detail::struct_pack_byte Byte>
 [[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t,
                                                           const Byte *data,
                                                           size_t size,
-                                                          size_t &consume_len) {
+                                                          Args &...args) {
   detail::unpacker in(data, size);
-  return in.deserialize(t, consume_len);
+  return in.deserialize(t, args...);
 }
 
-template <typename T, detail::deserialize_view View>
+template <typename T, typename... Args, detail::deserialize_view View>
+[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t, const View &v,
+                                                          size_t &consume_len,
+                                                          Args &...args) {
+  detail::unpacker in(v.data(), v.size());
+  return in.deserialize(consume_len, t, args...);
+}
+
+template <typename T, typename... Args, detail::struct_pack_byte Byte>
+[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(
+    T &t, const Byte *data, size_t size, size_t &consume_len, Args &...args) {
+  detail::unpacker in(data, size);
+  return in.deserialize(consume_len, t, args...);
+}
+
+template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to_with_offset(
-    T &t, const View &v, size_t &offset) {
+    T &t, const View &v, size_t &offset, Args &...args) {
   detail::unpacker in(v.data() + offset, v.size() - offset);
   size_t sz;
-  auto ret = in.deserialize(t, sz);
+  auto ret = in.deserialize(sz, t, args...);
   offset += sz;
   return ret;
 }
 
-template <typename T, detail::struct_pack_byte Byte>
+template <typename T, typename... Args, detail::struct_pack_byte Byte>
 [[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to_with_offset(
-    T &t, const Byte *data, size_t size, size_t &offset) {
+    T &t, const Byte *data, size_t size, size_t &offset, Args &...args) {
   detail::unpacker in(data + offset, size - offset);
   size_t sz;
-  auto ret = in.deserialize(t, sz);
+  auto ret = in.deserialize(sz, t, args...);
   offset += sz;
   return ret;
 }

--- a/src/struct_pack/doc/struct_pack_doc.hpp
+++ b/src/struct_pack/doc/struct_pack_doc.hpp
@@ -545,27 +545,38 @@ template <typename T, detail::deserialize_view View>
  * assert(p == p2);
  * ```
  * @tparam T
+ * @tparam Args
  * @tparam Byte
  * @param t 保存反序列化的结果。
- * @param data 待反序列化的数据，其包含成员函数data()和size()
- * @param size
+ * @param data 指向序列化buffer的指针
+ * @param size buffer的长度
+ * @param args
+ * 函数允许填入多个引用，然后按std::tuple<T,args...>类型解析数据并反序列化。
+ * 受C++推导规则限制，args置于参数末尾。
  * @return
  * std::errc类型的错误码。另外，t作为出参保存序列化结果。当有错误发生时，t的值是未定义的。
  */
-template <typename T, detail::struct_pack_byte Byte>
+template <typename T, typename... Args, detail::struct_pack_byte Byte>
 [[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t,
                                                           const Byte *data,
-                                                          size_t size);
+                                                          size_t size,
+                                                          Args... args);
 /*!
  * \ingroup struct_pack
  * @tparam T
+ * @tparam Args
  * @tparam View
- * @param t
- * @param v
+ * @param t 保存反序列化的结果。
+ * @param v 待反序列化的数据，其包含成员函数data()和size()
+ * @param args
+ * 函数允许填入多个引用，然后按std::tuple<T,args...>类型解析数据并反序列化。
+ * 受C++推导规则限制，args置于参数末尾。
  * @return
+ * std::errc类型的错误码。另外，t作为出参保存序列化结果。当有错误发生时，t的值是未定义的。
  */
-template <typename T, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t, const View &v);
+template <typename T, typename... Args, detail::deserialize_view View>
+[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t, const View &v,
+                                                          Args... args);
 
 /*!
  * \ingroup struct_pack
@@ -585,18 +596,22 @@ template <typename T, detail::deserialize_view View>
  * }
  * ```
  * @tparam T
+ * @tparam Args
  * @tparam Byte
  * @param t 保存反序列化的结果。
  * @param data 指向保存序列化结果的内存首地址。
  * @param size 内存的长度。
  * @param offset 反序列化起始位置的偏移量。
+ * @param args
+ * 函数允许填入多个引用，然后按std::tuple<T,args...>类型解析数据并反序列化。
+ * 受C++推导规则限制，args置于参数末尾。
  * @return
  * std::errc类型的错误码。另外，t作为出参，保存序列化结果。offset作为出参，会被更新为反序列化对象尾部相对于data的offset。
  *                当有错误发生时，t的值是未定义的，而offset则不会被更新。
  */
-template <typename T, detail::struct_pack_byte Byte>
+template <typename T, typename... Args, detail::struct_pack_byte Byte>
 [[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to_with_offset(
-    T &t, const Byte *data, size_t size, size_t &offset);
+    T &t, const Byte *data, size_t size, size_t &offset, Args... args);
 
 /*!
  * \ingroup struct_pack

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -792,6 +792,28 @@ TEST_CASE("testing exceptions") {
 TEST_CASE("testing serialize/deserialize varadic params") {
   {
     auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
+    auto res = struct_pack::deserialize<std::tuple<int, int, int, int, int>>(
+        ret.data(), ret.size());
+    CHECK(res);
+    CHECK(std::get<0>(res.value()) == 1);
+    CHECK(std::get<1>(res.value()) == 2);
+    CHECK(std::get<2>(res.value()) == 3);
+    CHECK(std::get<3>(res.value()) == 4);
+    CHECK(std::get<4>(res.value()) == 5);
+  }
+  {
+    auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
+    auto res =
+        struct_pack::deserialize<std::tuple<int, int, int, int, int>>(ret);
+    CHECK(res);
+    CHECK(std::get<0>(res.value()) == 1);
+    CHECK(std::get<1>(res.value()) == 2);
+    CHECK(std::get<2>(res.value()) == 3);
+    CHECK(std::get<3>(res.value()) == 4);
+    CHECK(std::get<4>(res.value()) == 5);
+  }
+  {
+    auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
     auto res = struct_pack::deserialize<int, int, int, int, int>(ret.data(),
                                                                  ret.size());
     CHECK(res);
@@ -812,55 +834,6 @@ TEST_CASE("testing serialize/deserialize varadic params") {
     CHECK(std::get<4>(res.value()) == 5);
   }
   {
-    auto ret = struct_pack::serialize(
-        42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
-        std::string{"Hello"},
-        std::array<std::vector<int>, 3>{
-            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
-        std::variant<int, float, double>{1.4});
-    auto res =
-        struct_pack::deserialize<int, float, double, int, unsigned long long,
-                                 std::string, std::array<std::vector<int>, 3>,
-                                 std::variant<int, float, double>>(ret.data(),
-                                                                   ret.size());
-    CHECK(res);
-    auto &values = res.value();
-    CHECK(std::get<0>(values) == 42);
-    CHECK(std::get<1>(values) == 2.71828f);
-    CHECK(std::get<2>(values) == 3.1415926);
-    CHECK(std::get<3>(values) == 71086291);
-    CHECK(std::get<4>(values) == 1145141919810Ull);
-    CHECK(std::get<5>(values) == std::string{"Hello"});
-    CHECK(std::get<6>(values) ==
-          std::array<std::vector<int>, 3>{
-              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
-    CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
-  }
-  {
-    auto ret = struct_pack::serialize(
-        42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
-        std::string{"Hello"},
-        std::array<std::vector<int>, 3>{
-            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
-        std::variant<int, float, double>{1.4});
-    auto res =
-        struct_pack::deserialize<int, float, double, int, unsigned long long,
-                                 std::string, std::array<std::vector<int>, 3>,
-                                 std::variant<int, float, double>>(ret);
-    CHECK(res);
-    auto &values = res.value();
-    CHECK(std::get<0>(values) == 42);
-    CHECK(std::get<1>(values) == 2.71828f);
-    CHECK(std::get<2>(values) == 3.1415926);
-    CHECK(std::get<3>(values) == 71086291);
-    CHECK(std::get<4>(values) == 1145141919810Ull);
-    CHECK(std::get<5>(values) == std::string{"Hello"});
-    CHECK(std::get<6>(values) ==
-          std::array<std::vector<int>, 3>{
-              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
-    CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
-  }
-  {
     std::vector<char> ret;
     struct_pack::serialize_to(ret, 1, 2, 3, 4, 5);
     auto res = struct_pack::deserialize<int, int, int, int, int>(ret.data(),
@@ -886,6 +859,126 @@ TEST_CASE("testing serialize/deserialize varadic params") {
     CHECK(std::get<4>(values) == 5);
   }
   {
+    auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
+    int a[5];
+    auto res = struct_pack::deserialize_to(a[0], ret.data(), ret.size(), a[1],
+                                           a[2], a[3], a[4]);
+    CHECK(res == std::errc{});
+    CHECK(a[0] == 1);
+    CHECK(a[1] == 2);
+    CHECK(a[2] == 3);
+    CHECK(a[3] == 4);
+    CHECK(a[4] == 5);
+  }
+  {
+    auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
+    int a[5];
+    auto res = struct_pack::deserialize_to(a[0], ret, a[1], a[2], a[3], a[4]);
+    CHECK(res == std::errc{});
+    CHECK(a[0] == 1);
+    CHECK(a[1] == 2);
+    CHECK(a[2] == 3);
+    CHECK(a[3] == 4);
+    CHECK(a[4] == 5);
+  }
+  {
+    auto ret = struct_pack::serialize(
+        42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
+        std::string{"Hello"},
+        std::array<std::vector<int>, 3>{
+            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
+        std::variant<int, float, double>{1.4});
+    auto res = struct_pack::deserialize<std::tuple<
+        int, float, double, int, unsigned long long, std::string,
+        std::array<std::vector<int>, 3>, std::variant<int, float, double>>>(
+        ret.data(), ret.size());
+    CHECK(res);
+    auto &values = res.value();
+    CHECK(std::get<0>(values) == 42);
+    CHECK(std::get<1>(values) == 2.71828f);
+    CHECK(std::get<2>(values) == 3.1415926);
+    CHECK(std::get<3>(values) == 71086291);
+    CHECK(std::get<4>(values) == 1145141919810Ull);
+    CHECK(std::get<5>(values) == std::string{"Hello"});
+    CHECK(std::get<6>(values) ==
+          std::array<std::vector<int>, 3>{
+              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
+    CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
+  }
+  {
+    auto ret = struct_pack::serialize(
+        42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
+        std::string{"Hello"},
+        std::array<std::vector<int>, 3>{
+            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
+        std::variant<int, float, double>{1.4});
+    auto res = struct_pack::deserialize<std::tuple<
+        int, float, double, int, unsigned long long, std::string,
+        std::array<std::vector<int>, 3>, std::variant<int, float, double>>>(
+        ret);
+    CHECK(res);
+    auto &values = res.value();
+    CHECK(std::get<0>(values) == 42);
+    CHECK(std::get<1>(values) == 2.71828f);
+    CHECK(std::get<2>(values) == 3.1415926);
+    CHECK(std::get<3>(values) == 71086291);
+    CHECK(std::get<4>(values) == 1145141919810Ull);
+    CHECK(std::get<5>(values) == std::string{"Hello"});
+    CHECK(std::get<6>(values) ==
+          std::array<std::vector<int>, 3>{
+              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
+    CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
+  }
+  {
+    auto ret = struct_pack::serialize(
+        42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
+        std::string{"Hello"},
+        std::array<std::vector<int>, 3>{
+            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
+        std::variant<int, float, double>{1.4});
+    auto res =
+        struct_pack::deserialize<int, float, double, int, unsigned long long,
+                                 std::string, std::array<std::vector<int>, 3>,
+                                 std::variant<int, float, double>>(ret.data(),
+                                                                   ret.size());
+    CHECK(res);
+    auto &values = res.value();
+    CHECK(std::get<0>(values) == 42);
+    CHECK(std::get<1>(values) == 2.71828f);
+    CHECK(std::get<2>(values) == 3.1415926);
+    CHECK(std::get<3>(values) == 71086291);
+    CHECK(std::get<4>(values) == 1145141919810Ull);
+    CHECK(std::get<5>(values) == std::string{"Hello"});
+    CHECK(std::get<6>(values) ==
+          std::array<std::vector<int>, 3>{
+              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
+    CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
+  }
+  {
+    auto ret = struct_pack::serialize(
+        42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
+        std::string{"Hello"},
+        std::array<std::vector<int>, 3>{
+            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
+        std::variant<int, float, double>{1.4});
+    auto res =
+        struct_pack::deserialize<int, float, double, int, unsigned long long,
+                                 std::string, std::array<std::vector<int>, 3>,
+                                 std::variant<int, float, double>>(ret);
+    CHECK(res);
+    auto &values = res.value();
+    CHECK(std::get<0>(values) == 42);
+    CHECK(std::get<1>(values) == 2.71828f);
+    CHECK(std::get<2>(values) == 3.1415926);
+    CHECK(std::get<3>(values) == 71086291);
+    CHECK(std::get<4>(values) == 1145141919810Ull);
+    CHECK(std::get<5>(values) == std::string{"Hello"});
+    CHECK(std::get<6>(values) ==
+          std::array<std::vector<int>, 3>{
+              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
+    CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
+  }
+  {
     std::vector<char> ret;
     struct_pack::serialize_to(
         ret, 42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
@@ -935,6 +1028,61 @@ TEST_CASE("testing serialize/deserialize varadic params") {
           std::array<std::vector<int>, 3>{
               {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
     CHECK(std::get<7>(values) == std::variant<int, float, double>{1.4});
+  }
+  {
+    std::vector<char> ret;
+    struct_pack::serialize_to(
+        ret, 42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
+        std::string{"Hello"},
+        std::array<std::vector<int>, 3>{
+            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
+        std::variant<int, float, double>{1.4});
+    std::tuple<int, float, double, int, unsigned long long, std::string,
+               std::array<std::vector<int>, 3>,
+               std::variant<int, float, double>>
+        t;
+    auto res = struct_pack::deserialize_to(
+        std::get<0>(t), ret.data(), ret.size(), std::get<1>(t), std::get<2>(t),
+        std::get<3>(t), std::get<4>(t), std::get<5>(t), std::get<6>(t),
+        std::get<7>(t));
+    CHECK(res == std::errc{});
+    CHECK(std::get<0>(t) == 42);
+    CHECK(std::get<1>(t) == 2.71828f);
+    CHECK(std::get<2>(t) == 3.1415926);
+    CHECK(std::get<3>(t) == 71086291);
+    CHECK(std::get<4>(t) == 1145141919810Ull);
+    CHECK(std::get<5>(t) == std::string{"Hello"});
+    CHECK(std::get<6>(t) ==
+          std::array<std::vector<int>, 3>{
+              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
+    CHECK(std::get<7>(t) == std::variant<int, float, double>{1.4});
+  }
+  {
+    std::vector<char> ret;
+    struct_pack::serialize_to(
+        ret, 42, 2.71828f, 3.1415926, 71086291, 1145141919810Ull,
+        std::string{"Hello"},
+        std::array<std::vector<int>, 3>{
+            {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}},
+        std::variant<int, float, double>{1.4});
+    std::tuple<int, float, double, int, unsigned long long, std::string,
+               std::array<std::vector<int>, 3>,
+               std::variant<int, float, double>>
+        t;
+    auto res = struct_pack::deserialize_to(
+        std::get<0>(t), ret, std::get<1>(t), std::get<2>(t), std::get<3>(t),
+        std::get<4>(t), std::get<5>(t), std::get<6>(t), std::get<7>(t));
+    CHECK(res == std::errc{});
+    CHECK(std::get<0>(t) == 42);
+    CHECK(std::get<1>(t) == 2.71828f);
+    CHECK(std::get<2>(t) == 3.1415926);
+    CHECK(std::get<3>(t) == 71086291);
+    CHECK(std::get<4>(t) == 1145141919810Ull);
+    CHECK(std::get<5>(t) == std::string{"Hello"});
+    CHECK(std::get<6>(t) ==
+          std::array<std::vector<int>, 3>{
+              {{1, 1, 4, 5, 1, 4}, {1919, 810}, {710862, 91}}});
+    CHECK(std::get<7>(t) == std::variant<int, float, double>{1.4});
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Add support for varadic deserialize_to

## What is changing
Now deserialize_to allow variadic params.
Unfortunately, C++'s template type deduction can't work when the variadic is not in the end of parameters. So we have to add   the variadic at the end of paramters.
## Example

```cpp
struct person
{
  size_t id;
  std::string name;
};
struct Book
{
  size_t id;
  std::string name;
};
person p;
Book b;
//...
auto buffer=struct_pack::serialize("Betty"sv,"The Book"sv);
//...
struct_pack::deserialize_to(p.name,buffer,b.name);
assert(p.name=="Betty");
assert(b.name=="The Book");
```
