### PR TITLE
add struct_pack error code

### DIFF
--- a/include/coro_rpc/coro_rpc/async_connection.hpp
+++ b/include/coro_rpc/coro_rpc/async_connection.hpp
@@ -147,7 +147,7 @@ class async_connection : public std::enable_shared_from_this<async_connection> {
         assert(length == RPC_HEAD_LEN);
         rpc_header header{};
         auto errc = struct_pack::deserialize_to(header, head_, RPC_HEAD_LEN);
-        if (errc != err_ok) [[unlikely]] {
+        if (errc != struct_pack::errc::ok) [[unlikely]] {
           easylog::info("bad head:{}", struct_pack::error_message(errc));
           close();
           return;

--- a/include/coro_rpc/coro_rpc/coro_connection.hpp
+++ b/include/coro_rpc/coro_rpc/coro_connection.hpp
@@ -121,7 +121,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
       }
       assert(ret.second == RPC_HEAD_LEN);
       auto errc = struct_pack::deserialize_to(header, head_, RPC_HEAD_LEN);
-      if (errc != err_ok) [[unlikely]] {
+      if (errc != struct_pack::errc::ok) [[unlikely]] {
         easylog::info("bad head:{}", struct_pack::error_message(errc));
         co_await close();
         co_return;

--- a/include/coro_rpc/coro_rpc/coro_rpc_client.hpp
+++ b/include/coro_rpc/coro_rpc/coro_rpc_client.hpp
@@ -505,7 +505,7 @@ class coro_rpc_client {
                                        std::size_t len) {
     rpc_return_type_t<T> ret;
     auto ec = struct_pack::deserialize_to(ret, buffer, len);
-    if (ec == err_ok) {
+    if (ec == struct_pack::errc::ok) {
       if constexpr (std::is_same_v<T, void>) {
         return {};
       }
@@ -516,10 +516,10 @@ class coro_rpc_client {
     else {
       rpc_error err;
       auto ec = struct_pack::deserialize_to(err, buffer, len);
-      if (ec != err_ok) {
+      if (ec != struct_pack::errc::ok) {
         // if deserialize failed again,
         // we can do nothing but give an error code.
-        err.code = ec;
+        err.code = std::errc::invalid_argument;
       }
       return rpc_result<T>{unexpect_t{}, std::move(err)};
     }

--- a/include/coro_rpc/coro_rpc/router_impl.hpp
+++ b/include/coro_rpc/coro_rpc/router_impl.hpp
@@ -181,7 +181,7 @@ inline auto execute(std::string_view data, rpc_conn &conn,
         std::is_same_v<connection<conn_return_type, coro_connection>, First>;
     auto args = get_args < has_async_conn_v || has_coro_conn_v, param_type > ();
 
-    std::errc err{};
+    struct_pack::errc err{};
     constexpr size_t size = std::tuple_size_v<decltype(args)>;
     if constexpr (size > 0) {
       data = data.substr(FUNCTION_ID_LEN);
@@ -194,7 +194,7 @@ inline auto execute(std::string_view data, rpc_conn &conn,
       }
     }
 
-    if (err != err_ok) [[unlikely]] {
+    if (err != struct_pack::errc::ok) [[unlikely]] {
       return pack_result(std::errc::invalid_argument, "invalid arguments");
     }
 
@@ -309,7 +309,7 @@ execute_coro(std::string_view data, rpc_conn &conn, Self *self = nullptr) {
         std::is_same_v<connection<conn_return_type, coro_connection>, First>;
     auto args = get_args < has_async_conn_v || has_coro_conn_v, param_type > ();
 
-    std::errc err{};
+    struct_pack::errc err{};
     constexpr size_t size = std::tuple_size_v<decltype(args)>;
     if constexpr (size > 0) {
       data = data.substr(FUNCTION_ID_LEN);
@@ -322,7 +322,7 @@ execute_coro(std::string_view data, rpc_conn &conn, Self *self = nullptr) {
       }
     }
 
-    if (err != err_ok) [[unlikely]] {
+    if (err != struct_pack::errc::ok) [[unlikely]] {
       co_return pack_result(std::errc::invalid_argument, "invalid arguments");
     }
 

--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -119,8 +119,8 @@ using unexpect_t = tl::unexpect_t;
  * @param err error code.
  * @return error message.
  */
-STRUCT_PACK_INLINE std::string error_message(std::errc err) {
-  return std::make_error_code(err).message();
+STRUCT_PACK_INLINE std::string error_message(struct_pack::errc err) {
+  return struct_pack::make_error_code(err).message();
 }
 /*!
  * \ingroup struct_pack
@@ -220,38 +220,35 @@ serialize_with_offset(std::size_t offset, const Args &...args) {
 }
 
 template <typename T, typename... Args, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t, const View &v,
-                                                          Args &...args) {
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
+    T &t, const View &v, Args &...args) {
   detail::unpacker in(v.data(), v.size());
   return in.deserialize(t, args...);
 }
 
 template <typename T, typename... Args, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t,
-                                                          const Byte *data,
-                                                          size_t size,
-                                                          Args &...args) {
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
+    T &t, const Byte *data, size_t size, Args &...args) {
   detail::unpacker in(data, size);
   return in.deserialize(t, args...);
 }
 
 template <typename T, typename... Args, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(T &t, const View &v,
-                                                          size_t &consume_len,
-                                                          Args &...args) {
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
+    T &t, const View &v, size_t &consume_len, Args &...args) {
   detail::unpacker in(v.data(), v.size());
   return in.deserialize(consume_len, t, args...);
 }
 
 template <typename T, typename... Args, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to(
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
     T &t, const Byte *data, size_t size, size_t &consume_len, Args &...args) {
   detail::unpacker in(data, size);
   return in.deserialize(consume_len, t, args...);
 }
 
 template <typename T, typename... Args, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to_with_offset(
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to_with_offset(
     T &t, const View &v, size_t &offset, Args &...args) {
   detail::unpacker in(v.data() + offset, v.size() - offset);
   size_t sz;
@@ -261,7 +258,7 @@ template <typename T, typename... Args, detail::deserialize_view View>
 }
 
 template <typename T, typename... Args, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc deserialize_to_with_offset(
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to_with_offset(
     T &t, const Byte *data, size_t size, size_t &offset, Args &...args) {
   detail::unpacker in(data + offset, size - offset);
   size_t sz;
@@ -272,9 +269,9 @@ template <typename T, typename... Args, detail::struct_pack_byte Byte>
 
 template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const View &v) {
-  expected<detail::get_args_type<T, Args...>, std::errc> ret;
-  if (auto errc = deserialize_to(ret.value(), v); errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+  expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
+  if (auto errc = deserialize_to(ret.value(), v); errc != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
@@ -282,10 +279,10 @@ template <typename T, typename... Args, detail::deserialize_view View>
 template <typename T, typename... Args, detail::struct_pack_byte Byte>
 [[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const Byte *data,
                                                   size_t size) {
-  expected<detail::get_args_type<T, Args...>, std::errc> ret;
+  expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to(ret.value(), data, size);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+      errc != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
@@ -293,10 +290,10 @@ template <typename T, typename... Args, detail::struct_pack_byte Byte>
 template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const View &v,
                                                   size_t &consume_len) {
-  expected<detail::get_args_type<T, Args...>, std::errc> ret;
+  expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to(ret.value(), v, consume_len);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+      errc != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
@@ -304,10 +301,10 @@ template <typename T, typename... Args, detail::deserialize_view View>
 template <typename T, typename... Args, detail::struct_pack_byte Byte>
 [[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const Byte *data, size_t size,
                                                   size_t &consume_len) {
-  expected<detail::get_args_type<T, Args...>, std::errc> ret;
+  expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to(ret.value(), data, size, consume_len);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+      errc != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
@@ -315,10 +312,10 @@ template <typename T, typename... Args, detail::struct_pack_byte Byte>
 template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE auto deserialize_with_offset(const View &v,
                                                               size_t &offset) {
-  expected<detail::get_args_type<T, Args...>, std::errc> ret;
+  expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to_with_offset(ret.value(), v, offset);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+      errc != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
@@ -327,17 +324,17 @@ template <typename T, typename... Args, detail::struct_pack_byte Byte>
 [[nodiscard]] STRUCT_PACK_INLINE auto deserialize_with_offset(const Byte *data,
                                                               size_t size,
                                                               size_t &offset) {
-  expected<detail::get_args_type<T, Args...>, std::errc> ret;
+  expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to_with_offset(ret.value(), data, size, offset);
-      errc != std::errc{}) {
-    ret = unexpected<std::errc>{errc};
+      errc != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
 
 template <typename T, size_t I, typename Field, detail::deserialize_view View>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc get_field_to(Field &dst,
-                                                        const View &v) {
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc get_field_to(Field &dst,
+                                                                const View &v) {
   using T_Field =
       std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
   static_assert(std::is_same_v<Field, T_Field>,
@@ -348,9 +345,8 @@ template <typename T, size_t I, typename Field, detail::deserialize_view View>
 }
 
 template <typename T, size_t I, typename Field, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE std::errc get_field_to(Field &dst,
-                                                        const Byte *data,
-                                                        size_t size) {
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc get_field_to(
+    Field &dst, const Byte *data, size_t size) {
   using T_Field =
       std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
   static_assert(std::is_same_v<Field, T_Field>,
@@ -365,10 +361,10 @@ template <typename T, size_t I, detail::deserialize_view View>
   using T_Field =
       std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
   detail::unpacker in(v.data(), v.size());
-  expected<T_Field, std::errc> ret;
+  expected<T_Field, struct_pack::errc> ret;
 
-  if (auto ec = get_field_to<T, I>(ret.value(), v); ec != std::errc{}) {
-    ret = unexpected<std::errc>{ec};
+  if (auto ec = get_field_to<T, I>(ret.value(), v); ec != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{ec};
   }
   return ret;
 }
@@ -378,11 +374,11 @@ template <typename T, size_t I, detail::struct_pack_byte Byte>
   using T_Field =
       std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
   detail::unpacker in(data, size);
-  expected<T_Field, std::errc> ret;
+  expected<T_Field, struct_pack::errc> ret;
 
   if (auto ec = get_field_to<T, I>(ret.value(), data, size);
-      ec != std::errc{}) {
-    ret = unexpected<std::errc>{ec};
+      ec != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{ec};
   }
   return ret;
 }

--- a/include/struct_pack/struct_pack/error_code.h
+++ b/include/struct_pack/struct_pack/error_code.h
@@ -7,7 +7,6 @@ enum class errc {
   ok = 0,
   no_buffer_space,
   invalid_argument,
-  address_in_use,
   hash_conflict,
 };
 
@@ -25,8 +24,6 @@ class struct_pack_category : public std::error_category {
         return "no buffer space";
       case errc::invalid_argument:
         return "invalid argument";
-      case errc::address_in_use:
-        return "address in use";
       case errc::hash_conflict:
         return "hash conflict";
 

--- a/include/struct_pack/struct_pack/error_code.h
+++ b/include/struct_pack/struct_pack/error_code.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <system_error>
+
+namespace struct_pack {
+enum class errc {
+  ok = 0,
+  no_buffer_space,
+  invalid_argument,
+  address_in_use,
+  hash_conflict,
+};
+
+class struct_pack_category : public std::error_category {
+ public:
+  virtual const char *name() const noexcept override {
+    return "struct_pack::category";
+  }
+
+  virtual std::string message(int err_val) const override {
+    switch (static_cast<errc>(err_val)) {
+      case errc::ok:
+        return "ok";
+      case errc::no_buffer_space:
+        return "no buffer space";
+      case errc::invalid_argument:
+        return "invalid argument";
+      case errc::address_in_use:
+        return "address in use";
+      case errc::hash_conflict:
+        return "hash conflict";
+
+      default:
+        return "(unrecognized error)";
+    }
+  }
+};
+
+inline const std::error_category &category() {
+  static struct_pack::struct_pack_category instance;
+  return instance;
+}
+
+inline std::error_code make_error_code(struct_pack::errc err) {
+  return std::error_code((std::underlying_type_t<errc> &)err,
+                         struct_pack::category());
+}
+}  // namespace struct_pack

--- a/src/coro_rpc/tests/test_async_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_async_rpc_server.cpp
@@ -253,7 +253,7 @@ TEST_CASE("test server write queue") {
     std::size_t sz;
     auto ret =
         struct_pack::deserialize_to(r2, buffer_read.data(), body_len, sz);
-    CHECK(ret == std::errc{});
+    CHECK(ret == struct_pack::errc::ok);
     CHECK(sz == body_len);
     CHECK(r2 == r);
   }

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -59,8 +59,8 @@ struct CoroServerTester : ServerTester {
     }
     else {
       thd = std::thread([&] {
-        auto ec=server.start();
-        REQUIRE(ec==std::errc{});
+        auto ec = server.start();
+        REQUIRE(ec == std::errc{});
       });
     }
 
@@ -148,7 +148,7 @@ struct CoroServerTester : ServerTester {
       ec = new_server.start();
     }
     REQUIRE_MESSAGE(ec == std::errc::address_in_use,
-                  make_error_code(ec).message());
+                    make_error_code(ec).message());
   }
   void test_server_send_bad_rpc_result() {
     easylog::info("run {}", __func__);
@@ -297,7 +297,7 @@ TEST_CASE("test server write queue") {
     std::size_t sz;
     auto ret =
         struct_pack::deserialize_to(r2, buffer_read.data(), body_len, sz);
-    CHECK(ret == std::errc{});
+    CHECK(ret == struct_pack::errc::ok);
     CHECK(sz == body_len);
     CHECK(r2 == r);
   }

--- a/src/coro_rpc/tests/test_remote.cpp
+++ b/src/coro_rpc/tests/test_remote.cpp
@@ -39,7 +39,7 @@ rpc_result<function_return_type_t<decltype(func)>> get_result(
   using R = function_return_type_t<decltype(func)>;
   typename RPC_trait<R>::return_type r;
   auto res = struct_pack::deserialize_to(r, data);
-  if (res == std::errc{}) {
+  if (res == struct_pack::errc{}) {
     if constexpr (std::is_same_v<R, void>) {
       return {};
     }
@@ -49,7 +49,7 @@ rpc_result<function_return_type_t<decltype(func)>> get_result(
   }
   rpc_error err;
   res = struct_pack::deserialize_to(err, data);
-  CHECK(res == std::errc{});
+  CHECK(res == struct_pack::errc{});
   return rpc_result<R>{unexpect_t{}, std::move(err)};
 }
 
@@ -60,10 +60,10 @@ void check_result(const auto &pair, size_t offset = 0) {
   std::string_view data(buffer.data() + offset, buffer.size() - offset);
   typename RPC_trait<R>::return_type r;
   auto res = struct_pack::deserialize_to(r, data);
-  if (res != std::errc{}) {
+  if (res != struct_pack::errc{}) {
     rpc_error r;
     auto res = struct_pack::deserialize_to(r, data);
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
   }
 }
 
@@ -295,7 +295,7 @@ TEST_CASE("testing object arguments") {
   auto buf = struct_pack::serialize(p);
   person p1;
   auto ec = struct_pack::deserialize_to(p1, buf);
-  REQUIRE(ec == std::errc{});
+  REQUIRE(ec == struct_pack::errc{});
   test_route_and_check<get_person>(async_conn, p);
 
   register_handler<get_person1>();

--- a/src/struct_pack/examples/serialize/serialize.cpp
+++ b/src/struct_pack/examples/serialize/serialize.cpp
@@ -81,7 +81,7 @@ void basic_usage() {
   {
     person p2;
     [[maybe_unused]] auto ec = struct_pack::deserialize_to(p2, buffer);
-    assert(ec == std::errc{});
+    assert(ec == struct_pack::errc{});
     assert(p == p2);
   }
   // api 3. partial deserialize
@@ -104,7 +104,7 @@ void basic_usage() {
     person p3;
     auto buffer = struct_pack::serialize(p.age, p2.name);
     auto result = struct_pack::deserialize_to(p3.age, buffer, p3.name);
-    assert(result == std::errc{});
+    assert(result == struct_pack::errc{});
     assert(p3.age == p.age);
     assert(p3.name == p2.name);
   }

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -126,14 +126,14 @@ TEST_CASE("testing deserialize_view") {
   {
     person p2;
     auto res = deserialize_to(p2, ret);
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(p2 == p);
   }
   {
     size_t len = 114514;
     person p2;
     auto res = deserialize_to(p2, ret, len);
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(p2 == p);
     CHECK(len == ret.size());
   }
@@ -141,7 +141,7 @@ TEST_CASE("testing deserialize_view") {
     size_t offset = 0;
     person p2;
     auto res = deserialize_to(p2, ret, offset);
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(p2 == p);
     CHECK(offset == ret.size());
   }
@@ -179,10 +179,10 @@ TEST_CASE("testing api") {
     CHECK(ret2 == need_size);
     person p1, p2;
     auto ec1 = deserialize_to(p1, my_buffer.data(), my_buffer.size());
-    CHECK(ec1 == std::errc{});
+    CHECK(ec1 == struct_pack::errc{});
     auto ec2 = deserialize_to(p2, my_buffer2.data() + offset,
                               my_buffer2.size() - offset);
-    CHECK(ec2 == std::errc{});
+    CHECK(ec2 == struct_pack::errc{});
     CHECK(p == p1);
     CHECK(p == p2);
   }
@@ -214,17 +214,18 @@ TEST_CASE("testing pack object") {
 
   person p1{};
   auto ec = deserialize_to(p1, ret.data(), ret.size());
-  CHECK(ec == std::errc{});
+  CHECK(ec == struct_pack::errc{});
   CHECK(p == p1);
 
-  CHECK(deserialize_to(p1, ret.data(), 4) == std::errc::no_buffer_space);
+  CHECK(deserialize_to(p1, ret.data(), 4) ==
+        struct_pack::errc::no_buffer_space);
 
   SUBCASE("test empty string") {
     p.name = "";
     ret = serialize(p);
     person p2{};
     ec = deserialize_to(p2, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(p == p2);
   }
 }
@@ -253,14 +254,14 @@ void test_container(auto &v) {
   using T = std::remove_cvref_t<decltype(v)>;
   T v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == std::errc{});
+  CHECK(ec == struct_pack::errc{});
   CHECK(v == v1);
 
   v.clear();
   v1.clear();
   ret = serialize(v);
   ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == std::errc{});
+  CHECK(ec == struct_pack::errc{});
   CHECK(v1.empty());
   CHECK(v == v1);
 }
@@ -429,7 +430,7 @@ void test_tuple_like(auto &v) {
   using T = std::remove_cvref_t<decltype(v)>;
   T v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == std::errc{});
+  CHECK(ec == struct_pack::errc{});
   CHECK(v == v1);
 }
 
@@ -492,11 +493,11 @@ TEST_CASE("test_trivial_copy_tuple") {
 
   std::tuple<int, int> v{};
   auto ec = deserialize_to(v, buf);
-  CHECK(ec != std::errc{});
+  CHECK(ec != struct_pack::errc{});
 
   decltype(tp) tp1;
   auto ec2 = deserialize_to(tp1, buf);
-  CHECK(ec2 == std::errc{});
+  CHECK(ec2 == struct_pack::errc{});
   CHECK(tp == tp1);
 }
 
@@ -513,7 +514,7 @@ TEST_CASE("test_trivial_copy_tuple in an object") {
 
   test_obj obj1;
   auto ec = deserialize_to(obj1, buf);
-  CHECK(ec == std::errc{});
+  CHECK(ec == struct_pack::errc{});
   CHECK(obj.tp == obj1.tp);
 }
 
@@ -523,7 +524,7 @@ void test_c_array(auto &v) {
   using T = std::remove_cvref_t<decltype(v)>;
   T v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  REQUIRE(ec == std::errc{});
+  REQUIRE(ec == struct_pack::errc{});
 
   auto size = std::extent_v<T>;
   for (int i = 0; i < size; ++i) {
@@ -553,7 +554,7 @@ TEST_CASE("testing enum") {
     auto ret = serialize(e);
     std::size_t sz;
     auto ec = deserialize_to(e2, ret.data(), ret.size(), sz);
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(sz == ret.size());
     CHECK(e == e2);
   }
@@ -563,7 +564,7 @@ TEST_CASE("testing enum") {
     auto ec = deserialize<enum_i32>(ret.data(), ret.size());
     CHECK(!ec);
     if (!ec) {
-      CHECK(ec.error() == std::errc::invalid_argument);
+      CHECK(ec.error() == struct_pack::errc::invalid_argument);
     }
   }
   {
@@ -612,14 +613,14 @@ TEST_CASE("test variant") {
     std::variant<int, double> var = 1.4, var2;
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(var2 == var);
   }
   {
     std::variant<int, std::monostate> var = std::monostate{}, var2;
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(var2 == var);
   }
   {
@@ -628,7 +629,7 @@ TEST_CASE("test variant") {
         var2;
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(var2 == var);
     CHECK(var2.index() == 1);
   }
@@ -636,7 +637,7 @@ TEST_CASE("test variant") {
     std::variant<std::monostate, std::string> var{"hello"}, var2;
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(var2 == var);
   }
   {
@@ -663,7 +664,7 @@ TEST_CASE("test variant") {
         big_variant2;
     auto ret = struct_pack::serialize(big_variant);
     auto ec = struct_pack::deserialize_to(big_variant2, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(big_variant2 == big_variant);
   }
 }
@@ -674,35 +675,36 @@ TEST_CASE("test monostate") {
     static_assert(struct_pack::get_needed_size(std::monostate{}) == 4);
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(var2 == var);
   }
 }
 
 TEST_CASE("test expected") {
   {
-    tl::expected<int, std::errc> exp{42}, exp2;
+    tl::expected<int, struct_pack::errc> exp{42}, exp2;
     auto ret = serialize(exp);
     auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(exp2 == exp);
   }
   {
-    tl::expected<std::vector<int>, std::errc> exp{std::vector{41, 42, 43}},
+    tl::expected<std::vector<int>, struct_pack::errc> exp{
+        std::vector{41, 42, 43}},
         exp2;
     auto ret = serialize(exp);
     auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(exp2 == exp);
   }
   {
-    tl::expected<std::vector<int>, std::errc> exp{
-        tl::unexpected{std::errc::address_in_use}},
+    tl::expected<std::vector<int>, struct_pack::errc> exp{
+        tl::unexpected{struct_pack::errc::address_in_use}},
         exp2;
 
     auto ret = serialize(exp);
     auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(exp2 == exp);
   }
 }
@@ -729,7 +731,7 @@ TEST_CASE("testing object with containers, enum, tuple array, and pair") {
 
   complicated_object v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == std::errc{});
+  CHECK(ec == struct_pack::errc{});
   CHECK(v.g == v1.g);
   CHECK(v.h == v1.h);
   CHECK(v.i == v1.i);
@@ -744,7 +746,7 @@ TEST_CASE("testing object with containers, enum, tuple array, and pair") {
 
     nested_object nested1{};
     auto ec = deserialize_to(nested1, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(nested.p == nested1.p);
     CHECK(nested.name == nested1.name);
     CHECK(nested.o.m == nested1.o.m);
@@ -768,29 +770,29 @@ TEST_CASE("testing object with containers, enum, tuple array, and pair") {
     auto res = get_field<complicated_object, 14>(ret.data(), 24);
     CHECK(!res);
     if (!res) {
-      CHECK(res.error() == std::errc::no_buffer_space);
+      CHECK(res.error() == struct_pack::errc::no_buffer_space);
     }
   }
   SUBCASE("test get_field_to") {
     std::string res1;
     auto ec = get_field_to<complicated_object, 2>(res1, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(res1 == "hello");
     ec = get_field_to<complicated_object, 2>(res1, ret);
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(res1 == "hello");
     std::pair<std::string, person> res2;
     ec = get_field_to<complicated_object, 14>(res2, ret.data(), ret.size());
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(res2 == v.o);
     ec = get_field_to<complicated_object, 14>(res2, ret);
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(res2 == v.o);
 
     auto res = get_field_to<complicated_object, 14>(res2, ret.data(), 24);
-    CHECK(ec == std::errc{});
-    if (ec != std::errc{}) {
-      CHECK(ec == std::errc::no_buffer_space);
+    CHECK(ec == struct_pack::errc{});
+    if (ec != struct_pack::errc{}) {
+      CHECK(ec == struct_pack::errc::no_buffer_space);
     }
   }
 }
@@ -828,10 +830,10 @@ TEST_CASE("testing exceptions") {
   serialize_to(my_byte_buffer, data_list);
   std::vector<int> data_list2;
   auto ec = deserialize_to(data_list2, my_byte_buffer.data(), 0);
-  CHECK(ec == std::errc::no_buffer_space);
+  CHECK(ec == struct_pack::errc::no_buffer_space);
   ec = deserialize_to(data_list2, my_byte_buffer.data(),
                       my_byte_buffer.size() - 1);
-  CHECK(ec == std::errc::no_buffer_space);
+  CHECK(ec == struct_pack::errc::no_buffer_space);
 
   std::vector<std::byte> my_byte_buffer2;
   std::optional<bool> bool_opt;
@@ -840,7 +842,7 @@ TEST_CASE("testing exceptions") {
                                                my_byte_buffer2.size() - 1);
   CHECK(!ret3);
   if (!ret3) {
-    CHECK(ret3.error() == std::errc::no_buffer_space);
+    CHECK(ret3.error() == struct_pack::errc::no_buffer_space);
   }
 }
 
@@ -918,7 +920,7 @@ TEST_CASE("testing serialize/deserialize varadic params") {
     int a[5];
     auto res = struct_pack::deserialize_to(a[0], ret.data(), ret.size(), a[1],
                                            a[2], a[3], a[4]);
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(a[0] == 1);
     CHECK(a[1] == 2);
     CHECK(a[2] == 3);
@@ -929,7 +931,7 @@ TEST_CASE("testing serialize/deserialize varadic params") {
     auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
     int a[5];
     auto res = struct_pack::deserialize_to(a[0], ret, a[1], a[2], a[3], a[4]);
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(a[0] == 1);
     CHECK(a[1] == 2);
     CHECK(a[2] == 3);
@@ -1100,7 +1102,7 @@ TEST_CASE("testing serialize/deserialize varadic params") {
         std::get<0>(t), ret.data(), ret.size(), std::get<1>(t), std::get<2>(t),
         std::get<3>(t), std::get<4>(t), std::get<5>(t), std::get<6>(t),
         std::get<7>(t));
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(std::get<0>(t) == 42);
     CHECK(std::get<1>(t) == 2.71828f);
     CHECK(std::get<2>(t) == 3.1415926);
@@ -1127,7 +1129,7 @@ TEST_CASE("testing serialize/deserialize varadic params") {
     auto res = struct_pack::deserialize_to(
         std::get<0>(t), ret, std::get<1>(t), std::get<2>(t), std::get<3>(t),
         std::get<4>(t), std::get<5>(t), std::get<6>(t), std::get<7>(t));
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(std::get<0>(t) == 42);
     CHECK(std::get<1>(t) == 2.71828f);
     CHECK(std::get<2>(t) == 3.1415926);
@@ -1204,7 +1206,7 @@ TEST_CASE("testing deserialization") {
   auto ret = serialize(p);
 
   person p1{};
-  CHECK(deserialize_to(p1, ret.data(), ret.size()) == std::errc{});
+  CHECK(deserialize_to(p1, ret.data(), ret.size()) == struct_pack::errc{});
 }
 
 TEST_CASE("testing deserialization with invalid data") {
@@ -1212,17 +1214,17 @@ TEST_CASE("testing deserialization with invalid data") {
 
   std::string str{};
   auto ret2 = deserialize_to(str, ret.data(), ret.size());
-  CHECK(ret2 == std::errc::invalid_argument);
+  CHECK(ret2 == struct_pack::errc::invalid_argument);
 
   ret2 = deserialize_to(str, ret.data(), INT32_MAX);
-  CHECK(ret2 == std::errc::invalid_argument);
+  CHECK(ret2 == struct_pack::errc::invalid_argument);
 
   SUBCASE("test invalid int") {
     ret = serialize(std::string("hello"));
 
     std::tuple<int, int> tp{};
     auto ret3 = deserialize_to(tp, ret.data(), ret.size());
-    CHECK(ret3 == std::errc::invalid_argument);
+    CHECK(ret3 == struct_pack::errc::invalid_argument);
   }
 }
 
@@ -1312,7 +1314,7 @@ TEST_CASE("test use wide string") {
     auto ret = serialize(sv);
     std::wstring str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == sv);
   }
   {
@@ -1320,7 +1322,7 @@ TEST_CASE("test use wide string") {
     auto ret = serialize(sv);
     std::u8string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == sv);
   }
   {
@@ -1328,7 +1330,7 @@ TEST_CASE("test use wide string") {
     auto ret = serialize(sv);
     std::u16string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == sv);
   }
   {
@@ -1336,7 +1338,7 @@ TEST_CASE("test use wide string") {
     auto ret = serialize(sv);
     std::u32string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == sv);
   }
 }
@@ -1347,7 +1349,7 @@ TEST_CASE("test use string_view") {
     auto ret = serialize("hello struct pack"sv);
     std::string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == "hello struct pack"sv);
   }
   {
@@ -1355,7 +1357,7 @@ TEST_CASE("test use string_view") {
     auto ret = serialize(sv);
     std::wstring str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == sv);
   }
   {
@@ -1363,7 +1365,7 @@ TEST_CASE("test use string_view") {
     auto ret = serialize(sv);
     std::u8string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == sv);
   }
   {
@@ -1371,7 +1373,7 @@ TEST_CASE("test use string_view") {
     auto ret = serialize(sv);
     std::u16string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == sv);
   }
   {
@@ -1379,7 +1381,7 @@ TEST_CASE("test use string_view") {
     auto ret = serialize(sv);
     std::u32string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(str == sv);
   }
 }
@@ -1389,49 +1391,49 @@ TEST_CASE("char test") {
     char ch = '1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(ch == ch2);
   }
   {
     signed char ch = '1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(ch == ch2);
   }
   {
     unsigned char ch = '1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(ch == ch2);
   }
   {
     wchar_t ch = L'1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(ch == ch2);
   }
   {
     char8_t ch = u8'1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(ch == ch2);
   }
   {
     char16_t ch = u'1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(ch == ch2);
   }
   {
     char32_t ch = U'1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == std::errc{});
+    REQUIRE(ec == struct_pack::errc{});
     CHECK(ch == ch2);
   }
 }
@@ -1470,13 +1472,13 @@ TEST_CASE("array test") {
   {
     ar3[117] = test_str;
     auto ret = deserialize_to(ar3_1, serialize(ar3));
-    assert(ret == std::errc{});
+    assert(ret == struct_pack::errc{});
     assert(ar3_1[117] == test_str);
   }
   {
     ar4[15472] = test_str;
     auto ret = deserialize_to(ar4_1, serialize(ar4));
-    assert(ret == std::errc{});
+    assert(ret == struct_pack::errc{});
     assert(ar4_1[15472] == test_str);
   }
 }
@@ -1486,7 +1488,8 @@ void test_no_buffer_space(T &t, std::vector<int> size_list) {
   auto ret = serialize(t);
   T t1{};
   for (auto size : size_list) {
-    CHECK(deserialize_to(t1, ret.data(), size) == std::errc::no_buffer_space);
+    CHECK(deserialize_to(t1, ret.data(), size) ==
+          struct_pack::errc::no_buffer_space);
   }
 }
 
@@ -1510,13 +1513,13 @@ TEST_CASE("test get field exceptions") {
   auto pair = get_field<int, 0>(ret.data(), ret.size());
   CHECK(!pair);
   if (!pair) {
-    CHECK(pair.error() == std::errc::invalid_argument);
+    CHECK(pair.error() == struct_pack::errc::invalid_argument);
   }
 
   auto pair1 = get_field<person, 0>(ret.data(), 3);
   CHECK(!pair1);
   if (!pair1) {
-    CHECK(pair1.error() == std::errc::no_buffer_space);
+    CHECK(pair1.error() == struct_pack::errc::no_buffer_space);
   }
 }
 
@@ -1525,7 +1528,7 @@ TEST_CASE("test set_value") {
   auto ret = serialize(p);
   detail::unpacker in(ret.data(), ret.size());
   person p2;
-  std::errc ec;
+  struct_pack::errc ec;
   std::string s;
   int v;
   int v2 = -1;
@@ -1542,21 +1545,23 @@ TEST_CASE("test free functions") {
   CHECK(!buffer.empty());
 
   person p1{};
-  CHECK(deserialize_to(p1, buffer.data(), buffer.size()) == std::errc{});
+  CHECK(deserialize_to(p1, buffer.data(), buffer.size()) ==
+        struct_pack::errc{});
 
   std::optional<int> op1{};
   auto buf1 = serialize(op1);
   std::optional<int> op2{};
-  CHECK(deserialize_to(op2, buf1.data(), buf1.size()) == std::errc{});
+  CHECK(deserialize_to(op2, buf1.data(), buf1.size()) == struct_pack::errc{});
   CHECK(!op2.has_value());
 
   op1 = 42;
   auto buf2 = serialize(op1);
-  CHECK(deserialize_to(op2, buf2.data(), buf2.size()) == std::errc{});
+  CHECK(deserialize_to(op2, buf2.data(), buf2.size()) == struct_pack::errc{});
   CHECK(op2.has_value());
   CHECK(op2.value() == 42);
 
-  CHECK(deserialize_to(op2, buf2.data(), 1) == std::errc::no_buffer_space);
+  CHECK(deserialize_to(op2, buf2.data(), 1) ==
+        struct_pack::errc::no_buffer_space);
 
   auto pair = get_field<person, 0>(buffer.data(), buffer.size());
   CHECK(pair);
@@ -1608,19 +1613,21 @@ TEST_CASE("test compatible") {
 
     person p;
     auto res = deserialize_to(p, buffer.data(), buffer.size());
-    CHECK(res == std::errc{});
+    CHECK(res == struct_pack::errc{});
     CHECK(p.name == p1.name);
     CHECK(p.age == p1.age);
 
     // short data
     for (int i = 0, lim = get_needed_size(p); i < lim; ++i)
-      CHECK(deserialize_to(p, buffer.data(), i) == std::errc::no_buffer_space);
+      CHECK(deserialize_to(p, buffer.data(), i) ==
+            struct_pack::errc::no_buffer_space);
 
     ret = serialize_to(buffer.data(), buffer.size(), p);
     CHECK(ret != 0);
 
     person1 p2;
-    CHECK(deserialize_to(p2, buffer.data(), buffer.size()) == std::errc{});
+    CHECK(deserialize_to(p2, buffer.data(), buffer.size()) ==
+          struct_pack::errc{});
     CHECK((p2.age == p.age && p2.name == p.name));
   }
   SUBCASE("big compatible metainfo") {
@@ -1712,7 +1719,7 @@ TEST_CASE("test serialize offset") {
   auto ret = serialize_to(buffer.data() + offset, buffer.size(), p);
   CHECK(ret != 0);
   person p2;
-  CHECK(deserialize_to(p2, buffer.data() + offset, ret) == std::errc{});
+  CHECK(deserialize_to(p2, buffer.data() + offset, ret) == struct_pack::errc{});
   CHECK(p2 == p);
 
   std::vector<char> buffer2;
@@ -1723,7 +1730,7 @@ TEST_CASE("test serialize offset") {
   CHECK(data_offset + need_size == buffer2.size());
   person p3;
   CHECK(deserialize_to(p3, buffer2.data() + data_offset, need_size) ==
-        std::errc{});
+        struct_pack::errc{});
   CHECK(p3 == p);
 }
 
@@ -1752,14 +1759,14 @@ TEST_CASE("test de_serialize offset") {
     std::string res;
     auto ec = struct_pack::deserialize_to_with_offset(res, ho.data(), ho.size(),
                                                       offset);
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(res == hi + std::to_string(i));
     CHECK(offset == sizes[i]);
   }
   for (size_t i = 0, offset = 0; i < 100; ++i) {
     std::string res;
     auto ec = struct_pack::deserialize_to_with_offset(res, ho, offset);
-    CHECK(ec == std::errc{});
+    CHECK(ec == struct_pack::errc{});
     CHECK(res == hi + std::to_string(i));
     CHECK(offset == sizes[i]);
   }
@@ -1770,7 +1777,7 @@ TEST_CASE("deque") {
   auto ret = struct_pack::serialize(raw);
   std::deque<int> res;
   auto ec = struct_pack::deserialize_to(res, ret.data(), ret.size());
-  CHECK(ec == std::errc{});
+  CHECK(ec == struct_pack::errc{});
   CHECK(raw == res);
 }
 TEST_CASE("compatible convert to optional") {
@@ -1914,14 +1921,14 @@ TEST_CASE("type calculate") {
                   "T[sz] with different T should get different MD5");
     int ar[5] = {};
     float ar2[5] = {};
-    CHECK(deserialize_to(ar2, serialize(ar)) != std::errc{});
+    CHECK(deserialize_to(ar2, serialize(ar)) != struct_pack::errc{});
   }
   {
     static_assert(get_type_code<int[5]>() != get_type_code<int[6]>(),
                   "T[sz] with different sz should get different MD5");
     int ar[5] = {};
     int ar2[6] = {};
-    CHECK(deserialize_to(ar2, serialize(ar)) != std::errc{});
+    CHECK(deserialize_to(ar2, serialize(ar)) != struct_pack::errc{});
   }
   {
     static_assert(get_type_code<std::optional<int>>() !=

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -698,8 +698,8 @@ TEST_CASE("test expected") {
     CHECK(exp2 == exp);
   }
   {
-    tl::expected<std::vector<int>, struct_pack::errc> exp{
-        tl::unexpected{struct_pack::errc::address_in_use}},
+    tl::expected<std::vector<int>, std::errc> exp{
+        tl::unexpected{std::errc::address_in_use}},
         exp2;
 
     auto ret = serialize(exp);


### PR DESCRIPTION
## Why

std::errc is not enough for struct_pack, so add struct_pack error code. 

## What is changing

std::errc to struct_pack::errc
