### PR TITLE
import tuplet

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,6 +22,8 @@ Creative Commons Zero v1.0 Universal License
 
 test/doctest.h
 
+include/struct_pack/struct_pack/tuplet.hpp
+
 Distributed under the Boost Software License, Version 1.0. (See accompanying
 file LICENSE_1_0.txt or copy at <http://www.boost.org/LICENSE_1_0.txt>)
 

--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -135,6 +135,11 @@ concept tuple = requires(Type tuple) {
 };
 
 template <typename Type>
+concept tuple_size = requires(Type tuple) {
+  sizeof(std::tuple_size<std::remove_cvref_t<Type>>);
+};
+
+template <typename Type>
 concept array = requires(Type arr) {
   arr.size();
   std::tuple_size<std::remove_cvref_t<Type>>{};
@@ -218,6 +223,9 @@ template <typename T>
 consteval std::size_t member_count() {
   if constexpr (struct_pack::members_count < T >> 0) {
     return struct_pack::members_count<T>;
+  }
+  else if constexpr (tuple_size<T>) {
+    return std::tuple_size<T>::value;
   }
   else {
     return member_count_impl<T>();

--- a/include/struct_pack/struct_pack/tuple.hpp
+++ b/include/struct_pack/struct_pack/tuple.hpp
@@ -611,4 +611,12 @@ struct tuple_element<I, tuplet::pair<A, B>> {
   using type = std::conditional_t<I == 0, A, B>;
 };
 }  // namespace std
+
+namespace tuplet {
+template <class T>
+constexpr size_t tuple_size_v = std::tuple_size<T>::value;
+
+template <size_t I, class T>
+using tuple_element_t = typename std::tuple_element<I, T>::type;
+}  // namespace tuplet
 #endif

--- a/include/struct_pack/struct_pack/tuple.hpp
+++ b/include/struct_pack/struct_pack/tuple.hpp
@@ -1,0 +1,614 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// https://github.com/codeinred/tuplet/blob/main/include/tuplet/tuple.hpp
+// commit id: ce4ab635c4f70b63ef9d19728bc8d76d71ae8685
+// Use of this source code is governed by a Boost Software License that can be
+// found in the LICENSE file.
+
+#ifndef TUPLET_TUPLET_HPP_IMPLEMENTATION
+#define TUPLET_TUPLET_HPP_IMPLEMENTATION
+
+#include <compare>
+#include <cstddef>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#if (__has_cpp_attribute(no_unique_address))
+#define TUPLET_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#elif (__has_cpp_attribute(msvc::no_unique_address)) || \
+    ((defined _MSC_VER) && (!defined __clang__))
+// Note __has_cpp_attribute(msvc::no_unique_address) itself doesn't work as
+// of 19.30.30709, even though the attribute itself is supported. See
+// https://github.com/llvm/llvm-project/issues/49358#issuecomment-981041089
+#define TUPLET_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#else
+// no_unique_address is not available.
+#define TUPLET_NO_UNIQUE_ADDRESS
+#endif
+
+// tuplet concepts and traits
+namespace tuplet {
+template <class T>
+using identity_t = T;
+
+// Obtains T::type
+template <class T>
+using type_t = typename T::type;
+
+template <size_t I>
+using tag = std::integral_constant<size_t, I>;
+
+template <size_t I>
+constexpr tag<I> tag_v{};
+
+template <size_t N>
+using tag_range = std::make_index_sequence<N>;
+
+template <class T, class U>
+concept same_as = std::is_same_v<T, U> && std::is_same_v<U, T>;
+
+template <class T, class U>
+concept other_than = !std::is_same_v<std::decay_t<T>, U>;
+
+template <class Tup>
+using base_list_t = typename std::decay_t<Tup>::base_list;
+template <class Tup>
+using element_list_t = typename std::decay_t<Tup>::element_list;
+
+template <class Tuple>
+concept base_list_tuple = requires() {
+  typename std::decay_t<Tuple>::base_list;
+};
+
+template <class T>
+concept stateless = std::is_empty_v<std::decay_t<T>>;
+
+template <class T>
+concept indexable = stateless<T> || requires(T t) {
+  t[tag<0>()];
+};
+
+template <class U, class T>
+concept assignable_to = requires(U u, T t) {
+  t = u;
+};
+
+template <class T>
+concept ordered = requires(T const& t) {
+  {t <=> t};
+};
+template <class T>
+concept equality_comparable = requires(T const& t) {
+  { t == t } -> same_as<bool>;
+};
+}  // namespace tuplet
+
+// tuplet::type_list implementation
+// tuplet::type_map implementation
+// tuplet::tuple_elem implementation
+// tuplet::deduce_elems
+namespace tuplet {
+template <class... T>
+struct tuple;
+
+template <class... T>
+struct type_list {};
+
+template <class... Ls, class... Rs>
+constexpr auto operator+(type_list<Ls...>, type_list<Rs...>) {
+  return type_list<Ls..., Rs...>{};
+}
+
+template <class... Bases>
+struct type_map : Bases... {
+  using base_list = type_list<Bases...>;
+  using Bases::operator[]...;
+  using Bases::decl_elem...;
+  auto operator<=>(type_map const&) const = default;
+  bool operator==(type_map const&) const = default;
+};
+
+template <size_t I, class T>
+struct tuple_elem {
+  // Like declval, but with the element
+  static T decl_elem(tag<I>);
+  using type = T;
+
+  TUPLET_NO_UNIQUE_ADDRESS T value;
+
+  constexpr decltype(auto) operator[](tag<I>) & { return (value); }
+  constexpr decltype(auto) operator[](tag<I>) const& { return (value); }
+  constexpr decltype(auto) operator[](tag<I>) && {
+    return (std::move(*this).value);
+  }
+  auto operator<=>(tuple_elem const&) const = default;
+  bool operator==(tuple_elem const&) const = default;
+  // Implements comparison for tuples containing reference types
+  constexpr auto operator<=>(tuple_elem const& other) const noexcept(noexcept(
+      value <=> other.value)) requires(std::is_reference_v<T>&& ordered<T>) {
+    return value <=> other.value;
+  }
+  constexpr bool operator==(tuple_elem const& other) const
+      noexcept(noexcept(value == other.value)) requires(
+          std::is_reference_v<T>&& equality_comparable<T>) {
+    return value == other.value;
+  }
+};
+template <class T>
+using unwrap_ref_decay_t = typename std::unwrap_ref_decay<T>::type;
+}  // namespace tuplet
+
+// tuplet::detail::get_tuple_base implementation
+// tuplet::detail::apply_impl
+// tuplet::detail::size_t_from_digits
+namespace tuplet::detail {
+template <class A, class... T>
+struct get_tuple_base;
+
+template <size_t... I, class... T>
+struct get_tuple_base<std::index_sequence<I...>, T...> {
+  using type = type_map<tuple_elem<I, T>...>;
+};
+
+template <class F, class T, class... Bases>
+constexpr decltype(auto) apply_impl(F&& f, T&& t, type_list<Bases...>) {
+  return static_cast<F&&>(f)(static_cast<T&&>(t).identity_t<Bases>::value...);
+}
+template <char... D>
+constexpr size_t size_t_from_digits() {
+  static_assert((('0' <= D && D <= '9') && ...), "Must be integral literal");
+  size_t num = 0;
+  return ((num = num * 10 + (D - '0')), ..., num);
+}
+template <class First, class>
+using first_t = First;
+
+template <class T, class... Q>
+constexpr auto repeat_type(type_list<Q...>) {
+  return type_list<first_t<T, Q>...>{};
+}
+template <class... Outer>
+constexpr auto get_outer_bases(type_list<Outer...>) {
+  return (repeat_type<Outer>(base_list_t<type_t<Outer>>{}) + ...);
+}
+template <class... Outer>
+constexpr auto get_inner_bases(type_list<Outer...>) {
+  return (base_list_t<type_t<Outer>>{} + ...);
+}
+
+// This takes a forwarding tuple as a parameter. The forwarding tuple only
+// contains references, so it should just be taken by value.
+template <class T, class... Outer, class... Inner>
+constexpr auto cat_impl(T tup, type_list<Outer...>, type_list<Inner...>)
+    -> tuple<type_t<Inner>...> {
+  return {static_cast<type_t<Outer>&&>(tup.identity_t<Outer>::value)
+              .identity_t<Inner>::value...};
+}
+}  // namespace tuplet::detail
+
+// tuplet::tuple implementation
+namespace tuplet {
+template <class... T>
+using tuple_base_t =
+    typename detail::get_tuple_base<tag_range<sizeof...(T)>, T...>::type;
+
+template <class... T>
+struct tuple : tuple_base_t<T...> {
+  constexpr static size_t N = sizeof...(T);
+  using super = tuple_base_t<T...>;
+  using super::operator[];
+  using base_list = typename super::base_list;
+  using element_list = type_list<T...>;
+  using super::decl_elem;
+
+  template <other_than<tuple> U>  // Preserves default assignments
+  constexpr auto& operator=(U&& tup) {
+    using tuple2 = std::decay_t<U>;
+    if (base_list_tuple<tuple2>) {
+      eq_impl(static_cast<U&&>(tup), base_list(), typename tuple2::base_list());
+    }
+    else {
+      eq_impl(static_cast<U&&>(tup), tag_range<N>());
+    }
+    return *this;
+  }
+
+  template <assignable_to<T>... U>
+  constexpr auto& assign(U&&... values) {
+    assign_impl(base_list(), static_cast<U&&>(values)...);
+    return *this;
+  }
+
+  auto operator<=>(tuple const&) const = default;
+  bool operator==(tuple const&) const = default;
+
+  // Applies a function to every element of the tuple. The order is the
+  // declaration order, so first the function will be applied to element 0,
+  // then element 1, then element 2, and so on, where element N is identified
+  // by get<N>
+  template <class F>
+  constexpr void for_each(F&& func) & {
+    for_each_impl(base_list(), static_cast<F&&>(func));
+  }
+  template <class F>
+  constexpr void for_each(F&& func) const& {
+    for_each_impl(base_list(), static_cast<F&&>(func));
+  }
+  template <class F>
+  constexpr void for_each(F&& func) && {
+    static_cast<tuple&&>(*this).for_each_impl(base_list(),
+                                              static_cast<F&&>(func));
+  }
+
+  // Applies a function to each element successively, until one returns a
+  // truthy value. Returns true if any application returned a truthy value,
+  // and false otherwise
+  template <class F>
+  constexpr bool any(F&& func) & {
+    return any_impl(base_list(), static_cast<F&&>(func));
+  }
+  template <class F>
+  constexpr bool any(F&& func) const& {
+    return any_impl(base_list(), static_cast<F&&>(func));
+  }
+  template <class F>
+  constexpr bool any(F&& func) && {
+    return static_cast<tuple&&>(*this).any_impl(base_list(),
+                                                static_cast<F&&>(func));
+  }
+
+  // Applies a function to each element successively, until one returns a
+  // falsy value. Returns true if every application returned a truthy value,
+  // and false otherwise
+  template <class F>
+  constexpr bool all(F&& func) & {
+    return all_impl(base_list(), static_cast<F&&>(func));
+  }
+  template <class F>
+  constexpr bool all(F&& func) const& {
+    return all_impl(base_list(), static_cast<F&&>(func));
+  }
+  template <class F>
+  constexpr bool all(F&& func) && {
+    return static_cast<tuple&&>(*this).all_impl(base_list(),
+                                                static_cast<F&&>(func));
+  }
+
+  // Map a function over every element in the tuple, using the values to
+  // construct a new tuple
+  template <class F>
+  constexpr auto map(F&& func) & {
+    return map_impl(base_list(), static_cast<F&&>(func));
+  }
+  template <class F>
+  constexpr auto map(F&& func) const& {
+    return map_impl(base_list(), static_cast<F&&>(func));
+  }
+  template <class F>
+  constexpr auto map(F&& func) && {
+    return static_cast<tuple&&>(*this).map_impl(base_list(),
+                                                static_cast<F&&>(func));
+  }
+
+ private:
+  template <class U, class... B1, class... B2>
+  constexpr void eq_impl(U&& u, type_list<B1...>, type_list<B2...>) {
+    // See:
+    // https://developercommunity.visualstudio.com/t/fold-expressions-unreliable-in-171-with-c20/1676476
+    (void(B1::value = static_cast<U&&>(u).B2::value), ...);
+  }
+  template <class U, size_t... I>
+  constexpr void eq_impl(U&& u, std::index_sequence<I...>) {
+    (void(tuple_elem<I, T>::value = get<I>(static_cast<U&&>(u))), ...);
+  }
+  template <class... U, class... B>
+  constexpr void assign_impl(type_list<B...>, U&&... u) {
+    (void(B::value = static_cast<U&&>(u)), ...);
+  }
+
+  template <class F, class... B>
+  constexpr void for_each_impl(type_list<B...>, F&& func) & {
+    (void(func(B::value)), ...);
+  }
+  template <class F, class... B>
+  constexpr void for_each_impl(type_list<B...>, F&& func) const& {
+    (void(func(B::value)), ...);
+  }
+  template <class F, class... B>
+  constexpr void for_each_impl(type_list<B...>, F&& func) && {
+    (void(func(static_cast<T&&>(B::value))), ...);
+  }
+
+  template <class F, class... B>
+  constexpr bool any_impl(type_list<B...>, F&& func) & {
+    return (bool(func(B::value)) || ...);
+  }
+  template <class F, class... B>
+  constexpr bool any_impl(type_list<B...>, F&& func) const& {
+    return (bool(func(B::value)) || ...);
+  }
+  template <class F, class... B>
+  constexpr bool any_impl(type_list<B...>, F&& func) && {
+    return (bool(func(static_cast<T&&>(B::value))) || ...);
+  }
+
+  template <class F, class... B>
+  constexpr bool all_impl(type_list<B...>, F&& func) & {
+    return (bool(func(B::value)) && ...);
+  }
+  template <class F, class... B>
+  constexpr bool all_impl(type_list<B...>, F&& func) const& {
+    return (bool(func(B::value)) && ...);
+  }
+  template <class F, class... B>
+  constexpr bool all_impl(type_list<B...>, F&& func) && {
+    return (bool(func(static_cast<T&&>(B::value))) && ...);
+  }
+
+  template <class F, class... B>
+  constexpr auto map_impl(
+      type_list<B...>,
+      F&& func) & -> tuple<unwrap_ref_decay_t<decltype(func(B::value))>...> {
+    return {func(B::value)...};
+  }
+  template <class F, class... B>
+  constexpr auto map_impl(type_list<B...>, F&& func)
+      const& -> tuple<unwrap_ref_decay_t<decltype(func(B::value))>...> {
+    return {func(B::value)...};
+  }
+  template <class F, class... B>
+  constexpr auto map_impl(type_list<B...>, F&& func) && -> tuple<
+      unwrap_ref_decay_t<decltype(func(static_cast<T&&>(B::value)))>...> {
+    return {func(static_cast<T&&>(B::value))...};
+  }
+};
+template <>
+struct tuple<> : tuple_base_t<> {
+  constexpr static size_t N = 0;
+  using super = tuple_base_t<>;
+  using base_list = type_list<>;
+  using element_list = type_list<>;
+
+  template <other_than<tuple> U>  // Preserves default assignments
+  requires stateless<U>           // Check that U is similarly stateless
+  constexpr auto& operator=(U&&) noexcept { return *this; }
+
+  constexpr auto& assign() noexcept { return *this; }
+  auto operator<=>(tuple const&) const = default;
+  bool operator==(tuple const&) const = default;
+
+  // Applies a function to every element of the tuple. The order is the
+  // declaration order, so first the function will be applied to element 0,
+  // then element 1, then element 2, and so on, where element N is identified
+  // by get<N>
+  //
+  // (Does nothing when invoked on empty tuple)
+  template <class F>
+  constexpr void for_each(F&&) const noexcept {}
+
+  // Applies a function to each element successively, until one returns a
+  // truthy value. Returns true if any application returned a truthy value,
+  // and false otherwise
+  //
+  // (Returns false for empty tuple)
+  template <class F>
+  constexpr bool any(F&&) const noexcept {
+    return false;
+  }
+
+  // Applies a function to each element successively, until one returns a
+  // falsy value. Returns true if every application returned a truthy value,
+  // and false otherwise
+  //
+  // (Returns true for empty tuple)
+  template <class F>
+  constexpr bool all(F&&) const noexcept {
+    return true;
+  }
+
+  // Map a function over every element in the tuple, using the values to
+  // construct a new tuple
+  //
+  // (Returns empty tuple when invoked on empty tuple)
+  template <class F>
+  constexpr auto map(F&&) const noexcept {
+    return tuple{};
+  }
+};
+template <class... Ts>
+tuple(Ts...) -> tuple<unwrap_ref_decay_t<Ts>...>;
+}  // namespace tuplet
+
+// tuplet::pair implementation
+namespace tuplet {
+template <class First, class Second>
+struct pair {
+  constexpr static size_t N = 2;
+  TUPLET_NO_UNIQUE_ADDRESS First first;
+  TUPLET_NO_UNIQUE_ADDRESS Second second;
+
+  constexpr decltype(auto) operator[](tag<0>) & { return (first); }
+  constexpr decltype(auto) operator[](tag<0>) const& { return (first); }
+  constexpr decltype(auto) operator[](tag<0>) && {
+    return (std::move(*this).first);
+  }
+  constexpr decltype(auto) operator[](tag<1>) & { return (second); }
+  constexpr decltype(auto) operator[](tag<1>) const& { return (second); }
+  constexpr decltype(auto) operator[](tag<1>) && {
+    return (std::move(*this).second);
+  }
+
+  template <other_than<pair> Type>  // Preserves default assignments
+  constexpr auto& operator=(Type&& tup) {
+    auto&& [a, b] = static_cast<Type&&>(tup);
+    first = static_cast<decltype(a)&&>(a);
+    second = static_cast<decltype(b)&&>(b);
+    return *this;
+  }
+
+  template <assignable_to<First> F2, assignable_to<Second> S2>
+  constexpr auto& assign(F2&& f, S2&& s) {
+    first = static_cast<F2&&>(f);
+    second = static_cast<S2&&>(s);
+    return *this;
+  }
+  auto operator<=>(pair const&) const = default;
+  bool operator==(pair const&) const = default;
+};
+template <class A, class B>
+pair(A, B) -> pair<unwrap_ref_decay_t<A>, unwrap_ref_decay_t<B>>;
+}  // namespace tuplet
+
+// tuplet::convert implementation
+namespace tuplet {
+// Converts from one tuple type to any other tuple or U
+template <class Tuple>
+struct convert {
+  using base_list = typename std::decay_t<Tuple>::base_list;
+  Tuple tuple;
+  template <class U>
+  constexpr operator U() && {
+    return convert_impl<U>(base_list{});
+  }
+
+ private:
+  template <class U, class... Bases>
+  constexpr U convert_impl(type_list<Bases...>) {
+    return U{static_cast<Tuple&&>(tuple).identity_t<Bases>::value...};
+  }
+};
+template <class Tuple>
+convert(Tuple&) -> convert<Tuple&>;
+template <class Tuple>
+convert(Tuple const&) -> convert<Tuple const&>;
+template <class Tuple>
+convert(Tuple&&) -> convert<Tuple>;
+}  // namespace tuplet
+
+// tuplet::get implementation
+// tuplet::tie implementation
+// tuplet::apply implementation
+namespace tuplet {
+template <size_t I, indexable Tup>
+constexpr decltype(auto) get(Tup&& tup) {
+  return static_cast<Tup&&>(tup)[tag<I>()];
+}
+
+template <class... T>
+constexpr tuple<T&...> tie(T&... t) {
+  return {t...};
+}
+
+template <class F, base_list_tuple Tup>
+constexpr decltype(auto) apply(F&& func, Tup&& tup) {
+  return detail::apply_impl(static_cast<F&&>(func), static_cast<Tup&&>(tup),
+                            typename std::decay_t<Tup>::base_list());
+}
+template <class F, class A, class B>
+constexpr decltype(auto) apply(F&& func, tuplet::pair<A, B>& pair) {
+  return static_cast<F&&>(func)(pair.first, pair.second);
+}
+template <class F, class A, class B>
+constexpr decltype(auto) apply(F&& func, tuplet::pair<A, B> const& pair) {
+  return static_cast<F&&>(func)(pair.first, pair.second);
+}
+template <class F, class A, class B>
+constexpr decltype(auto) apply(F&& func, tuplet::pair<A, B>&& pair) {
+  return static_cast<F&&>(func)(std::move(pair).first, std::move(pair).second);
+}
+}  // namespace tuplet
+
+// tuplet::tuple_cat implementation
+// tuplet::make_tuple implementation
+// tuplet::forward_as_tuple implementation
+namespace tuplet {
+template <base_list_tuple... T>
+constexpr auto tuple_cat(T&&... ts) {
+  if constexpr (sizeof...(T) == 0) {
+    return tuple<>();
+  }
+  else {
+/**
+ * It appears that Clang produces better assembly when
+ * TUPLET_CAT_BY_FORWARDING_TUPLE == 0, while GCC produces better assembly when
+ * TUPLET_CAT_BY_FORWARDING_TUPLE == 1. MSVC always produces terrible assembly
+ * in either case. This will set TUPLET_CAT_BY_FORWARDING_TUPLE to the correct
+ * value (0 for clang, 1 for everyone else)
+ *
+ * See: https://github.com/codeinred/tuplet/discussions/14
+ */
+#if !defined(TUPLET_CAT_BY_FORWARDING_TUPLE)
+#if defined(__clang__)
+#define TUPLET_CAT_BY_FORWARDING_TUPLE 0
+#else
+#define TUPLET_CAT_BY_FORWARDING_TUPLE 1
+#endif
+#endif
+#if TUPLET_CAT_BY_FORWARDING_TUPLE
+    using big_tuple = tuple<T&&...>;
+#else
+    using big_tuple = tuple<std::decay_t<T>...>;
+#endif
+    using outer_bases = base_list_t<big_tuple>;
+    constexpr auto outer = detail::get_outer_bases(outer_bases{});
+    constexpr auto inner = detail::get_inner_bases(outer_bases{});
+    return detail::cat_impl(big_tuple{static_cast<T&&>(ts)...}, outer, inner);
+  }
+}
+
+template <typename... Ts>
+constexpr auto make_tuple(Ts&&... args) {
+  return tuple<unwrap_ref_decay_t<Ts>...>{static_cast<Ts&&>(args)...};
+}
+
+template <typename... T>
+constexpr auto forward_as_tuple(T&&... a) noexcept {
+  return tuple<T&&...>{static_cast<T&&>(a)...};
+}
+}  // namespace tuplet
+
+// tuplet literals
+namespace tuplet::literals {
+template <char... D>
+constexpr auto operator""_tag() noexcept
+    -> tag<detail::size_t_from_digits<D...>()> {
+  return {};
+}
+}  // namespace tuplet::literals
+
+// std::tuple_size specialization
+// std::tuple_element specialization
+namespace std {
+template <class... T>
+struct tuple_size<tuplet::tuple<T...>>
+    : std::integral_constant<size_t, sizeof...(T)> {};
+
+template <size_t I, class... T>
+struct tuple_element<I, tuplet::tuple<T...>> {
+  using type = decltype(tuplet::tuple<T...>::decl_elem(tuplet::tag<I>()));
+};
+template <class A, class B>
+struct tuple_size<tuplet::pair<A, B>> : std::integral_constant<size_t, 2> {};
+
+template <size_t I, class A, class B>
+struct tuple_element<I, tuplet::pair<A, B>> {
+  static_assert(I < 2, "tuplet::pair only has 2 elements");
+  using type = std::conditional_t<I == 0, A, B>;
+};
+}  // namespace std
+#endif

--- a/src/struct_pack/tests/CMakeLists.txt
+++ b/src/struct_pack/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
-add_executable(test_serialize test_serialize.cpp main.cpp)
+add_executable(test_serialize test_serialize.cpp test_tuplet.cpp main.cpp)
 add_test(NAME test_serialize COMMAND test_serialize)
 target_compile_definitions(test_serialize PRIVATE STRUCT_PACK_USE_INT16_SIZE STRUCT_PACK_ENABLE_UNPORTABLE_TYPE)
 target_link_libraries(test_serialize PRIVATE libstruct_pack doctest)

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -464,6 +464,9 @@ TEST_CASE("testing std::array") {
 TEST_CASE("test_trivial_copy_tuple") {
   tuplet::tuple tp = tuplet::make_tuple(1, 2);
 
+  constexpr auto count = detail::member_count<decltype(tp)>();
+  static_assert(count == 2);
+
   static_assert(std::is_same_v<decltype(tp), tuplet::tuple<int, int>>);
   static_assert(!std::is_same_v<decltype(tp), std::tuple<int, int>>);
 
@@ -485,6 +488,23 @@ TEST_CASE("test_trivial_copy_tuple") {
   auto ec2 = deserialize_to(tp1, buf);
   CHECK(ec2 == std::errc{});
   CHECK(tp == tp1);
+}
+
+struct test_obj {
+  int id;
+  std::string str;
+  tuplet::tuple<int, std::string> tp;
+  int d;
+};
+
+TEST_CASE("test_trivial_copy_tuple in an object") {
+  test_obj obj{1, "hello", {2, "tuple"}, 3};
+  auto buf = serialize(obj);
+
+  test_obj obj1;
+  auto ec = deserialize_to(obj1, buf);
+  CHECK(ec == std::errc{});
+  CHECK(obj.tp == obj1.tp);
 }
 
 void test_c_array(auto &v) {

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -461,6 +461,32 @@ TEST_CASE("testing std::array") {
   test_tuple_like(v3);
 }
 
+TEST_CASE("test_trivial_copy_tuple") {
+  tuplet::tuple tp = tuplet::make_tuple(1, 2);
+
+  static_assert(std::is_same_v<decltype(tp), tuplet::tuple<int, int>>);
+  static_assert(!std::is_same_v<decltype(tp), std::tuple<int, int>>);
+
+  static_assert(
+      std::is_same_v<decltype(detail::get_types(tp)), tuplet::tuple<int, int>>);
+  static_assert(
+      !std::is_same_v<decltype(detail::get_types(tp)), std::tuple<int, int>>);
+
+  static_assert(get_type_code<decltype(tp)>() !=
+                get_type_code<std::tuple<int, int>>());
+
+  auto buf = serialize(tp);
+
+  std::tuple<int, int> v{};
+  auto ec = deserialize_to(v, buf);
+  CHECK(ec != std::errc{});
+
+  decltype(tp) tp1;
+  auto ec2 = deserialize_to(tp1, buf);
+  CHECK(ec2 == std::errc{});
+  CHECK(tp == tp1);
+}
+
 void test_c_array(auto &v) {
   auto ret = serialize(v);
 

--- a/src/struct_pack/tests/test_tuplet.cpp
+++ b/src/struct_pack/tests/test_tuplet.cpp
@@ -7,8 +7,8 @@
 #include <type_traits>
 
 #include "doctest.h"
-#include "struct_pack/struct_pack/struct_pack_impl.hpp"
 #include "struct_pack/struct_pack/reflection.h"
+#include "struct_pack/struct_pack/struct_pack_impl.hpp"
 
 using namespace std::string_view_literals;
 
@@ -196,7 +196,8 @@ TEST_CASE("Check tuplet::apply with tuplet::tie") {
 TEST_CASE("Test that for_each works") {
   std::string str;
 
-  tuplet::tuple tup{"Hello world!", std::string("This is a test..."), 10, 20, 3.141592};
+  tuplet::tuple tup{"Hello world!", std::string("This is a test..."), 10, 20,
+                    3.141592};
   static_assert(struct_pack::detail::trivial_copy_tuple<decltype(tup)>);
   static_assert(std::is_aggregate_v<decltype(tup)>);
   static_assert(std::is_trivially_copyable_v<tuplet::tuple<int, double>>);
@@ -204,7 +205,8 @@ TEST_CASE("Test that for_each works") {
   static_assert(!std::is_trivially_copyable_v<std::tuple<int, double>>);
   static_assert(!struct_pack::detail::tuple<decltype(tup)>);
   static_assert(tuplet::tuple_size_v<decltype(tup)>);
-  static_assert(std::is_same_v<tuplet::tuple_element_t<1, decltype(tup)>, std::string>);
+  static_assert(
+      std::is_same_v<tuplet::tuple_element_t<1, decltype(tup)>, std::string>);
 
   tup.for_each([&]<typename T>(T& value) {
     if constexpr (std::is_fundamental_v<T>) {

--- a/src/struct_pack/tests/test_tuplet.cpp
+++ b/src/struct_pack/tests/test_tuplet.cpp
@@ -7,9 +7,8 @@
 #include <type_traits>
 
 #include "doctest.h"
-#include "struct_pack/struct_pack/tuple.hpp"
-
-using namespace tuplet;
+#include "struct_pack/struct_pack/struct_pack_impl.hpp"
+#include "struct_pack/struct_pack/reflection.h"
 
 using namespace std::string_view_literals;
 
@@ -195,13 +194,17 @@ TEST_CASE("Check tuplet::apply with tuplet::tie") {
 }
 
 TEST_CASE("Test that for_each works") {
-  using tuplet::tuple;
-
   std::string str;
 
-  //   auto ins = std::back_inserter(str);
-
-  tuple tup{"Hello world!", std::string("This is a test..."), 10, 20, 3.141592};
+  tuplet::tuple tup{"Hello world!", std::string("This is a test..."), 10, 20, 3.141592};
+  static_assert(struct_pack::detail::trivial_copy_tuple<decltype(tup)>);
+  static_assert(std::is_aggregate_v<decltype(tup)>);
+  static_assert(std::is_trivially_copyable_v<tuplet::tuple<int, double>>);
+  static_assert(!std::is_trivially_copyable_v<decltype(tup)>);
+  static_assert(!std::is_trivially_copyable_v<std::tuple<int, double>>);
+  static_assert(!struct_pack::detail::tuple<decltype(tup)>);
+  static_assert(tuplet::tuple_size_v<decltype(tup)>);
+  static_assert(std::is_same_v<tuplet::tuple_element_t<1, decltype(tup)>, std::string>);
 
   tup.for_each([&]<typename T>(T& value) {
     if constexpr (std::is_fundamental_v<T>) {

--- a/src/struct_pack/tests/test_tuplet.cpp
+++ b/src/struct_pack/tests/test_tuplet.cpp
@@ -1,0 +1,303 @@
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include "doctest.h"
+#include "struct_pack/struct_pack/tuple.hpp"
+
+using namespace tuplet;
+
+using namespace std::string_view_literals;
+
+template <typename Tuple, size_t... Indexes, typename Fn>
+constexpr decltype(auto) tuple_for_each_impl(
+    Tuple&& tuple, std::integer_sequence<size_t, Indexes...>, Fn&& fn) {
+  (fn(get<Indexes>(std::forward<Tuple>(tuple))), ...);
+
+  return std::forward<Fn>(fn);
+}
+template <typename Tuple, typename Fn>
+constexpr decltype(auto) tuple_for_each(Tuple&& tuple, Fn&& fn) {
+  using indexes =
+      std::make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>;
+
+  return tuple_for_each_impl(std::forward<Tuple>(tuple), indexes{},
+                             std::forward<Fn>(fn));
+}
+
+template <size_t Alignment, typename T>
+constexpr T align_value(T value) {
+  constexpr auto alignment{static_cast<T>(Alignment)};
+
+  value += alignment - 1;
+  value &= ~(alignment - 1);
+
+  return value;
+}
+
+#if (defined _MSC_VER)
+constexpr bool is_cl_or_clang_cl = true;
+#else
+constexpr bool is_cl_or_clang_cl = false;
+#endif
+
+#define DO_STRINGIZE(a) #a
+#define STRINGIZE(a) DO_STRINGIZE(a)
+
+constexpr bool has_no_unique_address =
+    sizeof(STRINGIZE(TUPLET_NO_UNIQUE_ADDRESS)) > 1;
+
+struct empty {};
+
+struct struct_with_empty {
+  alignas(sizeof(int) * 2) int a;
+  TUPLET_NO_UNIQUE_ADDRESS empty b;
+  int c;
+};
+
+static_assert(offsetof(struct_with_empty, b) == (has_no_unique_address)
+                  ? 0
+                  : sizeof(int));
+static_assert(sizeof(struct_with_empty) ==
+              (has_no_unique_address ? (sizeof(int) * 2) : (sizeof(int) * 4)));
+
+// c's offset is different with cl + [[msvc::no_unique_address]] than gcc/clang
+// with [[no_unique_address]].
+static_assert(offsetof(struct_with_empty, c) ==
+                      (has_no_unique_address && !is_cl_or_clang_cl)
+                  ? sizeof(int)
+                  : 2 * sizeof(int));
+
+template <typename Tuple>
+void test_tuple_alignment() {
+  Tuple t;
+  const auto base_addr{reinterpret_cast<uintptr_t>(&t)};
+  size_t offset{0}, index{0};
+
+  tuple_for_each(t, [&](auto& element) {
+    using element_type = std::decay_t<decltype(element)>;
+
+    const auto addr{reinterpret_cast<uintptr_t>(&element)};
+    const auto element_offset{addr - base_addr};
+    constexpr auto element_size{sizeof(element_type)};
+
+    offset = align_value<alignof(element_type)>(offset);
+
+    if (has_no_unique_address) {
+      // cl with [[msvc::no_unique_address]] will not optimize out empty
+      // tuple elements.
+      if (is_cl_or_clang_cl || (element_type::s_size != 0)) {
+        CHECK(element_offset == offset);
+
+        if (!is_cl_or_clang_cl && !std::is_aggregate_v<element_type>) {
+          // Only non-aggregates allow their padding to be used for
+          // the next element.
+          // cl doesn't do this either.
+          offset += element_type::s_size;
+        }
+        else {
+          offset += element_size;
+        }
+      }
+      else {
+        // gcc and clang will optimize away and the offset is 0, not the
+        // offset of the previous element.
+        CHECK(element_offset == 0);
+      }
+    }
+    else {
+      // Simple case; no [[no_unique_address]] affecting things.
+      CHECK(element_offset == offset);
+      offset += element_size;
+    }
+  });
+
+  offset = align_value<alignof(Tuple)>(offset);
+
+  CHECK(offset == sizeof(Tuple));
+}
+
+template <size_t Size, size_t Alignment>
+struct alignas(Alignment) aligned_buffer_aggregate {
+  static constexpr size_t s_size{Size};
+
+  uint8_t m_buff[s_size];
+};
+
+template <size_t Alignment>
+struct alignas(Alignment) aligned_buffer_aggregate<0, Alignment> {
+  static constexpr size_t s_size{0};
+};
+
+template <size_t Size, size_t Alignment>
+struct alignas(Alignment) aligned_buffer {
+  static constexpr size_t s_size{Size};
+
+  uint8_t m_buff[s_size];
+
+  aligned_buffer() {}
+};
+
+template <size_t Alignment>
+struct alignas(Alignment) aligned_buffer<0, Alignment> {
+  static constexpr size_t s_size{0};
+
+  aligned_buffer() {}
+};
+
+TEST_CASE("Check alignment") {
+  using buff40_64_a = aligned_buffer_aggregate<40, 64>;
+  using buff10_16_a = aligned_buffer_aggregate<10, 16>;
+  using buff15_32_a = aligned_buffer_aggregate<15, 32>;
+  using buff0_16_a = aligned_buffer_aggregate<0, 16>;
+  using buff13_8_a = aligned_buffer_aggregate<13, 8>;
+
+  using buff40_64 = aligned_buffer<40, 64>;
+  using buff10_16 = aligned_buffer<10, 16>;
+  using buff15_32 = aligned_buffer<15, 32>;
+  using buff0_16 = aligned_buffer<0, 16>;
+  using buff13_8 = aligned_buffer<13, 8>;
+
+  test_tuple_alignment<tuplet::tuple<buff40_64_a, buff10_16_a, buff15_32_a,
+                                     buff0_16_a, buff13_8_a>>();
+
+  test_tuple_alignment<
+      tuplet::tuple<buff40_64, buff10_16, buff15_32, buff0_16, buff13_8>>();
+
+  test_tuple_alignment<tuplet::tuple<buff40_64_a, buff10_16, buff15_32_a,
+                                     buff0_16, buff13_8_a>>();
+
+  test_tuple_alignment<
+      tuplet::tuple<buff40_64, buff10_16_a, buff15_32, buff0_16_a, buff13_8>>();
+}
+
+TEST_CASE("Check tuplet::apply with tuplet::tie") {
+  int a = 0;
+  int b = 0;
+  std::string c;
+  REQUIRE((a == 0 && b == 0 && c == ""));
+
+  auto func = [](auto& x, auto& y, auto& z) {
+    x = 1;
+    y = 2;
+    z = "Hello, world!";
+  };
+
+  apply(func, tuplet::tie(a, b, c));
+
+  REQUIRE(a == 1);
+  REQUIRE(b == 2);
+  REQUIRE(c == "Hello, world!");
+}
+
+TEST_CASE("Test that for_each works") {
+  using tuplet::tuple;
+
+  std::string str;
+
+  //   auto ins = std::back_inserter(str);
+
+  tuple tup{"Hello world!", std::string("This is a test..."), 10, 20, 3.141592};
+
+  tup.for_each([&]<typename T>(T& value) {
+    if constexpr (std::is_fundamental_v<T>) {
+      str.append(std::to_string(value)).append("\n");
+    }
+    else {
+      str.append(value).append("\n");
+    }
+  });
+
+  REQUIRE(str ==
+          "Hello world!\n"       //
+          "This is a test...\n"  //
+          "10\n"                 //
+          "20\n"                 //
+          "3.141592\n");
+}
+
+TEST_CASE("Test that for_each moves values when given moved-from tuple") {
+  using tuplet::tuple;
+
+  auto tup = tuple{std::make_unique<int>(10), std::make_unique<int>(20),
+                   std::make_unique<int>(30)};
+
+  SUBCASE("Check that the tuple is valid") {
+    REQUIRE(tup.all([](auto& val) {
+      return bool(val);
+    }));
+  }
+  int sum = 0;
+  std::move(tup).for_each([&](auto value) {
+    sum += *value;
+  });
+
+  SUBCASE("check that the tuple was moved from and the sum is 60") {
+    REQUIRE(tup.all([](auto& val) {
+      return bool(val) == false;
+    }));
+    REQUIRE(sum == 60);
+  }
+}
+
+TEST_CASE("Move elements with tuple.map") {
+  using tuplet::tuple;
+  using std::string_view_literals::operator""sv;
+
+  auto tup = tuple{10, 20.4, "Hello, world"sv, std::make_unique<int>(10)};
+
+  auto expected = tuple{10, 20.4, "Hello, world"sv, std::make_unique<int>(10)};
+
+  auto fucking_yeet = [](auto val) {
+    return val;
+  };
+
+  auto result = std::move(tup).map(fucking_yeet);
+
+  INFO("Check that the tuple was moved-from");
+  REQUIRE(bool(get<3>(tup)) == false);
+  REQUIRE(*get<3>(result) == *get<3>(expected));
+}
+
+TEST_CASE("Check tuple decomposition") {
+  auto tup = tuplet::tuple{1, 2, std::string("Hello, world!")};
+
+  auto [a, b, c] = tup;
+
+  assert(a == 1);
+  assert(b == 2);
+  assert(c == "Hello, world!");
+}
+
+TEST_CASE("Check tuple decomposition by reference") {
+  auto tup = tuplet::tuple{0, 0, std::string()};
+
+  auto& [a, b, c] = tup;
+
+  a = 1;
+  b = 2;
+  c = "Hello, world!";
+
+  get<0>(tup);
+
+  assert(get<0>(tup) == 1);
+  assert(get<1>(tup) == 2);
+  assert(get<2>(tup) == "Hello, world!");
+}
+
+TEST_CASE("Check tuple decomposition by move") {
+  auto tup =
+      tuplet::tuple{1, std::make_unique<int>(2), std::string("Hello, world!")};
+
+  // Check that moving a tuple moves the elements when
+  // doing a structured bind
+  auto [a, b, c] = std::move(tup);
+
+  assert(a == 1);
+  assert(*b == 2);
+  assert(c == "Hello, world!");
+}


### PR DESCRIPTION
## Why

std::tuple is not trivial copyable type, we need a trivial copyable tuple, so import [tuplet](https://github.com/codeinred/tuplet)
