### PR TITLE
fix port in use for msvc; disable iocp

### DIFF
--- a/include/coro_rpc/coro_rpc/async_rpc_server.hpp
+++ b/include/coro_rpc/coro_rpc/async_rpc_server.hpp
@@ -214,7 +214,9 @@ class async_rpc_server {
     using asio::ip::tcp;
     auto endpoint = tcp::endpoint(tcp::v4(), port_);
     acceptor_.open(endpoint.protocol());
+#ifdef __GNUC__
     acceptor_.set_option(tcp::acceptor::reuse_address(true));
+#endif
 
     asio::error_code ec;
     acceptor_.bind(endpoint, ec);
@@ -224,6 +226,9 @@ class async_rpc_server {
       acceptor_.close(ec);
       return std::errc::address_in_use;
     }
+#ifdef _MSC_VER
+    acceptor_.set_option(tcp::acceptor::reuse_address(true));
+#endif
     acceptor_.listen();
 
     auto end_point = acceptor_.local_endpoint(ec);

--- a/include/coro_rpc/coro_rpc/coro_rpc_server.hpp
+++ b/include/coro_rpc/coro_rpc/coro_rpc_server.hpp
@@ -238,7 +238,9 @@ class coro_rpc_server {
     using asio::ip::tcp;
     auto endpoint = tcp::endpoint(tcp::v4(), port_);
     acceptor_.open(endpoint.protocol());
+#ifdef __GNUC__
     acceptor_.set_option(tcp::acceptor::reuse_address(true));
+#endif
     asio::error_code ec;
     acceptor_.bind(endpoint, ec);
     if (ec) {
@@ -249,6 +251,9 @@ class coro_rpc_server {
       close_accept_promise_.set_value();
       return std::errc::address_in_use;
     }
+#ifdef _MSC_VER
+    acceptor_.set_option(tcp::acceptor::reuse_address(true));
+#endif
     acceptor_.listen();
 
     auto end_point = acceptor_.local_endpoint(ec);

--- a/src/coro_rpc/CMakeLists.txt
+++ b/src/coro_rpc/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(libcoro_rpc INTERFACE
         spdlog::spdlog
         async_simple::async_simple_header_only
         )
+add_definitions(-DASIO_DISABLE_IOCP)
 option(ENABLE_IO_URING "Enable io_uring" OFF)
 if (ENABLE_IO_URING) 
     message(STATUS "Use IO_URING for I/O in linux")

--- a/src/coro_rpc/CMakeLists.txt
+++ b/src/coro_rpc/CMakeLists.txt
@@ -11,7 +11,11 @@ target_link_libraries(libcoro_rpc INTERFACE
         spdlog::spdlog
         async_simple::async_simple_header_only
         )
-add_definitions(-DASIO_DISABLE_IOCP)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")        
+    add_definitions(-DASIO_DISABLE_IOCP)
+endif()
+
 option(ENABLE_IO_URING "Enable io_uring" OFF)
 if (ENABLE_IO_URING) 
     message(STATUS "Use IO_URING for I/O in linux")


### PR DESCRIPTION
## Why

Fix port in use for msvc, and disable iocp to avoid a bug: socket destruct after io_context destruct will cause crash, but it's ok on linux, so disable win iocp to avoid the bug.
