### PR TITLE
[coro_rpc] Fix the problem that filesystem::path::c_str() can't be logged in windows.

### DIFF
--- a/include/logging/easylog.hpp
+++ b/include/logging/easylog.hpp
@@ -91,27 +91,27 @@ inline void log(spdlog::level::level_enum level, source_location location,
 
   switch (level) {
     case spdlog::level::trace:
-      spdlog::trace("{}:{}: {}", p.filename().c_str(), location.line(),
+      spdlog::trace("{}:{}: {}", p.filename().string(), location.line(),
                     fmt::format(fmt, std::forward<Args>(args)...));
       break;
     case spdlog::level::debug:
-      spdlog::debug("{}:{}: {}", p.filename().c_str(), location.line(),
+      spdlog::debug("{}:{}: {}", p.filename().string(), location.line(),
                     fmt::format(fmt, std::forward<Args>(args)...));
       break;
     case spdlog::level::info:
-      spdlog::info("{}:{}: {}", p.filename().c_str(), location.line(),
+      spdlog::info("{}:{}: {}", p.filename().string(), location.line(),
                    fmt::format(fmt, std::forward<Args>(args)...));
       break;
     case spdlog::level::warn:
-      spdlog::warn("{}:{}: {}", p.filename().c_str(), location.line(),
+      spdlog::warn("{}:{}: {}", p.filename().string(), location.line(),
                    fmt::format(fmt, std::forward<Args>(args)...));
       break;
     case spdlog::level::err:
-      spdlog::error("{}:{}: {}", p.filename().c_str(), location.line(),
+      spdlog::error("{}:{}: {}", p.filename().string(), location.line(),
                     fmt::format(fmt, std::forward<Args>(args)...));
       break;
     case spdlog::level::critical:
-      spdlog::critical("{}:{}: {}", p.filename().c_str(), location.line(),
+      spdlog::critical("{}:{}: {}", p.filename().string(), location.line(),
                        fmt::format(fmt, std::forward<Args>(args)...));
       break;
     case spdlog::level::off:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The filesystem::path's value_type is wchar_t in windows, and spdlog don't support wchar_t.

## What is changing

Convert filesystem::path to std::string, instead of get the native string.

## Example