### PR TITLE
update the doc: client connect port is std::string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ int main() {
 
 Lazy<void> test_client() {
   coro_rpc_client client;
-  co_await client.connect("localhost", /*port =*/9000);
+  co_await client.connect("localhost", /*port =*/"9000");
 
   auto r = co_await client.call<echo>("hello coro_rpc"); //传参数调用rpc函数
   std::cout << r.result.value() << "\n"; //will print "hello coro_rpc"

--- a/src/coro_rpc/doc/coro_rpc_introduction_cn.md
+++ b/src/coro_rpc/doc/coro_rpc_introduction_cn.md
@@ -65,7 +65,7 @@ rpc_client端
 
 Lazy<void> test_client() {
   coro_rpc_client client;
-  co_await client.connect("localhost", /*port =*/9000);
+  co_await client.connect("localhost", /*port =*/"9000");
 
   auto r = co_await client.call<echo>("hello coro_rpc"); //传参数调用rpc函数
   std::cout << r.result.value() << "\n"; //will print "hello coro_rpc"
@@ -138,7 +138,7 @@ client端
 
 Lazy<void> test_client() {
   coro_rpc_client client;
-  co_await client.connect("localhost", /*port =*/9000);
+  co_await client.connect("localhost", /*port =*/"9000");
 
   //RPC调用
   co_await client.call<hello>();
@@ -281,7 +281,7 @@ coro_rpc协程
 
 Lazy<void> say_hello(){
   coro_rpc_client client;
-    co_await client.connect("localhost", /*port =*/9000);
+    co_await client.connect("localhost", /*port =*/"9000");
   while (true){
     auto r = co_await client.call<echo>("hello coro_rpc");
     assert(r.result.value() == "hello coro_rpc");

--- a/src/coro_rpc/doc/coro_rpc_introduction_en.md
+++ b/src/coro_rpc/doc/coro_rpc_introduction_en.md
@@ -58,7 +58,7 @@ An RPC client has to connect to the server and then call the remote method.
 
 Lazy<void> test_client() {
   coro_rpc_client client;
-  co_await client.connect("localhost", /*port =*/9000);
+  co_await client.connect("localhost", /*port =*/"9000");
 
   auto r = co_await client.call<echo>("hello coro_rpc"); // call the method with parameters
   std::cout << r.result.value() << "\n"; //will print "hello coro_rpc"
@@ -130,7 +130,7 @@ In client, we have the following:
 
 Lazy<void> test_client() {
   coro_rpc_client client;
-  co_await client.connect("localhost", /*port =*/9000);
+  co_await client.connect("localhost", /*port =*/"9000");
 
   //RPC invokes
   co_await client.call<hello>();
@@ -272,7 +272,7 @@ example::EchoService_Stub stub(&channel);
 
 Lazy<void> say_hello(){
   coro_rpc_client client;
-    co_await client.connect("localhost", /*port =*/9000);
+    co_await client.connect("localhost", /*port =*/"9000");
   while (true){
     auto r = co_await client.call<echo>("hello coro_rpc");
     assert(r.result.value() == "hello coro_rpc");


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
The document is outdated. 

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->
`client.connect("localhost", 9000)` howerver the 2nd parameter should be "9000"

## What is changing
doc

## Example
NA