### PR TITLE
[struct_pack] check alignment requirement

### DIFF
--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -41,6 +41,8 @@ namespace struct_pack {
 
 template <typename T>
 constexpr std::size_t members_count = 0;
+template <typename T>
+constexpr std::size_t min_alignment = 0;
 namespace detail {
 template <typename Type>
 concept deserialize_view = requires(Type container) {
@@ -230,6 +232,25 @@ consteval std::size_t member_count() {
   else {
     return member_count_impl<T>();
   }
+}
+// add extension like `members_count`
+template <typename T>
+consteval std::size_t min_align() {
+  if constexpr (struct_pack::min_alignment < T >> 0) {
+    return struct_pack::min_alignment<T>;
+  }
+  else {
+    // don't use \0 as 0
+    // due to \0 is a special flag for struct_pack
+    // '0' ascii code is 48
+    return '0';
+  }
+}
+// similar to `min_align`
+template <typename T>
+consteval std::size_t max_align() {
+  static_assert(std::alignment_of_v<T> > 0);
+  return std::alignment_of_v<T>;
 }
 
 constexpr static auto MaxVisitMembers = 64;

--- a/src/struct_pack/tests/CMakeLists.txt
+++ b/src/struct_pack/tests/CMakeLists.txt
@@ -1,5 +1,12 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
-add_executable(test_serialize test_serialize.cpp test_tuplet.cpp main.cpp)
+add_executable(test_serialize
+        test_serialize.cpp
+        test_tuplet.cpp
+        test_alignas.cpp
+        test_pragma_pack.cpp
+        test_pragma_pack_and_alignas_mix.cpp
+        main.cpp
+        )
 add_test(NAME test_serialize COMMAND test_serialize)
 target_compile_definitions(test_serialize PRIVATE STRUCT_PACK_USE_INT16_SIZE STRUCT_PACK_ENABLE_UNPORTABLE_TYPE)
 target_link_libraries(test_serialize PRIVATE libstruct_pack doctest)

--- a/src/struct_pack/tests/test_alignas.cpp
+++ b/src/struct_pack/tests/test_alignas.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstddef>
+#include <iostream>
+
+#include "doctest.h"
+#include "struct_pack/struct_pack.hpp"
+using namespace struct_pack;
+using namespace doctest;
+// clang-format off
+static std::string alignment_requirement_err_msg = "different alignment requirement, we must regard as different type";
+// clang-format on
+TEST_SUITE_BEGIN("test_alignas");
+namespace test_alignas {
+template <typename T>
+concept Dummy = requires {
+  T().a;
+  T().b;
+};
+
+template <Dummy A, Dummy B>
+bool operator==(const A& a, const B& b) {
+  return a.a == b.a && a.b == b.b;
+}
+struct dummy {
+  char a;
+  short b;
+};
+}  // namespace test_alignas
+TEST_CASE("testing no alignas") {
+  using T = test_alignas::dummy;
+  static_assert(std::alignment_of_v<T> == 2);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(alignof(T) == 2);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 2);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 2, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  auto ret = struct_pack::deserialize<T>(buf);
+  REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+  T d_t = ret.value();
+  CHECK(t == d_t);
+}
+namespace test_alignas {
+struct alignas(2) dummy_2 {
+  char a;
+  short b;
+};
+}  // namespace test_alignas
+TEST_CASE("testing alignas(2)") {
+  using T = test_alignas::dummy_2;
+  static_assert(std::alignment_of_v<T> == 2);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(alignof(T) == 2);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 2);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 2, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  SUBCASE("deserialize to dummy") {
+    using DT = test_alignas::dummy;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    DT d_t = ret.value();
+    CHECK(t == d_t);
+  }
+  SUBCASE("deserialize to dummy_2") {
+    using DT = test_alignas::dummy_2;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    DT d_t = ret.value();
+    CHECK(t == d_t);
+  }
+}
+namespace test_alignas {
+struct alignas(4) dummy_4 {
+  char a;
+  short b;
+};
+}  // namespace test_alignas
+TEST_CASE("testing alignas(4)") {
+  using T = test_alignas::dummy_4;
+  static_assert(std::alignment_of_v<T> == 4);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 4);
+  static_assert(alignof(T) == 4);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 2);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 4, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  SUBCASE("deserialize to dummy") {
+    using DT = test_alignas::dummy;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_2") {
+    using DT = test_alignas::dummy_2;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_4") {
+    using DT = test_alignas::dummy_4;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    DT d_t = ret.value();
+    CHECK(t == d_t);
+  }
+}
+namespace test_alignas {
+struct alignas(8) dummy_8 {
+  char a;
+  short b;
+};
+}  // namespace test_alignas
+TEST_CASE("testing alignas(8)") {
+  using T = test_alignas::dummy_8;
+  static_assert(std::alignment_of_v<T> == 8);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 8);
+  static_assert(alignof(T) == 8);
+  static_assert(sizeof(T) == 8);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 2);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 8, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  SUBCASE("deserialize to dummy") {
+    using DT = test_alignas::dummy;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_2") {
+    using DT = test_alignas::dummy_2;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_4") {
+    using DT = test_alignas::dummy_4;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_8") {
+    using DT = test_alignas::dummy_8;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    DT d_t = ret.value();
+    CHECK(t == d_t);
+  }
+}
+namespace test_alignas {
+struct alignas(4) A {
+  char a;
+  short b;
+};
+struct alignas(8) B {
+  char a;
+  int b;
+};
+struct alignas(16) Outer {
+  A a;
+  B b;
+};
+}  // namespace test_alignas
+
+TEST_CASE("testing nesting alignas") {
+  using T = test_alignas::Outer;
+  static_assert(std::alignment_of_v<T> == 16);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 16);
+  static_assert(alignof(T) == 16);
+  static_assert(sizeof(T) == 16);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 8);
+  auto literal = struct_pack::get_type_literal<T>();
+  // clang-format off
+  string_literal<char, 14> val{{(char)-3,
+                               12, 7, 48,  4, (char)-1,
+                               12, 1, 48,  8, (char)-1,
+                                      48, 16, (char)-1}};
+  // clang-format on
+  REQUIRE(literal == val);
+}
+TEST_SUITE_END;

--- a/src/struct_pack/tests/test_pragma_pack.cpp
+++ b/src/struct_pack/tests/test_pragma_pack.cpp
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstddef>
+#include <iostream>
+
+#include "doctest.h"
+#include "struct_pack/struct_pack.hpp"
+using namespace struct_pack;
+using namespace doctest;
+// clang-format off
+static std::string alignment_requirement_err_msg = "different alignment requirement, we must regard as different type";
+// clang-format on
+TEST_SUITE_BEGIN("test_pragma_pack");
+namespace test_pragma_pack {
+template <typename T>
+concept Dummy = requires {
+  T().a;
+  T().b;
+};
+
+template <Dummy A, Dummy B>
+bool operator==(const A& a, const B& b) {
+  return a.a == b.a && a.b == b.b;
+}
+struct dummy {
+  char a;
+  short b;
+};
+}  // namespace test_pragma_pack
+TEST_CASE("testing no #pragam pack") {
+  using T = test_pragma_pack::dummy;
+  static_assert(std::alignment_of_v<T> == 2);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(alignof(T) == 2);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 2);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 2, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  auto ret = struct_pack::deserialize<T>(buf);
+  REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+  T d_t = ret.value();
+  CHECK(t == d_t);
+}
+namespace test_pragma_pack {
+#pragma pack(1)
+struct dummy_1 {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack
+template <>
+constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::dummy_1> = 1;
+namespace test_pragma_pack {
+#pragma pack(1)
+// if we forget add the template specialization like above,
+// the deserialization will be failed.
+struct dummy_1_forget {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack
+TEST_CASE("testing #pragma pack(1)") {
+  using T = test_pragma_pack::dummy_1;
+  static_assert(std::alignment_of_v<T> == 1);
+  static_assert(struct_pack::min_alignment<T> == 1);
+  static_assert(struct_pack::detail::min_align<T>() == 1);
+  static_assert(struct_pack::detail::max_align<T>() == 1);
+  static_assert(alignof(T) == 1);
+  static_assert(sizeof(T) == 3);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 1);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 1, 1, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  SUBCASE("deserialize to dummy") {
+    using DT = test_pragma_pack::dummy;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_1") {
+    using DT = test_pragma_pack::dummy_1;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    DT d_t = ret.value();
+    CHECK(t == d_t);
+  }
+  SUBCASE("deserialize to dummy_1_forget") {
+    using DT = test_pragma_pack::dummy_1_forget;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+}
+namespace test_pragma_pack {
+#pragma pack(2)
+struct dummy_2 {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack
+template <>
+constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::dummy_2> = 2;
+namespace test_pragma_pack {
+#pragma pack(2)
+struct dummy_2_forget {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack
+TEST_CASE("testing #pragma pack(2)") {
+  using T = test_pragma_pack::dummy_2;
+  static_assert(std::alignment_of_v<T> == 2);
+  static_assert(struct_pack::min_alignment<T> == 2);
+  static_assert(struct_pack::detail::min_align<T>() == 2);
+  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(alignof(T) == 2);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 2);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 2, 2, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  SUBCASE("deserialize to dummy") {
+    using DT = test_pragma_pack::dummy;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_1") {
+    using DT = test_pragma_pack::dummy_1;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_1_forget") {
+    using DT = test_pragma_pack::dummy_1_forget;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_2") {
+    using DT = test_pragma_pack::dummy_2;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    DT d_t = ret.value();
+    CHECK(t == d_t);
+  }
+  SUBCASE("deserialize to dummy_2_forget") {
+    using DT = test_pragma_pack::dummy_2_forget;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    // although the default alignment is 2,
+    // if we forget add the `min_alignment<dummy_2> = 2;`
+    // struct_pack can't get the actual min alignment.
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+}
+
+namespace test_pragma_pack {
+#pragma pack(1)
+struct A {
+  char a;
+  short b;
+};
+#pragma pack()
+#pragma pack(2)
+struct B {
+  char a;
+  int b;
+};
+#pragma pack()
+struct Outer {
+  A a;
+  B b;
+};
+#pragma pack(1)
+struct Outer_1 {
+  A a;
+  B b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack
+template <>
+constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::A> = 1;
+template <>
+constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::B> = 2;
+template <>
+constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::Outer_1> = 1;
+TEST_CASE("testing nesting #pragma pack()") {
+  using T = test_pragma_pack::Outer;
+  static_assert(std::alignment_of_v<T> == 2);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(alignof(T) == 2);
+  static_assert(sizeof(T) == 10);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 4);
+  auto literal = struct_pack::get_type_literal<T>();
+  // clang-format off
+  string_literal<char, 14> val{{(char)-3,
+                                12, 7, 1, 1, (char)-1,
+                                12, 1, 2, 2, (char)-1,
+                                      48, 2, (char)-1}};
+  // clang-format on
+  REQUIRE(literal == val);
+}
+TEST_CASE("testing nesting #pragma pack(), outer pack(1)") {
+  using T = test_pragma_pack::Outer_1;
+  static_assert(std::alignment_of_v<T> == 1);
+  static_assert(struct_pack::min_alignment<T> == 1);
+  static_assert(struct_pack::detail::min_align<T>() == 1);
+  static_assert(struct_pack::detail::max_align<T>() == 1);
+  static_assert(alignof(T) == 1);
+  static_assert(sizeof(T) == 9);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 3);
+  auto literal = struct_pack::get_type_literal<T>();
+  // clang-format off
+  string_literal<char, 14> val{{(char)-3,
+                                12, 7, 1, 1, (char)-1,
+                                12, 1, 2, 2, (char)-1,
+                                       1, 1, (char)-1}};
+  // clang-format on
+  REQUIRE(literal == val);
+}
+TEST_SUITE_END;

--- a/src/struct_pack/tests/test_pragma_pack_and_alignas_mix.cpp
+++ b/src/struct_pack/tests/test_pragma_pack_and_alignas_mix.cpp
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstddef>
+#include <iostream>
+
+#include "doctest.h"
+#include "struct_pack/struct_pack.hpp"
+using namespace struct_pack;
+using namespace doctest;
+// clang-format off
+static std::string alignment_requirement_err_msg = "different alignment requirement, we must regard as different type";
+// clang-format on
+TEST_SUITE_BEGIN("test_pragma_pack_and_alignas_mix");
+namespace test_pragma_pack_and_alignas_mix {
+template <typename T>
+concept Dummy = requires {
+  T().a;
+  T().b;
+};
+
+template <Dummy A, Dummy B>
+bool operator==(const A& a, const B& b) {
+  return a.a == b.a && a.b == b.b;
+}
+struct dummy {
+  char a;
+  short b;
+};
+}  // namespace test_pragma_pack_and_alignas_mix
+TEST_CASE("testing no one") {
+  using T = test_pragma_pack_and_alignas_mix::dummy;
+  static_assert(std::alignment_of_v<T> == 2);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(alignof(T) == 2);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 2);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 2, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  auto ret = struct_pack::deserialize<T>(buf);
+  REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+  T d_t = ret.value();
+  CHECK(t == d_t);
+}
+namespace test_pragma_pack_and_alignas_mix {
+#pragma pack(1)
+struct alignas(2) dummy_1_2 {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack_and_alignas_mix
+template <>
+constexpr std::size_t
+    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::dummy_1_2> = 1;
+namespace test_pragma_pack_and_alignas_mix {
+#pragma pack(1)
+struct alignas(2) dummy_1_2_forget {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack_and_alignas_mix
+TEST_CASE("testing #pragam pack(1), alignas(2)") {
+  using T = test_pragma_pack_and_alignas_mix::dummy_1_2;
+  static_assert(std::alignment_of_v<T> == 2);
+  static_assert(struct_pack::min_alignment<T> == 1);
+  static_assert(struct_pack::detail::min_align<T>() == 1);
+  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(alignof(T) == 2);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 1);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 1, 2, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  SUBCASE("deserialize to dummy") {
+    using DT = test_pragma_pack_and_alignas_mix::dummy;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_1_2") {
+    using DT = test_pragma_pack_and_alignas_mix::dummy_1_2;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    DT d_t = ret.value();
+    CHECK(t == d_t);
+  }
+  SUBCASE("deserialize to dummy_1_2_forget") {
+    using DT = test_pragma_pack_and_alignas_mix::dummy_1_2_forget;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+}
+namespace test_pragma_pack_and_alignas_mix {
+#pragma pack(1)
+struct alignas(4) dummy_1_4 {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack_and_alignas_mix
+template <>
+constexpr std::size_t
+    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::dummy_1_4> = 1;
+namespace test_pragma_pack_and_alignas_mix {
+#pragma pack(1)
+struct alignas(2) dummy_1_4_forget {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack_and_alignas_mix
+TEST_CASE("testing #pragam pack(1), alignas(2)") {
+  using T = test_pragma_pack_and_alignas_mix::dummy_1_4;
+  static_assert(std::alignment_of_v<T> == 4);
+  static_assert(struct_pack::min_alignment<T> == 1);
+  static_assert(struct_pack::detail::min_align<T>() == 1);
+  static_assert(struct_pack::detail::max_align<T>() == 4);
+  static_assert(alignof(T) == 4);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 1);
+  T t{.a = 'a', .b = 666};
+  auto literal = struct_pack::get_type_literal<T>();
+  string_literal<char, 6> val{{(char)-3, 12, 7, 1, 4, (char)-1}};
+  REQUIRE(literal == val);
+  auto buf = struct_pack::serialize(t);
+  SUBCASE("deserialize to dummy") {
+    using DT = test_pragma_pack_and_alignas_mix::dummy;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_1_2") {
+    using DT = test_pragma_pack_and_alignas_mix::dummy_1_2;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_1_2_forget") {
+    using DT = test_pragma_pack_and_alignas_mix::dummy_1_2_forget;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+  SUBCASE("deserialize to dummy_1_4") {
+    using DT = test_pragma_pack_and_alignas_mix::dummy_1_4;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    DT d_t = ret.value();
+    CHECK(t == d_t);
+  }
+  SUBCASE("deserialize to dummy_1_4_forget") {
+    using DT = test_pragma_pack_and_alignas_mix::dummy_1_4_forget;
+    auto ret = struct_pack::deserialize<DT>(buf);
+    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+  }
+}
+
+namespace test_pragma_pack_and_alignas_mix {
+#pragma pack(4)
+struct alignas(2) dummy_4_2 {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack_and_alignas_mix
+template <>
+constexpr std::size_t
+    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::dummy_4_2> = 4;
+namespace test_pragma_pack_and_alignas_mix {
+#pragma pack(4)
+struct alignas(2) dummy_4_2_forget {
+  char a;
+  short b;
+};
+#pragma pack()
+}  // namespace test_pragma_pack_and_alignas_mix
+TEST_CASE("testing #pragam pack(4), alignas(2)") {
+  using T = test_pragma_pack_and_alignas_mix::dummy_4_2;
+  static_assert(std::alignment_of_v<T> == 2);
+  static_assert(struct_pack::min_alignment<T> == 4);
+  static_assert(struct_pack::detail::min_align<T>() == 4);
+  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(alignof(T) == 2);
+  static_assert(sizeof(T) == 4);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 2);
+  // auto buf = struct_pack::serialize(t);
+  // cannot compile
+  // #pragma pack may decrease the alignment of a class,
+  // however, it cannot make a class over aligned.
+}
+namespace test_pragma_pack_and_alignas_mix {
+#pragma pack(1)
+struct alignas(4) A {
+  char a;
+  short b;
+};
+#pragma pack()
+#pragma pack(2)
+struct alignas(8) B {
+  char a;
+  int b;
+};
+#pragma pack()
+struct alignas(16) Outer {
+  A a;
+  B b;
+};
+}  // namespace test_pragma_pack_and_alignas_mix
+template <>
+constexpr std::size_t
+    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::A> = 1;
+template <>
+constexpr std::size_t
+    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::B> = 2;
+TEST_CASE("testing mix nested") {
+  using T = test_pragma_pack_and_alignas_mix::Outer;
+  static_assert(std::alignment_of_v<T> == 16);
+  static_assert(struct_pack::min_alignment<T> == 0);
+  static_assert(struct_pack::detail::min_align<T>() == '0');
+  static_assert(struct_pack::detail::max_align<T>() == 16);
+  static_assert(alignof(T) == 16);
+  static_assert(sizeof(T) == 16);
+  static_assert(offsetof(T, a) == 0);
+  static_assert(offsetof(T, b) == 8);
+  auto literal = struct_pack::get_type_literal<T>();
+  // clang-format off
+  string_literal<char, 14> val{{(char)-3,
+                                12, 7, 1,  4, (char)-1,
+                                12, 1, 2,  8, (char)-1,
+                                      48, 16, (char)-1}};
+  // clang-format on
+  REQUIRE(literal == val);
+}
+TEST_SUITE_END;

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -45,6 +45,15 @@
 
 #include "doctest.h"
 using namespace struct_pack;
+// the original <=> operator cannot handle different Size
+template <typename Char, std::size_t Size1, std::size_t Size2>
+constexpr bool operator!=(const string_literal<Char, Size1> &s1,
+                          const string_literal<Char, Size2> &s2) {
+  if constexpr (Size1 == Size2) {
+    return s1 != s2;
+  }
+  return true;
+}
 
 struct person {
   int age;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

handle Case 1: Struct Align of https://github.com/alibaba/yalantinglibs/issues/45


One of the low-level features of C++ is the ability to specify the precise alignment of objects in memory to take maximum advantage of a specific hardware architecture.
In most scenarios, you never have to be concerned with alignment because the default alignment is already optimal. In some cases, however, you can achieve significant performance improvements, or memory savings, by specifying a custom alignment for your data structures. 

So, How do we handle these behavior?

We add the alignment requirement to the end of struct_pack type tree, before doing hash. 

To implement the check, let's look at the C++ alignment requirement first.

On the one hand, the C++11 standard introduces the keywords `alignof` and `alignas` to specify an alignment greater than the default. We can use `std::alignment_of_v<T>` to get the alignment requirement of the type T.

On the other hand, the C++ standard doesn't specify packing behavior for alignment on boundaries smaller than the compiler default for the target platform, so we still need to use the `#pragma pack` in that case. However, there is no way to get that value.

To exemplify, let's consider the following data structures:

```cpp
#pragma pack(1)
struct dummy {
  char a;
  short b;
};
#pragma pack()

#pragma pack(1)
struct alignas(2) dummy_1_2 {
  char a;
  short b;
};
#pragma pack()
```
we can add some check
```cpp
// dummy
  using T = dummy;
  static_assert(std::alignment_of_v<T> == 1);
  static_assert(alignof(T) == 1);
  static_assert(sizeof(T) == 3); // important
  static_assert(offsetof(T, a) == 0);
  static_assert(offsetof(T, b) == 1);

// dummy_1_2
  using T = dummy_1_2;
  static_assert(std::alignment_of_v<T> == 2);
  static_assert(alignof(T) == 2);
  static_assert(sizeof(T) == 4);
  static_assert(offsetof(T, a) == 0);
  static_assert(offsetof(T, b) == 1); // important
```
As you can see, the `std::alignment_of_v<T>` can only get the max alignment.
To get the min alignment, we add 
```cpp
template <typename T>
constexpr std::size_t min_alignment = 0;
```

## What is changing

add the alignment requirement to the end of struct_pack type tree, before doing hash. 

## Example
simple one first
```cpp
#pragma pack(1)
struct dummy {
  char a;
  short b;
};
#pragma pack()
// important
template <>
constexpr std::size_t struct_pack::min_alignment<dummy> = 1;
```

a nested one

```cpp
#pragma pack(1)
struct alignas(4) A {
  char a;
  short b;
};
#pragma pack()
#pragma pack(2)
struct alignas(8) B {
  char a;
  int b;
};
#pragma pack()
struct alignas(16) Outer {
  A a;
  B b;
};
// important
template <>
constexpr std::size_t struct_pack::min_alignment<A> = 1;
template <>
constexpr std::size_t struct_pack::min_alignment<B> = 2;
```

## Limitation
### alignas
The alignas specifier may be applied to:
- the declaration or definition of a class
- the declaration of a non-bitfield class data member;
- the declaration of a variable, except that it cannot be applied to the following:
  - a function parameter;
  - the exception parameter of a catch clause.

Currently, only the declaration or definition of a class handled, other usage of alignas in struct_pack is undefined behavior.

### #pragma pack
If you use `#pragma pack` and no corresponding specialization is written, the serialization and deserialization of that struct is undefined behavior.

## Reference
- [MSVC Alignment](https://learn.microsoft.com/en-us/cpp/cpp/alignment-cpp-declarations?view=msvc-170)
- [std::alignment_of](https://en.cppreference.com/w/cpp/types/alignment_of)