### PR TITLE
add ci

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,29 @@
+name: Clang Format Diff
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: install clang-format
+        run:  sudo apt install clang-format
+      - name: check-diff
+        run: |
+          diff=`git-clang-format --diff HEAD^`
+          if ! [[ "$diff" = "no modified files to format" || "$diff" = "clang-format did not modify any files" ]]; then
+              echo "The diff you sent is not formatted correctly."
+              echo "The suggested format is"
+              echo "$diff"
+              exit 1
+          fi

--- a/.github/workflows/linux_clang.yml
+++ b/.github/workflows/linux_clang.yml
@@ -1,0 +1,35 @@
+name: Ubuntu 20.04 (clang)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        mode: [Release, Debug]
+        libcxx: [OFF]
+        ssl: [ON, OFF]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install openssl
+          sudo apt-get install libssl-dev
+
+      - name: Configure CMake
+        run: CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DBUILD_WITH_LIBCXX=${{matrix.libcxx}} -DENABLE_SSL=${{matrix.ssl}}
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.mode}}
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{matrix.mode}} -j `nproc` -V

--- a/.github/workflows/linux_gcc.yml
+++ b/.github/workflows/linux_gcc.yml
@@ -1,0 +1,35 @@
+name: Ubuntu 20.04 (gcc)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        #mode: [Release, Debug]
+        mode: [Debug] # remove Release to reduce ci time
+        ssl: [ON, OFF]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install openssl
+          sudo apt-get install libssl-dev
+
+      - name: Configure CMake
+        run: CXX=g++ CC=gcc cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DENABLE_SSL=${{matrix.ssl}}
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.mode}}
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{matrix.mode}} -j `nproc` -V

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,42 @@
+name: macOS Monterey 12
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        #mode: [Release, Debug]
+        mode: [Debug] # remove Release to reduce ci time
+        ssl: [ON, OFF]
+
+    runs-on: macos-12
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: SetUp HomeBrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Install Dependencies
+        run: brew install openssl
+
+      - name: Configure CMake
+        run: OPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@3/3.0.5 CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DENABLE_SSL=${{matrix.ssl}}
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.mode}}
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{matrix.mode}} -j `nproc` -V

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,49 @@
+name: Windows Server 2022
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        #mode: [ Release, Debug ]
+        mode: [ Debug ]
+        #arch: [ Win32, x64, ARM, ARM64 ]
+        arch: [ Win32, x64 ]
+        #ssl: [ON, OFF]
+        ssl: [OFF]
+
+    env:
+      CXX: cl.exe
+      CC: cl.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: SetUp Vcpkg
+        uses: friendlyanon/setup-vcpkg@v1
+        with: { committish: 63aa65e65b9d2c08772ea15d25fb8fdb0d32e557 }
+
+      - name: test env
+        run: echo $VCPKG_ROOT
+
+      - name: Generate Project
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DyaLanTingLibs_ENABLE_PROJECTS=struct_pack -DENABLE_SSL=${{matrix.ssl}} -A ${{ matrix.arch }} -D "CMAKE_TOOLCHAIN_FILE=${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build struct_pack
+        run: cmake --build ${{github.workspace}}/build --config ${{ matrix.mode }}
+
+      - name: Test struct_pack
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{matrix.mode}} -j 2 -V

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "yalantinglibs",
+  "version-string": "0.1.0",
+  "port-version": 1,
+  "homepage": "https://github.com/alibaba/yalantinglibs",
+  "description": "A collection of C++20 libraries, include async_simple, coro_rpc and struct_pack.",
+  "dependencies": [
+    "openssl"
+  ]
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

Continuous integration (CI) is a software practice that requires frequently committing code to a shared repository. 

We need CI to 

## What is changing

use [GitHub Action](https://docs.github.com/en/actions) to build code 

- Ubuntu 20.04 (gcc)
- Ubuntu 20.04 (clang)
- Windows Server 2022 
- macOS Monterey 12

Note: 
- `coro_rpc` is not ready for MSVC, only `struct_pack` enabled in CI.
- to reduce ci time, for unix-like systems, only `Debug` mode enabled.
- `BUILD_WITH_LIBCXX` is disabled due to compile fail.
- `ENABLE_SSL` is enabled for unix-like systems.