### PR TITLE
add file transfer example

### DIFF
--- a/src/coro_rpc/examples/CMakeLists.txt
+++ b/src/coro_rpc/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples)
 add_subdirectory(helloworld)
+add_subdirectory(file_transfer)

--- a/src/coro_rpc/examples/file_transfer/CMakeLists.txt
+++ b/src/coro_rpc/examples/file_transfer/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.15)
+
+set(CMAKE_CXX_STANDARD 20)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
+include_directories(${CMAKE_SOURCE_DIR}/thirdparty/asio)
+include_directories(${CMAKE_SOURCE_DIR}/thirdparty/async_simple)
+include_directories(${CMAKE_SOURCE_DIR}/thirdparty/spdlog)
+
+add_definitions(-DASIO_HAS_STD_INVOKE_RESULT)
+add_definitions(-DASYNC_SIMPLE_HAS_NOT_AIO)
+
+add_executable(file_server file_server/rpc_service.cpp file_server/main.cpp)
+add_executable(file_client file_client/main.cpp)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_link_options(file_server PRIVATE "-fuse-ld=lld")
+    target_link_options(file_client PRIVATE "-fuse-ld=lld")
+    message(STATUS "Force add link option: -fuse-ld=lld")
+endif ()

--- a/src/coro_rpc/examples/file_transfer/file_server/main.cpp
+++ b/src/coro_rpc/examples/file_transfer/file_server/main.cpp
@@ -1,0 +1,15 @@
+#include <coro_rpc/coro_rpc_server.hpp>
+#include <iostream>
+
+#include "../rpc_service/rpc_service.h"
+int main() {
+  coro_rpc::register_handler<echo, upload, upload_file>();
+
+  dummy d{};
+  coro_rpc::register_one_handler<&dummy::echo>(&d);
+
+  coro_rpc::coro_rpc_server server(4, 9000);
+  auto ret = server.start();
+  assert(ret == std::errc{});
+  return 0;
+}

--- a/src/coro_rpc/examples/file_transfer/file_server/rpc_service.cpp
+++ b/src/coro_rpc/examples/file_transfer/file_server/rpc_service.cpp
@@ -1,0 +1,49 @@
+#include "../rpc_service/rpc_service.h"
+
+#include <filesystem>
+
+std::string echo(std::string str) { return str; }
+
+void upload_file(coro_rpc::connection<std::errc> conn, file_part part) {
+  std::shared_ptr<std::ofstream> stream = nullptr;
+  if (!conn.get_tag().has_value()) {
+    stream = std::make_shared<std::ofstream>();
+    auto filename = std::to_string(std::time(0)) +
+                    std::filesystem::path(part.filename).extension().string();
+    stream->open(filename, std::ios::binary | std::ios::app);
+    conn.set_tag(stream);
+  }
+  else {
+    stream = std::any_cast<std::shared_ptr<std::ofstream>>(conn.get_tag());
+  }
+
+  std::cout << "file part content size=" << part.content.size() << "\n";
+
+  stream->write(part.content.data(), part.content.size());
+  if (part.eof) {
+    stream->close();
+    conn.set_tag(std::any{});
+    std::cout << "file upload finished\n";
+  }
+
+  conn.response_msg(std::errc{});
+}
+
+std::string g_real_file = "";
+std::ofstream g_file;
+
+std::errc upload(file_part part) {
+  if (g_real_file.empty()) {
+    g_real_file = std::to_string(std::time(0)) +
+                  std::filesystem::path(part.filename).extension().string();
+    g_file.open(g_real_file, std::ios::binary | std::ios::app);
+  }
+
+  g_file.write(part.content.data(), part.content.size());
+  if (part.eof) {
+    g_real_file.clear();
+    g_file.close();
+  }
+
+  return {};
+}

--- a/src/coro_rpc/examples/file_transfer/rpc_service/rpc_service.h
+++ b/src/coro_rpc/examples/file_transfer/rpc_service/rpc_service.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <coro_rpc/coro_rpc_server.hpp>
+#include <fstream>
+#include <string>
+using namespace coro_rpc;
+
+std::string echo(std::string str);
+
+struct dummy {
+  std::string echo(std::string str) { return str; }
+};
+
+struct file_part {
+  std::string filename;
+  std::string content;
+  bool eof;
+};
+// this function is just for case study, only allow one client to upload file.
+std::errc upload(file_part part);
+
+// support arbitrary clients to upload file.
+void upload_file(coro_rpc::connection<std::errc> conn, file_part part);


### PR DESCRIPTION
## Why

Add a file transfer example for coro_rpc, to show how to use coro_rpc upload files.


