### PR TITLE
[struct pack] Detect hash conflict in debug mode

### DIFF
--- a/include/coro_rpc/coro_rpc/rpc_protocol.h
+++ b/include/coro_rpc/coro_rpc/rpc_protocol.h
@@ -17,6 +17,8 @@
 #include <optional>
 #include <string>
 #include <system_error>
+
+#include "struct_pack/struct_pack.hpp"
 #if __has_include(<expected>) && __cplusplus > 202002L
 #include <expected>
 #if __cpp_lib_expected >= 202202L
@@ -68,8 +70,7 @@ using unexpected = tl::unexpected<T>;
 using unexpect_t = tl::unexpect_t;
 #endif
 
-constexpr int SIZE_OF_TYPES_CODE = 4;
-constexpr int RPC_HEAD_LEN = sizeof(rpc_header) + SIZE_OF_TYPES_CODE;
+constexpr int RPC_HEAD_LEN = struct_pack::get_needed_size(rpc_header{});
 constexpr int RESPONSE_HEADER_LEN = 4;
 constexpr int FUNCTION_ID_LEN = 4;
 

--- a/include/coro_rpc/coro_rpc/rpc_protocol.h
+++ b/include/coro_rpc/coro_rpc/rpc_protocol.h
@@ -50,7 +50,13 @@ struct rpc_header {
   uint32_t seq_num;        //!< sequence number
   uint32_t length;         //!< length of RPC body
 };
-
+}  // namespace coro_rpc
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<coro_rpc::rpc_header> =
+    type_info_config::disable;
+};
+namespace coro_rpc {
 #if __cpp_lib_expected >= 202202L && __cplusplus > 202002L
 template <class T, class E>
 using expected = std::expected<T, E>;
@@ -71,6 +77,8 @@ using unexpect_t = tl::unexpect_t;
 #endif
 
 constexpr int RPC_HEAD_LEN = struct_pack::get_needed_size(rpc_header{});
+static_assert(RPC_HEAD_LEN == 16);
+
 constexpr int RESPONSE_HEADER_LEN = 4;
 constexpr int FUNCTION_ID_LEN = 4;
 

--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -132,16 +132,19 @@ STRUCT_PACK_INLINE std::string error_message(struct_pack::errc err) {
  */
 
 template <typename... Args>
-STRUCT_PACK_INLINE consteval std::size_t get_type_code() {
+STRUCT_PACK_INLINE consteval std::uint32_t get_type_code() {
   static_assert(sizeof...(Args) > 0);
+  std::uint32_t ret;
   if constexpr (sizeof...(Args) == 1) {
-    return detail::get_types_code<Args..., decltype(detail::get_types(
-                                               std::declval<Args...>()))>();
+    ret = detail::get_types_code<Args..., decltype(detail::get_types(
+                                              std::declval<Args...>()))>();
   }
   else {
-    return detail::get_types_code<std::tuple<std::remove_cvref_t<Args>...>,
-                                  std::tuple<Args...>>();
+    ret = detail::get_types_code<std::tuple<std::remove_cvref_t<Args>...>,
+                                 std::tuple<Args...>>();
   }
+  ret = ret - ret % 2;
+  return ret;
 }
 
 template <typename... Args>

--- a/include/struct_pack/struct_pack/error_code.h
+++ b/include/struct_pack/struct_pack/error_code.h
@@ -10,6 +10,8 @@ enum class errc {
   hash_conflict,
 };
 
+namespace detail {
+
 class struct_pack_category : public std::error_category {
  public:
   virtual const char *name() const noexcept override {
@@ -34,12 +36,9 @@ class struct_pack_category : public std::error_category {
 };
 
 inline const std::error_category &category() {
-  static struct_pack::struct_pack_category instance;
+  static struct_pack::detail::struct_pack_category instance;
   return instance;
 }
+}  // namespace detail
 
-inline std::error_code make_error_code(struct_pack::errc err) {
-  return std::error_code((std::underlying_type_t<errc> &)err,
-                         struct_pack::category());
-}
 }  // namespace struct_pack

--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -43,6 +43,7 @@ template <typename T>
 constexpr std::size_t members_count = 0;
 template <typename T>
 constexpr std::size_t min_alignment = 0;
+
 namespace detail {
 template <typename Type>
 concept deserialize_view = requires(Type container) {

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -1240,8 +1240,7 @@ class unpacker {
     constexpr auto literal = struct_pack::get_type_literal<T>();
     if (std::string_view{(char *)(data_ + pos_), literal.size() + 1} !=
         std::string_view{literal.data(), literal.size() + 1}) [[unlikely]] {
-      // hash conflict!
-      return errc::invalid_argument;
+      return errc::hash_conflict;
     }
     pos_ += literal.size() + 1;
     return errc{};

--- a/src/struct_pack/benchmark/benchmark.cpp
+++ b/src/struct_pack/benchmark/benchmark.cpp
@@ -211,7 +211,7 @@ void bench(T &t, PB &p, std::string tag) {
       std::size_t len = 0;
       for (size_t j = 0; j < SAMPLES_COUNT; j++) {
         auto ec = struct_pack::deserialize_to_with_offset(t, buffer1, len);
-        if (ec != std::errc{}) [[unlikely]] {
+        if (ec != struct_pack::errc{}) [[unlikely]] {
           exit(1);
         }
         no_op();

--- a/src/struct_pack/doc/struct_pack_doc.hpp
+++ b/src/struct_pack/doc/struct_pack_doc.hpp
@@ -270,7 +270,7 @@ template <typename... Args>
 
 /*!
  * \ingroup struct_pack
- * 当传入的参数多于一个时，返回类型`std::tuple<T...>`的校验码
+ * 返回一个31位的类型T的MD5校验码。当传入的参数多于一个时，返回类型`std::tuple<Args...>`的校验码
  *
  * 样例代码：
  *
@@ -285,7 +285,7 @@ template <typename... Args>
  * @return 编译期计算出的类型的哈希校验码。
  */
 template <typename... Args>
-STRUCT_PACK_INLINE consteval std::size_t get_type_code();
+STRUCT_PACK_INLINE consteval std::uint32_t get_type_code();
 
 /*!
  * \ingroup struct_pack

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -1734,7 +1734,7 @@ TEST_CASE("test hash confliet detected") {
   memcpy(ret.data(), &fake_hash, sizeof(fake_hash));
   auto res = deserialize<float>(ret);
   CHECK(!res);
-  CHECK(res.error() == struct_pack::errc::invalid_argument);
+  CHECK(res.error() == struct_pack::errc::hash_conflict);
 }
 #endif
 

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -163,7 +163,7 @@ TEST_CASE("testing api") {
     CHECK(ret1.size() == ret2.size() - offset);
     auto p1 = deserialize<person>(ret1.data(), ret1.size());
     CHECK(p1);
-    auto p2 = deserialize<person>(ret2.data() + offset, ret1.size() - offset);
+    auto p2 = deserialize<person>(ret2.data() + offset, ret2.size() - offset);
     CHECK(p2);
     CHECK(p == p1.value());
     CHECK(p == p2.value());
@@ -672,7 +672,11 @@ TEST_CASE("test variant") {
 TEST_CASE("test monostate") {
   {
     std::monostate var, var2;
+#ifdef NDEBUG
     static_assert(struct_pack::get_needed_size(std::monostate{}) == 4);
+#else
+    static_assert(struct_pack::get_needed_size(std::monostate{}) == 7);
+#endif
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
     CHECK(ec == struct_pack::errc{});
@@ -1632,8 +1636,13 @@ TEST_CASE("test compatible") {
   }
   SUBCASE("big compatible metainfo") {
     {
-      std::tuple<compatible<std::array<char, 247>>> big =
-          std::array<char, 247>{'A', 'E', 'I', 'O', 'U'};
+#ifdef NDEBUG
+      constexpr size_t array_sz = 247;
+#else
+      constexpr size_t array_sz = 244;
+#endif
+      std::tuple<compatible<std::array<char, array_sz>>> big =
+          std::array<char, array_sz>{'A', 'E', 'I', 'O', 'U'};
       auto sz = get_needed_size(big);
       CHECK(sz == 255);
       auto buffer = serialize(big);
@@ -1644,13 +1653,19 @@ TEST_CASE("test compatible") {
       memcpy(&r_sz, &buffer[5], 2);
       CHECK(r_sz == sz);
       auto big2 =
-          deserialize<std::tuple<compatible<std::array<char, 247>>>>(buffer);
+          deserialize<std::tuple<compatible<std::array<char, array_sz>>>>(
+              buffer);
       CHECK(big2);
       CHECK(std::get<0>(big2.value()).value() == std::get<0>(big).value());
     }
     {
-      std::tuple<compatible<std::array<char, 248>>> big =
-          std::array<char, 248>{'A', 'E', 'I', 'O', 'U'};
+#ifdef NDEBUG
+      constexpr size_t array_sz = 248;
+#else
+      constexpr size_t array_sz = 245;
+#endif
+      std::tuple<compatible<std::array<char, array_sz>>> big =
+          std::array<char, array_sz>{'A', 'E', 'I', 'O', 'U'};
       auto sz = get_needed_size(big);
       CHECK(sz == 256);
       auto buffer = serialize(big);
@@ -1661,13 +1676,19 @@ TEST_CASE("test compatible") {
       memcpy(&r_sz, &buffer[5], 2);
       CHECK(r_sz == sz);
       auto big2 =
-          deserialize<std::tuple<compatible<std::array<char, 248>>>>(buffer);
+          deserialize<std::tuple<compatible<std::array<char, array_sz>>>>(
+              buffer);
       CHECK(big2);
       CHECK(std::get<0>(big2.value()).value() == std::get<0>(big).value());
     }
     {
+#ifdef NDEBUG
+      constexpr size_t array_sz = 65523;
+#else
+      constexpr size_t array_sz = 65520;
+#endif
       std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
-      std::get<0>(big).value().resize(65523);
+      std::get<0>(big).value().resize(array_sz);
       auto sz = get_needed_size(big);
       CHECK(sz == 65535);
       auto buffer = serialize(big);
@@ -1682,8 +1703,13 @@ TEST_CASE("test compatible") {
       CHECK(std::get<0>(big2.value()).value() == std::get<0>(big).value());
     }
     {
+#ifdef NDEBUG
+      constexpr size_t array_sz = 65524;
+#else
+      constexpr size_t array_sz = 65521;
+#endif
       std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
-      std::get<0>(big).value().resize(65524);
+      std::get<0>(big).value().resize(array_sz);
       auto sz = get_needed_size(big);
       CHECK(sz == 65538);
       auto buffer = serialize(big);
@@ -1700,14 +1726,17 @@ TEST_CASE("test compatible") {
     // TODO: test 8byte-len compatible object
   }
 }
-// c++98
-template <typename T>
-void f1(T &&t);
-
-// c++20
-void f1(auto t);
-
-void f2(auto &&t);
+#ifndef NDEBUG
+TEST_CASE("test hash confliet detected") {
+  int32_t value = 42;
+  auto ret = serialize(value);
+  auto fake_hash = struct_pack::get_type_code<float>() | 0b1;
+  memcpy(ret.data(), &fake_hash, sizeof(fake_hash));
+  auto res = deserialize<float>(ret);
+  CHECK(!res);
+  CHECK(res.error() == struct_pack::errc::invalid_argument);
+}
+#endif
 
 TEST_CASE("test serialize offset") {
   uint32_t offset = 4;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Now struct_pack can detected hash conflict in deserialization. 

## What is changing

Add full type info when the NDEBUG marco was not defined. Then we will check it in deserialization. 