### PR TITLE
Support variant container size

### DIFF
--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -15,8 +15,6 @@
  */
 #pragma once
 
-#define STRUCT_PACK_OPTIMIZE 1
-
 #include <cstdint>
 #include <type_traits>
 #include <utility>

--- a/include/struct_pack/struct_pack/md5_constexpr.hpp
+++ b/include/struct_pack/struct_pack/md5_constexpr.hpp
@@ -68,6 +68,15 @@ struct string_literal : public std::array<CharType, Size + 1> {
   using base::rend;
 };
 
+template <typename Char, std::size_t Size1, std::size_t Size2>
+constexpr bool operator!=(const string_literal<Char, Size1> &s1,
+                          const string_literal<Char, Size2> &s2) {
+  if constexpr (Size1 == Size2) {
+    return s1 != s2;
+  }
+  return true;
+}
+
 template <typename CharType, std::size_t Size>
 string_literal(const CharType (&value)[Size])
     -> string_literal<CharType, Size - 1>;

--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -794,10 +794,9 @@ constexpr decltype(auto) STRUCT_PACK_INLINE visit_members(auto &&object,
   }
 }
 
-template <template <size_t index, typename... Args> typename Func,
-          typename... Args>
+template <template <size_t index, typename...> typename Func, typename... Args>
 constexpr decltype(auto) STRUCT_PACK_INLINE template_switch(std::size_t index,
-                                                            Args &...args) {
+                                                            auto &...args) {
   switch (index) {
     case 0:
       return Func<0, Args...>::run(args...);

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -172,8 +172,8 @@ constexpr auto get_types(U &&t) {
   }
   else if constexpr (std::is_aggregate_v<T>) {
     return visit_members(
-        std::forward<U>(t), [&]<typename... Args>(Args &&
-                                                  ...) CONSTEXPR_INLINE_LAMBDA {
+        std::forward<U>(t),
+        [&]<typename... Args>(Args &&...) CONSTEXPR_INLINE_LAMBDA {
           return std::tuple<std::remove_cvref_t<Args>...>{};
         });
   }

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -25,6 +25,7 @@
 #include <limits>
 #include <map>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <system_error>
 #include <tuple>
@@ -43,17 +44,6 @@ static_assert(std::endian::native == std::endian::little,
 #include "reflection.h"
 
 namespace struct_pack {
-
-#ifdef STRUCT_PACK_USE_INT8_SIZE
-using size_type = uint8_t;
-constexpr uint8_t MAX_SIZE = UINT8_MAX;
-#elif STRUCT_PACK_USE_INT16_SIZE
-using size_type = uint16_t;
-constexpr uint16_t MAX_SIZE = UINT16_MAX;
-#else
-using size_type = uint32_t;
-constexpr uint32_t MAX_SIZE = UINT32_MAX;
-#endif
 
 /*!
  * \ingroup struct_pack
@@ -133,6 +123,18 @@ template <typename... Args>
 STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal();
 
 namespace detail {
+
+[[noreturn]] inline void unreachable() {
+  // Uses compiler specific extensions if possible.
+  // Even if no extension is used, undefined behavior is still raised by
+  // an empty function body and the noreturn attribute.
+#ifdef __GNUC__  // GCC, Clang, ICC
+  __builtin_unreachable();
+#elif defined(_MSC_VER)  // msvc
+  __assume(false);
+#endif
+}
+
 // clang-format off
 template <typename T>
 concept struct_pack_byte = std::is_same_v<char, T>
@@ -742,56 +744,63 @@ consteval uint32_t get_types_code(std::index_sequence<I...>) {
   return get_types_code_impl<T, std::tuple_element_t<I, Tuple>...>();
 }
 
-[[noreturn]] STRUCT_PACK_INLINE void exit_container_size() {
-  std::cerr << "Serialize Error! The container's size is greater than "
-            << MAX_SIZE << std::endl;
-  std::exit(EXIT_FAILURE);
-}
 [[noreturn]] STRUCT_PACK_INLINE void exit_valueless_variant() {
   std::cerr << "Serialize Error! The variant is valueless!" << std::endl;
   std::exit(EXIT_FAILURE);
 }
 
+struct size_info {
+  std::size_t total;
+  std::size_t size_cnt;
+  std::size_t max_size;
+  constexpr size_info &operator+=(const size_info &other) {
+    this->total += other.total;
+    this->size_cnt += other.size_cnt;
+    this->max_size = std::max(this->max_size, other.max_size);
+    return *this;
+  }
+  constexpr size_info operator+(const size_info &other) {
+    return {this->total + other.total, this->size_cnt += other.size_cnt,
+            std::max(this->max_size, other.max_size)};
+  }
+};
+
 template <typename T, typename... Args>
-constexpr std::size_t STRUCT_PACK_INLINE
+constexpr size_info STRUCT_PACK_INLINE
 calculate_payload_size(const T &item, const Args &...items);
 
-constexpr std::size_t STRUCT_PACK_INLINE calculate_payload_size() { return 0; }
-
 template <typename T>
-constexpr std::size_t STRUCT_PACK_INLINE calculate_one_size(const T &item) {
+constexpr size_info STRUCT_PACK_INLINE calculate_one_size(const T &item) {
   static_assert((get_type_id<std::remove_cvref_t<T>>(), true));
   using type = std::remove_cvref_t<decltype(item)>;
   static_assert(!std::is_pointer_v<type>);
-  std::size_t total = 0;
+  size_info ret{.total = 0, .size_cnt = 0, .max_size = 0};
   if constexpr (std::is_same_v<type, std::monostate>) {
   }
   else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
-    total += sizeof(type);
-  }
-  else if constexpr (std::is_same_v<std::string, type>) {
-    total += (item.size() + sizeof(size_type));
+    ret.total += sizeof(type);
   }
   else if constexpr (c_array<type> || array<type>) {
     if constexpr (std::is_trivially_copyable_v<type>) {
-      total += sizeof(type);
+      ret.total += sizeof(type);
     }
     else {
       for (auto &i : item) {
-        total += calculate_one_size(i);
+        ret += calculate_one_size(i);
       }
     }
   }
   else if constexpr (map_container<type> || container<type>) {
-    total += sizeof(size_type);
+    ret.size_cnt += 1;
+    ret.max_size = std::max(ret.max_size, item.size());
     if constexpr (trivially_copyable_container<type>) {
       using value_type = typename type::value_type;
-      auto size = item.size() * sizeof(value_type);
-      total += size;
-      return total;
+      ret.total += item.size() * sizeof(value_type);
     }
-    for (auto &&i : item) {
-      total += calculate_one_size(i);
+    else {
+      for (auto &&i : item) {
+        ret += calculate_one_size(i);
+      }
     }
   }
   else if constexpr (container_adapter<type>) {
@@ -800,21 +809,21 @@ constexpr std::size_t STRUCT_PACK_INLINE calculate_one_size(const T &item) {
   else if constexpr (tuple<type>) {
     std::apply(
         [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-          total += calculate_payload_size(items...);
+          ret += calculate_payload_size(items...);
         },
         item);
   }
   else if constexpr (optional<type>) {
-    total += sizeof(char);
+    ret.total += sizeof(char);
     if (item.has_value()) {
-      total += calculate_one_size(*item);
+      ret += calculate_one_size(*item);
     }
   }
   else if constexpr (variant<type>) {
-    total += sizeof(uint32_t);
+    ret.total += sizeof(uint32_t);  // why is 32bit?
     if (item.index() != std::variant_npos) [[likely]] {
-      total += std::visit(
-          [](const auto &e) -> std::size_t {
+      ret += std::visit(
+          [](const auto &e) {
             return calculate_one_size(e);
           },
           item);
@@ -824,45 +833,46 @@ constexpr std::size_t STRUCT_PACK_INLINE calculate_one_size(const T &item) {
     }
   }
   else if constexpr (expected<type>) {
-    total += sizeof(bool);
+    ret.total += sizeof(bool);
     if (item.has_value()) {
       if constexpr (!std::is_same_v<typename type::value_type, void>)
-        total += calculate_one_size(item.value());
+        ret += calculate_one_size(item.value());
     }
     else {
-      total += calculate_one_size(item.error());
+      ret += calculate_one_size(item.error());
     }
   }
   else if constexpr (std::is_class_v<type>) {
     if constexpr (std::is_trivially_copyable_v<type>) {
-      total += sizeof(type);
+      ret.total += sizeof(type);
     }
     else {
       visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-        total += calculate_payload_size(items...);
+        ret += calculate_payload_size(items...);
       });
     }
   }
   else {
     static_assert(!sizeof(type), "the type is not supported yet");
   }
-  return total;
+  return ret;
 }
 
 template <typename Key, typename Value>
-constexpr std::size_t STRUCT_PACK_INLINE
+constexpr size_info STRUCT_PACK_INLINE
 calculate_one_size(const std::pair<Key, Value> &item) {
-  std::size_t total = 0;
-  total += calculate_one_size(item.first);
-  total += calculate_one_size(item.second);
-  return total;
+  auto ret = calculate_one_size(item.first);
+  ret += calculate_one_size(item.second);
+  return ret;
 }
 
 template <typename T, typename... Args>
-constexpr std::size_t STRUCT_PACK_INLINE
+constexpr size_info STRUCT_PACK_INLINE
 calculate_payload_size(const T &item, const Args &...items) {
-  auto sz = calculate_one_size(item);
-  return sz + calculate_payload_size(items...);
+  if constexpr (sizeof...(items))
+    return calculate_one_size(item) + calculate_payload_size(items...);
+  else
+    return calculate_one_size(item);
 }
 
 template <typename T, typename Tuple>
@@ -899,7 +909,7 @@ struct serialize_static_config {
 
 struct serialize_runtime_info {
   std::size_t len;
-  char metainfo;
+  unsigned char metainfo;
 };
 
 template <typename... Args>
@@ -926,13 +936,35 @@ template <serialize_config conf, typename... Args>
 [[nodiscard]] STRUCT_PACK_INLINE constexpr serialize_runtime_info
 get_serialize_runtime_info(const Args &...args) {
   using Type = get_args_type<Args...>;
-  serialize_runtime_info ret = {
-      .len = sizeof(uint32_t) + calculate_payload_size(args...), .metainfo = 0};
   constexpr bool has_compatible = serialize_static_config<Type>::has_compatible;
   constexpr bool has_type_literal = check_if_add_type_literal<conf, Type>();
+  serialize_runtime_info ret{.len = sizeof(uint32_t)};
+  auto sz_info = calculate_payload_size(args...);
+
+  if (sz_info.max_size < (1ull << 8)) [[likely]] {
+    ret.len += sz_info.total + sz_info.size_cnt;
+    ret.metainfo = 0b00000;
+  }
+  else if (sz_info.max_size < (1ull << 16)) {
+    ret.len += sz_info.total + sz_info.size_cnt * 2;
+    ret.metainfo = 0b01000;
+  }
+  else if (sz_info.max_size < (1ull << 32)) {
+    ret.len += sz_info.total + sz_info.size_cnt * 4;
+    ret.metainfo = 0b10000;
+  }
+  else {
+    ret.len += sz_info.total + sz_info.size_cnt * 8;
+    ret.metainfo = 0b11000;
+  }
   constexpr bool has_meta_info = has_compatible || has_type_literal;
   if constexpr (has_meta_info) {
-    ret.len += sizeof(char);
+    ret.len += sizeof(unsigned char);
+  }
+  else {
+    if (ret.metainfo) {
+      ret.len += sizeof(unsigned char);
+    }
   }
   if constexpr (has_type_literal) {
     constexpr auto type_literal = struct_pack::get_type_literal<Args...>();
@@ -965,10 +997,11 @@ class packer {
   packer(const packer &) = delete;
   packer &operator=(const packer &) = delete;
 
-  template <serialize_config conf, typename T, typename... Args>
+  template <serialize_config conf, std::size_t size_type, typename T,
+            typename... Args>
   STRUCT_PACK_INLINE void serialize(const T &t, const Args &...args) {
-    serialize_metainfo<conf>(t, args...);
-    serialize_many(t, args...);
+    serialize_metainfo<conf, size_type == 1>(t, args...);
+    serialize_many<size_type>(t, args...);
   }
 
   STRUCT_PACK_INLINE const Byte *data() { return data_; }
@@ -996,15 +1029,16 @@ class packer {
                   check_if_add_type_literal<conf, serialize_type>()) {
       return raw_types_code - raw_types_code % 2 + 1;
     }
-    // TODO: size_type
     else {  // default case, only has hash_code
       return raw_types_code - raw_types_code % 2;
     }
   }
-  template <serialize_config conf, typename T, typename... Args>
+  template <serialize_config conf, bool is_default_size_type, typename T,
+            typename... Args>
   constexpr void STRUCT_PACK_INLINE serialize_metainfo(const T &t,
                                                        const Args &...args) {
-    constexpr auto hash_head = calculate_hash_head<conf, T, Args...>();
+    constexpr auto hash_head = calculate_hash_head<conf, T, Args...>() |
+                               (is_default_size_type ? 0 : 1);
     std::memcpy(data_ + pos_, &hash_head, sizeof(uint32_t));
     pos_ += sizeof(uint32_t);
     if constexpr (hash_head % 2) {  // has more metainfo
@@ -1022,19 +1056,20 @@ class packer {
         std::memcpy(data_ + pos_, type_literal.data(), type_literal.size() + 1);
         pos_ += type_literal.size() + 1;
       }
-      // TODO:size_type
     }
   }
 
  private:
-  constexpr void STRUCT_PACK_INLINE serialize_many() { return; }
-
+  template <std::size_t size_type>
   constexpr void STRUCT_PACK_INLINE serialize_many(const auto &first_item,
                                                    const auto &...items) {
-    serialize_one(first_item);
-    serialize_many(items...);
+    serialize_one<size_type>(first_item);
+    if constexpr (sizeof...(items) > 0) {
+      serialize_many<size_type>(items...);
+    }
   }
 
+  template <std::size_t size_type>
   constexpr void STRUCT_PACK_INLINE serialize_one(const auto &item) {
     using type = std::remove_cvref_t<decltype(item)>;
     static_assert(!std::is_pointer_v<type>);
@@ -1050,28 +1085,51 @@ class packer {
         pos_ += sizeof(type);
       }
       else {
-        for (auto &i : item) {
-          serialize_one(i);
+        for (const auto &i : item) {
+          serialize_one<size_type>(i);
         }
       }
     }
     else if constexpr (map_container<type> || container<type>) {
-      if (item.size() > MAX_SIZE) [[unlikely]] {
-        exit_container_size();
+      auto size = item.size();
+#ifdef STRUCT_PACK_OPTIMIZE
+      std::memcpy(data_ + pos_, &size, size_type);
+      pos_ += size_type;
+#else
+      if constexpr (size_type == 1) {
+        std::memcpy(data_ + pos_, &size, size_type);
+        pos_ += size_type;
       }
-      size_type size = item.size();
-      std::memcpy(data_ + pos_, &size, sizeof(size_type));
-      pos_ += sizeof(size_type);
-
+      else {
+        switch ((info.metainfo & 0b11000) >> 3) {
+          case 1:
+            std::memcpy(data_ + pos_, &size, 2);
+            pos_ += 2;
+            break;
+          case 2:
+            std::memcpy(data_ + pos_, &size, 4);
+            pos_ += 4;
+            break;
+          case 3:
+            std::memcpy(data_ + pos_, &size, 8);
+            pos_ += 8;
+            break;
+          default:
+            unreachable();
+        }
+      }
+#endif
       if constexpr (trivially_copyable_container<type>) {
         using value_type = typename type::value_type;
-        auto size = item.size() * sizeof(value_type);
-        std::memcpy(data_ + pos_, item.data(), size);
-        pos_ += size;
+        auto container_size = 1ull * size * sizeof(value_type);
+        std::memcpy(data_ + pos_, item.data(), container_size);
+        pos_ += container_size;
         return;
       }
-      for (auto &&i : item) {
-        serialize_one(i);
+      else {
+        for (const auto &i : item) {
+          serialize_one<size_type>(i);
+        }
       }
     }
     else if constexpr (container_adapter<type>) {
@@ -1081,7 +1139,7 @@ class packer {
     else if constexpr (tuple<type>) {
       std::apply(
           [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-            serialize_many(items...);
+            serialize_many<size_type>(items...);
           },
           item);
     }
@@ -1091,7 +1149,7 @@ class packer {
       pos_ += sizeof(char);
 
       if (has_value) {
-        serialize_one(*item);
+        serialize_one<size_type>(*item);
       }
     }
     else if constexpr (variant<type>) {
@@ -1104,7 +1162,7 @@ class packer {
         pos_ += sizeof(index);
         std::visit(
             [this](auto &&e) {
-              this->serialize_one(e);
+              this->serialize_one<size_type>(e);
             },
             item);
       }
@@ -1115,11 +1173,15 @@ class packer {
       pos_ += sizeof(has_value);
       if (has_value) {
         if constexpr (!std::is_same_v<typename type::value_type, void>)
-          serialize_one(item.value());
+          serialize_one<size_type>(item.value());
       }
       else {
-        serialize_one(item.error());
+        serialize_one<size_type>(item.error());
       }
+    }
+    else if constexpr (pair<type>) {
+      serialize_one<size_type>(item.first);
+      serialize_one<size_type>(item.second);
     }
     else if constexpr (std::is_class_v<type>) {
       static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
@@ -1129,7 +1191,7 @@ class packer {
       }
       else {
         visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-          serialize_many(items...);
+          serialize_many<size_type>(items...);
         });
       }
     }
@@ -1137,13 +1199,6 @@ class packer {
       static_assert(!sizeof(type), "the type is not supported yet");
     }
     return;
-  }
-
-  template <typename Key, typename Value>
-  constexpr void STRUCT_PACK_INLINE
-  serialize_one(const std::pair<Key, Value> &item) {
-    serialize_one(item.first);
-    serialize_one(item.second);
   }
 
   template <typename T>
@@ -1170,8 +1225,25 @@ class unpacker {
     if (err_code != struct_pack::errc{}) [[unlikely]] {
       return err_code;
     }
-    auto ret = deserialize_many(t, args...);
-    return ret;
+    switch (size_type_) {
+      case 0:
+        return deserialize_many<1>(t, args...);
+#ifdef STRUCT_PACK_OPTIMIZE
+      case 1:
+        return deserialize_many<2>(t, args...);
+      case 2:
+        return deserialize_many<4>(t, args...);
+      case 3:
+        return deserialize_many<8>(t, args...);
+#else
+      case 1:
+      case 2:
+      case 3:
+        return deserialize_many<2>(t, args...);
+#endif
+      default:
+        unreachable();
+    }
   }
 
   template <typename T, typename... Args>
@@ -1182,7 +1254,31 @@ class unpacker {
     if (err_code != struct_pack::errc{}) [[unlikely]] {
       return err_code;
     }
-    auto ret = deserialize_many(t, args...);
+    struct_pack::errc ret;
+    switch (size_type_) {
+      case 0:
+        ret = deserialize_many<1>(t, args...);
+        break;
+#ifdef STRUCT_PACK_OPTIMIZE
+      case 1:
+        ret = deserialize_many<2>(t, args...);
+        break;
+      case 2:
+        ret = deserialize_many<4>(t, args...);
+        break;
+      case 3:
+        ret = deserialize_many<8>(t, args...);
+        break;
+#else
+      case 1:
+      case 2:
+      case 3:
+        ret = deserialize_many<2>(t, args...);
+        break;
+#endif
+      default:
+        unreachable();
+    }
     len = (ret == struct_pack::errc{} ? std::max(pos_, data_len) : 0);
     return ret;
   }
@@ -1194,17 +1290,45 @@ class unpacker {
           &field) {
     using T = std::remove_cvref_t<U>;
 
-    static T t;
     if (auto [code, _] = deserialize_metainfo<T>(); code != struct_pack::errc{})
         [[unlikely]] {
       return code;
     }
+    switch (size_type_) {
+      case 0:
+        return get_field_impl<1, U, I>(field);
+#ifdef STRUCT_PACK_OPTIMIZE
+      case 1:
+        return get_field_impl<2, U, I>(field);
+      case 2:
+        return get_field_impl<4, U, I>(field);
+      case 3:
+        return get_field_impl<8, U, I>(field);
+#else
+      case 1:
+      case 2:
+      case 3:
+        return get_field_impl<2, U, I>(field);
+#endif
+      default:
+        unreachable();
+    }
+  }
+
+  template <std::size_t size_type, typename U, size_t I>
+  STRUCT_PACK_INLINE struct_pack::errc get_field_impl(
+      std::tuple_element_t<
+          I, decltype(get_types(std::declval<std::remove_cvref_t<U>>()))>
+          &field) {
+    using T = std::remove_cvref_t<U>;
+
+    static T t;
     struct_pack::errc err_code;
     if constexpr (tuple<T>) {
       err_code = std::apply(
           [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
             static_assert(I < sizeof...(items), "out of range");
-            return for_each<I>(field, items...);
+            return for_each<size_type, I>(field, items...);
           },
           t);
     }
@@ -1212,46 +1336,56 @@ class unpacker {
       static_assert(std::is_aggregate_v<T>);
       err_code = visit_members(t, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
         static_assert(I < sizeof...(items), "out of range");
-        return for_each<I>(field, items...);
+        return for_each<size_type, I>(field, items...);
       });
+    }
+    else {
+      static_assert(!sizeof(T), "illegal type");
     }
     pos_ = 0;
     return err_code;
   }
 
  private:
-  template <size_t index, typename unpack, typename variant_t>
+  template <size_t index, typename size_type>
   struct variant_construct_helper_not_skipped {
-    static STRUCT_PACK_INLINE void run(unpack &unpacker, variant_t &v) {
+    template <typename unpack, typename variant_t>
+    static STRUCT_PACK_INLINE constexpr void run(unpack &unpacker,
+                                                 variant_t &v) {
       if constexpr (index >= std::variant_size_v<variant_t>) {
         return;
       }
       else {
         v = variant_t{std::in_place_index_t<index>{}};
-        unpacker.template deserialize_one<true>(std::get<index>(v));
+        unpacker.template deserialize_one<size_type::value, true>(
+            std::get<index>(v));
       }
     }
   };
 
-  template <size_t index, typename unpack, typename variant_t>
+  template <size_t index, typename size_type>
   struct variant_construct_helper_skipped {
-    static STRUCT_PACK_INLINE void run(unpack &unpacker, variant_t &v) {
+    template <typename unpack, typename variant_t>
+    static STRUCT_PACK_INLINE constexpr void run(unpack &unpacker,
+                                                 variant_t &v) {
       if constexpr (index >= std::variant_size_v<variant_t>) {
         return;
       }
       else {
         v = variant_t{std::in_place_index_t<index>{}};
-        unpacker.template deserialize_one<false>(std::get<index>(v));
+        unpacker.template deserialize_one<size_type::value, false>(
+            std::get<index>(v));
       }
     };
   };
 
   STRUCT_PACK_INLINE std::pair<struct_pack::errc, std::size_t>
-  deserialize_compatible(char compatible_sz_len) {
+  deserialize_compatible(unsigned compatible_sz_len) {
     constexpr std::size_t sz[] = {0, 2, 4, 8};
     auto len_sz = sz[compatible_sz_len];
     uint64_t data_len = 0;
-    if (size_ < sizeof(uint32_t) + sizeof(char) + len_sz) [[unlikely]] {
+    if (size_ < sizeof(uint32_t) + sizeof(unsigned char) + len_sz)
+        [[unlikely]] {
       return {errc::no_buffer_space, 0};
     }
     std::memcpy(&data_len, data_ + pos_, len_sz);
@@ -1286,48 +1420,49 @@ class unpacker {
     pos_ += sizeof(uint32_t);
     if (current_types_code % 2 == 0) [[likely]]  // unexist extended metainfo
     {
+      size_type_ = 0;
       return {};
     }
-    if (size_ < sizeof(char) + sizeof(uint32_t)) [[unlikely]] {
+    if (size_ < sizeof(unsigned char) + sizeof(uint32_t)) [[unlikely]] {
       return {struct_pack::errc::no_buffer_space, 0};
     }
-    char metainfo;
-    std::memcpy(&metainfo, data_ + pos_, sizeof(char));
-    pos_ += sizeof(char);
-    // TODO: deserialize size_type
+    unsigned char metainfo;
+    std::memcpy(&metainfo, data_ + pos_, sizeof(unsigned char));
+    pos_ += sizeof(unsigned char);
     std::pair<errc, std::size_t> ret;
-    char compatible_sz_len = metainfo & 0b11;
+    auto compatible_sz_len = metainfo & 0b11;
     if (compatible_sz_len) {
       if (ret = deserialize_compatible(compatible_sz_len); ret.first != errc{})
           [[unlikely]] {
         return ret;
       }
     }
-    char has_type_literal = metainfo & 0b100;
+    auto has_type_literal = metainfo & 0b100;
     if (has_type_literal) {
       if (auto ec = deserialize_type_literal<T>(); ec != errc{}) [[unlikely]] {
         return {ec, 0};
       }
     }
+    size_type_ = (metainfo & 0b11000) >> 3;
     return ret;
   }
 
-  template <bool NotSkip = true>
+  template <size_t size_type, bool NotSkip = true>
   constexpr struct_pack::errc STRUCT_PACK_INLINE deserialize_many() {
     return {};
   }
 
-  template <bool NotSkip = true>
+  template <size_t size_type, bool NotSkip = true>
   constexpr struct_pack::errc STRUCT_PACK_INLINE
   deserialize_many(auto &&first_item, auto &&...items) {
-    auto code = deserialize_one<NotSkip>(first_item);
+    auto code = deserialize_one<size_type, NotSkip>(first_item);
     if (code != struct_pack::errc{}) [[unlikely]] {
       return code;
     }
-    return deserialize_many<NotSkip>(items...);
+    return deserialize_many<size_type, NotSkip>(items...);
   }
 
-  template <bool NotSkip = true>
+  template <size_t size_type, bool NotSkip>
   constexpr struct_pack::errc STRUCT_PACK_INLINE deserialize_one(auto &item) {
     struct_pack::errc code{};
     using type = std::remove_cvref_t<decltype(item)>;
@@ -1352,52 +1487,71 @@ class unpacker {
       }
       else {
         for (auto &i : item) {
-          code = deserialize_one<NotSkip>(i);
+          code = deserialize_one<size_type, NotSkip>(i);
           if (code != struct_pack::errc{}) [[unlikely]] {
             return code;
           }
         }
       }
     }
-    else if constexpr (map_container<type>) {
-      size_type size = 0;
-      if (pos_ + sizeof(size_type) > size_) [[unlikely]] {
-        return struct_pack::errc::no_buffer_space;
-      }
-      std::memcpy(&size, data_ + pos_, sizeof(size_type));
-      pos_ += sizeof(size_type);
-      if (size == 0) [[unlikely]] {
-        return {};
-      }
-
-      using key_type = typename type::key_type;
-      using value_type = typename type::mapped_type;
-      std::pair<key_type, value_type> pair{};
-      for (int i = 0; i < size; ++i) {
-        code = deserialize_one<NotSkip>(pair);
-        if (code != struct_pack::errc{}) [[unlikely]] {
-          return code;
-        }
-        if constexpr (NotSkip) {
-          item.emplace(std::move(pair));
-        }
-      }
-    }
     else if constexpr (container<type>) {
-      size_type size = 0;
-      if (pos_ + sizeof(size_type) > size_) [[unlikely]] {
+      size_t size = 0;
+#ifdef STRUCT_PACK_OPTIMIZE
+      if (pos_ + size_type > size_) [[unlikely]] {
         return struct_pack::errc::no_buffer_space;
       }
-      std::memcpy(&size, data_ + pos_, sizeof(size_type));
-      pos_ += sizeof(size_type);
+      std::memcpy(&size, data_ + pos_, size_type);
+      pos_ += size_type;
+#else
+      if constexpr (size_type == 1) {
+        if (pos_ + size_type > size_) [[unlikely]] {
+          return struct_pack::errc::no_buffer_space;
+        }
+        std::memcpy(&size, data_ + pos_, size_type);
+        pos_ += size_type;
+      }
+      else {
+        switch (size_type_) {
+          case 1:
+            if (pos_ + 2 > size_) [[unlikely]] {
+              return struct_pack::errc::no_buffer_space;
+            }
+            std::memcpy(&size, data_ + pos_, 2);
+            pos_ += 2;
+            break;
+          case 2:
+            if (pos_ + 4 > size_) [[unlikely]] {
+              return struct_pack::errc::no_buffer_space;
+            }
+            std::memcpy(&size, data_ + pos_, 4);
+            pos_ += 4;
+            break;
+          case 3:
+            if (pos_ + 8 > size_) [[unlikely]] {
+              return struct_pack::errc::no_buffer_space;
+            }
+            std::memcpy(&size, data_ + pos_, 8);
+            pos_ += 8;
+            break;
+          default:
+            unreachable();
+        }
+      }
+#endif
       if (size == 0) [[unlikely]] {
         return {};
       }
-
-      if constexpr (set_container<type>) {
-        typename type::value_type value;
+      if constexpr (map_container<type> || set_container<type>) {
+        decltype([]<typename T>(const T &t) {
+          if constexpr (map_container<T>) {
+            return std::pair<typename T::key_type, typename T::mapped_type>{};
+          }
+          else {
+            return typename T::value_type{};
+          }
+        }(item)) value;
         for (int i = 0; i < size; ++i) {
-          code = deserialize_one<NotSkip>(value);
+          code = deserialize_one<size_type, NotSkip>(value);
           if (code != struct_pack::errc{}) [[unlikely]] {
             return code;
           }
@@ -1408,8 +1562,8 @@ class unpacker {
       }
       else {
         using value_type = typename type::value_type;
-        size_t mem_sz = size * sizeof(value_type);
         if constexpr (trivially_copyable_container<type>) {
+          size_t mem_sz = size * sizeof(value_type);
           if constexpr (NotSkip) {
             if (pos_ + mem_sz > size_) [[unlikely]] {
               return struct_pack::errc::no_buffer_space;
@@ -1428,7 +1582,7 @@ class unpacker {
           if constexpr (NotSkip) {
             item.resize(size);
             for (auto &i : item) {
-              code = deserialize_one<NotSkip>(i);
+              code = deserialize_one<size_type, NotSkip>(i);
               if (code != struct_pack::errc{}) [[unlikely]] {
                 return code;
               }
@@ -1437,7 +1591,7 @@ class unpacker {
           else {
             value_type useless;
             for (size_t i = 0; i < size; ++i) {
-              code = deserialize_one<NotSkip>(useless);
+              code = deserialize_one<size_type, NotSkip>(useless);
               if (code != struct_pack::errc{}) [[unlikely]] {
                 return code;
               }
@@ -1453,7 +1607,7 @@ class unpacker {
     else if constexpr (tuple<type>) {
       std::apply(
           [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-            code = deserialize_many(items...);
+            code = deserialize_many<size_type>(items...);
           },
           item);
     }
@@ -1468,7 +1622,7 @@ class unpacker {
         return {};
       }
       item = type{std::in_place_t{}};
-      deserialize_one<NotSkip>(item.value());
+      deserialize_one<size_type, NotSkip>(item.value());
     }
     else if constexpr (variant<type>) {
       if (pos_ + sizeof(uint32_t) > size_) [[unlikely]] {
@@ -1482,11 +1636,14 @@ class unpacker {
       }
       else {
         if constexpr (NotSkip) {
-          template_switch<variant_construct_helper_not_skipped>(index, *this,
-                                                                item);
+          template_switch<variant_construct_helper_not_skipped,
+                          std::integral_constant<std::size_t, size_type>>(
+              index, *this, item);
         }
         else {
-          template_switch<variant_construct_helper_skipped>(index, *this, item);
+          template_switch<variant_construct_helper_skipped,
+                          std::integral_constant<std::size_t, size_type>>(
+              index, *this, item);
         }
       }
     }
@@ -1499,11 +1656,11 @@ class unpacker {
       pos_ += sizeof(bool);
       if (has_value) {
         if constexpr (!std::is_same_v<typename type::value_type, void>)
-          deserialize_one<NotSkip>(item.value());
+          deserialize_one<size_type, NotSkip>(item.value());
       }
       else {
         typename type::error_type value;
-        deserialize_one<NotSkip>(value);
+        deserialize_one<size_type, NotSkip>(value);
         if constexpr (NotSkip) {
           item = typename type::unexpected_type{std::move(value)};
         }
@@ -1523,7 +1680,7 @@ class unpacker {
       }
       else {
         visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-          code = deserialize_many(items...);
+          code = deserialize_many<size_type>(items...);
         });
       }
     }
@@ -1533,27 +1690,28 @@ class unpacker {
     return code;
   }
 
-  template <bool NotSkip = true, typename Key, typename Value>
+  template <size_t size_type, bool NotSkip = true, typename Key, typename Value>
   constexpr struct_pack::errc STRUCT_PACK_INLINE
   deserialize_one(std::pair<Key, Value> &item) {
-    auto code = deserialize_one<NotSkip>(item.first);
+    auto code = deserialize_one<size_type, NotSkip>(item.first);
     if (code != struct_pack::errc{}) [[unlikely]] {
       return code;
     }
-    return deserialize_one<NotSkip>(item.second);
+    return deserialize_one<size_type, NotSkip>(item.second);
   }
 
   // partial deserialize_to
-  template <size_t I, size_t FiledIndex, typename FiledType, typename T>
+  template <size_t size_type, size_t I, size_t FieldIndex, typename FiledType,
+            typename T>
   STRUCT_PACK_INLINE bool set_value(struct_pack::errc &err_code,
                                     FiledType &field, T &&t) {
-    if constexpr (FiledIndex == I) {
+    if constexpr (FieldIndex == I) {
       static_assert(std::is_same_v<std::remove_cvref_t<FiledType>,
                                    std::remove_cvref_t<T>>);
-      err_code = deserialize_one<true>(field);
+      err_code = deserialize_one<size_type, true>(field);
       return /*don't skip=*/true;
     }
-    err_code = deserialize_one<false>(t);
+    err_code = deserialize_one<size_type, false>(t);
     return /*don't skip=*/false;
   }
 
@@ -1562,14 +1720,15 @@ class unpacker {
     return std::get<I>(std::forward_as_tuple(ts...));
   }
 
-  template <size_t FiledIndex, typename FiledType, typename... Args>
+  template <size_t size_type, size_t FieldIndex, typename FiledType,
+            typename... Args>
   STRUCT_PACK_INLINE constexpr decltype(auto) for_each(FiledType &field,
                                                        Args &&...items) {
     bool stop = false;
     struct_pack::errc code{};
     [&]<std::size_t... I>(std::index_sequence<I...>) CONSTEXPR_INLINE_LAMBDA {
       ((!stop &&
-        (stop = set_value<I, FiledIndex>(code, field, get_nth<I>(items...)))),
+        (stop = set_value<size_type, I, FieldIndex>(code, field, get_nth<I>(items...)))),
        ...);
     }
     (std::make_index_sequence<sizeof...(Args)>{});
@@ -1579,6 +1738,7 @@ class unpacker {
   const Byte *data_;
   std::size_t size_;
   std::size_t pos_{};
+  unsigned char size_type_;
 };
 
 }  // namespace detail

--- a/src/coro_rpc/tests/CMakeLists.txt
+++ b/src/coro_rpc/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ add_executable(test_rpc
         )
 target_link_libraries(test_rpc PRIVATE libcoro_rpc doctest)
 target_compile_definitions(test_rpc PRIVATE UNIT_TEST_INJECT)
-target_compile_definitions(test_rpc PRIVATE STRUCT_PACK_USE_INT16_SIZE STRUCT_PACK_ENABLE_UNPORTABLE_TYPE)
+target_compile_definitions(test_rpc PRIVATE STRUCT_PACK_ENABLE_UNPORTABLE_TYPE)
 add_custom_command(
         TARGET test_rpc POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/src/struct_pack/benchmark/CMakeLists.txt
+++ b/src/struct_pack/benchmark/CMakeLists.txt
@@ -7,4 +7,4 @@ execute_process(
 add_executable(struct_pack_benchmark benchmark.cpp no_op.cpp ${CMAKE_BINARY_DIR}/benchmark/benchmark.pb.cc)
 target_include_directories(struct_pack_benchmark PUBLIC ${CMAKE_BINARY_DIR}/benchmark/)
 target_link_libraries(struct_pack_benchmark ${Protobuf_LIBRARIES})
-target_compile_definitions(struct_pack_benchmark PRIVATE MSGPACK_NO_BOOST)
+target_compile_definitions(struct_pack_benchmark PRIVATE MSGPACK_NO_BOOST STRUCT_PACK_OPTIMIZE)

--- a/src/struct_pack/benchmark/benchmark.cpp
+++ b/src/struct_pack/benchmark/benchmark.cpp
@@ -54,6 +54,17 @@ struct person {
   MSGPACK_DEFINE(id, name, age, salary);
 };
 
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<person> = type_info_config::disable;
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<std::vector<person>> =
+    type_info_config::disable;
+};
+
 template <typename T>
 T get_max() {
   if constexpr (std::is_same_v<T, int8_t>) {
@@ -91,6 +102,18 @@ struct rect {
   T width = get_max<T>();
   T height = get_max<T>();
   MSGPACK_DEFINE(x, y, width, height);
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<rect<int32_t>> =
+    type_info_config::disable;
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<std::vector<rect<int32_t>>> =
+    type_info_config::disable;
 };
 
 enum Color : uint8_t { Red, Green, Blue };
@@ -137,6 +160,17 @@ struct Monster {
   };
   MSGPACK_DEFINE(pos, mana, hp, name, inventory, (int &)color, weapons,
                  equipped, path);
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<Monster> = type_info_config::disable;
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<std::vector<Monster>> =
+    type_info_config::disable;
 };
 
 static constexpr int OBJECT_COUNT = 20;

--- a/src/struct_pack/tests/CMakeLists.txt
+++ b/src/struct_pack/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 add_executable(test_serialize
         test_serialize.cpp
+        test_compile_time_calculate.cpp
+        test_data_struct.cpp
         test_tuplet.cpp
         test_alignas.cpp
         test_pragma_pack.cpp
@@ -8,5 +10,5 @@ add_executable(test_serialize
         main.cpp
         )
 add_test(NAME test_serialize COMMAND test_serialize)
-target_compile_definitions(test_serialize PRIVATE STRUCT_PACK_USE_INT32_SIZE STRUCT_PACK_ENABLE_UNPORTABLE_TYPE)
+target_compile_definitions(test_serialize PRIVATE STRUCT_PACK_ENABLE_UNPORTABLE_TYPE)
 target_link_libraries(test_serialize PRIVATE libstruct_pack doctest)

--- a/src/struct_pack/tests/test_compile_time_calculate.cpp
+++ b/src/struct_pack/tests/test_compile_time_calculate.cpp
@@ -1,0 +1,365 @@
+#include "doctest.h"
+#include "struct_pack/struct_pack.hpp"
+#include "test_struct.hpp"
+
+using namespace struct_pack;
+
+struct compatible_in_nested_class {
+  int a;
+  struct_pack::compatible<int> c;
+};
+
+struct bug_member_count_struct1 {
+  int i;
+  struct hello {
+    std::optional<int> j;
+  } hi;
+  double k = 3;
+};
+
+struct bug_member_count_struct2 : bug_member_count_struct1 {};
+
+template <>
+constexpr std::size_t struct_pack::members_count<bug_member_count_struct2> = 3;
+
+TEST_CASE("test members_count") {
+  {
+    using t = bug_member_count_struct1;
+    t b;
+    auto res = struct_pack::serialize(b);
+    auto ret = struct_pack::deserialize<t>(res.data(), res.size());
+    CHECK(ret);
+  }
+  {
+    using t = bug_member_count_struct2;
+    t b;
+    auto res = struct_pack::serialize(b);
+    auto ret = struct_pack::deserialize<t>(res.data(), res.size());
+    CHECK(ret);
+  }
+}
+
+TEST_CASE("compatible not in the end of struct") {
+  static_assert(
+      detail::check_if_compatible_element_exist<
+          0, int, struct_pack::compatible<short>, std::string>() == -1,
+      "compatible member not in the end is illegal!");
+  static_assert(detail::check_if_compatible_element_exist<
+                    0, int, compatible_in_nested_class>() == -1,
+                "compatible member in the nested class is illegal!");
+  static_assert(
+      detail::check_if_compatible_element_exist<0, compatible_in_nested_class,
+                                                double>() == -1,
+      "compatible member in the nested class is illegal!");
+  static_assert(
+      detail::check_if_compatible_element_exist<
+          0, double, std::tuple<int, double, compatible<std::string>>>() == -1,
+      "compatible member in the nested class is illegal!");
+}
+
+struct type_calculate_test_1 {
+  tuplet::tuple<
+      std::pair<std::map<int, std::string>, std::vector<std::list<int>>>,
+      std::set<int>, std::array<int64_t, 64>, std::optional<int>>
+      a;
+};
+struct type_calculate_test_2 {
+  struct {
+    tuplet::tuple<std::unordered_map<int, std::string>,
+                  std::deque<std::vector<int>>>
+        a;
+    std::multiset<int> b;
+    int64_t c[64];
+    std::optional<int> d;
+  } e;
+};
+
+#ifndef NDEBUG
+TEST_CASE("test hash conflict detected") {
+  int32_t value = 42;
+  auto ret = serialize(value);
+  auto fake_hash = struct_pack::get_type_code<float>() | 0b1;
+  memcpy(ret.data(), &fake_hash, sizeof(fake_hash));
+  auto res = deserialize<float>(ret);
+  CHECK(!res);
+  CHECK(res.error() == struct_pack::errc::hash_conflict);
+}
+#endif
+
+struct type_calculate_test_3 {
+  struct {
+    std::pair<std::unordered_map<int, std::string>,
+              std::deque<std::vector<double>>>
+        a;
+    std::multiset<int> b;
+    int64_t c[64];
+    std::optional<int> d;
+  } e;
+};
+
+TEST_CASE("type calculate") {
+  static_assert(std::is_trivially_copyable<struct_pack::compatible<int>>::value,
+                "must be true");
+
+  {
+    static_assert(get_type_code<std::vector<int>>() !=
+                      get_type_code<std::vector<float>>(),
+                  "vector<T> with different T should get different MD5");
+    CHECK(!deserialize<std::vector<int>>(serialize(std::vector<float>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::deque<int>>() != get_type_code<std::deque<float>>(),
+        "deque<T> with different T should get different MD5");
+    CHECK(!deserialize<std::deque<int>>(serialize(std::deque<float>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::list<int>>() != get_type_code<std::list<float>>(),
+        "list<T> with different T should get different MD5");
+    CHECK(!deserialize<std::list<int>>(serialize(std::list<float>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::set<int>>() != get_type_code<std::set<float>>(),
+        "set<T> with different T should get different MD5");
+    CHECK(!deserialize<std::set<int>>(serialize(std::set<float>{})));
+  }
+  {
+    static_assert(get_type_code<std::map<int, std::string>>() !=
+                      get_type_code<std::map<float, std::string>>(),
+                  "map<T1,T2> with different T1 should get different MD5");
+    CHECK(!deserialize<std::map<int, std::string>>(
+        serialize(std::map<float, std::string>{})));
+  }
+
+  {
+    static_assert(get_type_code<std::map<std::string, int>>() !=
+                      get_type_code<std::map<std::string, float>>(),
+                  "map<T1,T2> with different T2 should get different MD5");
+    CHECK(!deserialize<std::map<std::string, int>>(
+        serialize(std::map<std::string, float>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::unordered_map<int, std::string>>() !=
+            get_type_code<std::unordered_map<float, std::string>>(),
+        "unordered_map<T1,T2> with different T1 should get different MD5");
+    CHECK(!deserialize<std::unordered_map<int, std::string>>(
+        serialize(std::unordered_map<float, std::string>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::unordered_map<std::string, int>>() !=
+            get_type_code<std::unordered_map<std::string, float>>(),
+        "unordered_map<T1,T2> with different T2 should get different MD5");
+    CHECK(!deserialize<std::unordered_map<std::string, int>>(
+        serialize(std::unordered_map<std::string, float>{})));
+  }
+  {
+    static_assert(get_type_code<std::unordered_set<int>>() !=
+                      get_type_code<std::unordered_set<float>>(),
+                  "unordered_set<T> with different T should get different MD5");
+    CHECK(!deserialize<std::unordered_set<int>>(
+        serialize(std::unordered_set<float>{})));
+  }
+  {
+    static_assert(get_type_code<std::array<int, 5>>() !=
+                      get_type_code<std::array<float, 5>>(),
+                  "array<T,sz> with different T should get different MD5");
+    CHECK(!deserialize<std::array<int, 5>>(serialize(std::array<float, 5>{})));
+  }
+  {
+    static_assert(get_type_code<std::array<int, 5>>() !=
+                      get_type_code<std::array<int, 6>>(),
+                  "array<T,sz> with different sz should get different MD5");
+    CHECK(!deserialize<std::array<int, 5>>(serialize(std::array<int, 6>{})));
+  }
+  {
+    static_assert(get_type_code<int[5]>() != get_type_code<float[5]>(),
+                  "T[sz] with different T should get different MD5");
+    int ar[5] = {};
+    float ar2[5] = {};
+    CHECK(deserialize_to(ar2, serialize(ar)) != struct_pack::errc{});
+  }
+  {
+    static_assert(get_type_code<int[5]>() != get_type_code<int[6]>(),
+                  "T[sz] with different sz should get different MD5");
+    int ar[5] = {};
+    int ar2[6] = {};
+    CHECK(deserialize_to(ar2, serialize(ar)) != struct_pack::errc{});
+  }
+  {
+    static_assert(get_type_code<std::optional<int>>() !=
+                      get_type_code<std::optional<float>>(),
+                  "optional<T> with different T should get different MD5");
+    CHECK(!deserialize<std::array<int, 5>>(serialize(std::array<int, 6>{})));
+  }
+  {
+    static_assert(
+        get_type_code<int, float, int>() != get_type_code<int, int, int>(),
+        "T... with different T... should get different MD5");
+    CHECK(!deserialize<int, int>(serialize(1, 2, 3)));
+  }
+  {
+    static_assert(get_type_code<std::tuple<int, float, int>>() !=
+                      get_type_code<std::tuple<int, int, int>>(),
+                  "tuple<T...> with different T... should get different MD5");
+    CHECK(!deserialize<int, int>(serialize(1, 2, 3)));
+  }
+  {
+    static_assert(get_type_code<std::tuple<int, float, int>>() ==
+                      get_type_code<int, float, int>(),
+                  "tuple<T...> and T... should get same MD5");
+    CHECK(deserialize<std::tuple<int, float, int>>(serialize(1, 2.0f, 3)));
+  }
+  {
+    static_assert(get_type_code<std::pair<int, int>>() !=
+                      get_type_code<std::pair<float, int>>(),
+                  "pair<T1,T2> with different T1 should get different MD5");
+    CHECK(!deserialize<std::pair<int, int>>(serialize(std::pair{1.3f, 1})));
+  }
+  {
+    static_assert(get_type_code<std::pair<int, float>>() !=
+                      get_type_code<std::pair<int, int>>(),
+                  "pair<T1,T2> with different T2 should get different MD5");
+    CHECK(!deserialize<std::pair<int, float>>(serialize(std::pair{1, 1})));
+  }
+  {
+    static_assert(
+        get_type_code<complicated_object>() != get_type_code<person>(),
+        "class{T...} with different T... should get different MD5");
+    CHECK(!deserialize<complicated_object>(serialize(person{})));
+  }
+  {
+    static_assert(
+        get_type_code<compatible<int>>() == get_type_code<compatible<float>>(),
+        "compatible<T> with different T should get same MD5");
+    CHECK(deserialize<compatible<int>>(serialize(compatible<float>{1})));
+  }
+  {
+    static_assert(
+        get_type_code<std::list<int>>() == get_type_code<std::vector<int>>(),
+        "different class accord with container concept should get same MD5");
+    CHECK(deserialize<std::list<int>>(serialize(std::vector<int>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::deque<int>>() == get_type_code<std::vector<int>>(),
+        "different class accord with container concept should get same MD5");
+    CHECK(deserialize<std::deque<int>>(serialize(std::vector<int>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::deque<int>>() == get_type_code<std::list<int>>(),
+        "different class accord with container concept should get same MD5");
+    CHECK(deserialize<std::deque<int>>(serialize(std::list<int>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::array<int, 5>>() == get_type_code<int[5]>(),
+        "different class accord with array concept should get same MD5");
+    int ar[5] = {};
+    CHECK(deserialize<std::array<int, 5>>(serialize(ar)));
+  }
+  {
+    static_assert(
+        get_type_code<std::map<int, int>>() ==
+            get_type_code<std::unordered_map<int, int>>(),
+        "different class accord with map concept should get same MD5");
+    CHECK(deserialize<std::map<int, int>>(
+        serialize(std::unordered_map<int, int>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::set<int>>() ==
+            get_type_code<std::unordered_set<int>>(),
+        "different class accord with set concept should get same MD5");
+    CHECK(deserialize<std::set<int>>(serialize(std::unordered_set<int>{})));
+  }
+  {
+    static_assert(
+        get_type_code<std::pair<int, std::string>>() == get_type_code<person>(),
+        "different class accord with trival_class concept should "
+        "get same MD5");
+    CHECK(deserialize<std::pair<int, std::string>>(serialize(person{})));
+  }
+  {
+    static_assert(get_type_code<tuplet::tuple<int, std::string>>() ==
+                      get_type_code<person>(),
+                  "different class accord with trival_class concept should "
+                  "get same MD5");
+    CHECK(deserialize<tuplet::tuple<int, std::string>>(serialize(person{})));
+  }
+  {
+    static_assert(get_type_code<std::pair<int, std::string>>() ==
+                      get_type_code<tuplet::tuple<int, std::string>>(),
+                  "different class accord with trival_class concept should "
+                  "get same MD5");
+    CHECK(deserialize<std::pair<int, std::string>>(
+        serialize(tuplet::tuple<int, std::string>{})));
+  }
+  {
+    static_assert(get_type_code<std::tuple<int, std::string>>() !=
+                      get_type_code<person>(),
+                  "different class accord and trival_class"
+                  "concept should get different MD5");
+    CHECK(!deserialize<std::tuple<int, std::string>>(serialize(person{})));
+  }
+  {
+    static_assert(get_type_code<std::pair<int, std::string>>() !=
+                      get_type_code<std::tuple<int, std::string>>(),
+                  "different class accord and trival_class concept should "
+                  "get different MD5");
+    CHECK(!deserialize<std::pair<int, std::string>>(
+        serialize(std::tuple<int, std::string>{})));
+  }
+  {
+    static_assert(get_type_code<type_calculate_test_1>() ==
+                      get_type_code<type_calculate_test_2>(),
+                  "struct type_calculate_test_1 && type_calculate_test_2 "
+                  "should get the "
+                  "same MD5");
+    CHECK(
+        deserialize<type_calculate_test_1>(serialize(type_calculate_test_2{})));
+  }
+
+  {
+    static_assert(get_type_code<type_calculate_test_1>() !=
+                      get_type_code<type_calculate_test_3>(),
+                  "struct type_calculate_test_1 && type_calculate_test_3 "
+                  "should get the "
+                  "different MD5");
+    CHECK(!deserialize<type_calculate_test_1>(
+        serialize(type_calculate_test_3{})));
+  }
+
+  {
+    static_assert(get_type_code<int>() != get_type_code<std::tuple<int>>(),
+                  "T & tuple<T> should get different MD5");
+    CHECK(!deserialize<int>(serialize(std::tuple<int>{})));
+  }
+
+  {
+    static_assert(get_type_code<int>() != get_type_code<tuplet::tuple<int>>(),
+                  "T & tuple_::tuple<T> should get different MD5");
+    CHECK(!deserialize<int>(serialize(tuplet::tuple<int>{})));
+  }
+
+  {
+    static_assert(get_type_code<std::tuple<int>>() !=
+                      get_type_code<std::tuple<std::tuple<int>>>(),
+                  "tuple<T> & tuple<tuple<T>> should get different MD5");
+    CHECK(!deserialize<std::tuple<int>>(
+        serialize(std::tuple<std::tuple<int>>{})));
+  }
+
+  {
+    static_assert(
+        get_type_code<std::tuple<int>, int>() !=
+            get_type_code<std::tuple<int, int>>(),
+        "tuple<tuple<T1>,T2> & tuple<tuple<T1,T2>> should get different MD5");
+    CHECK(!deserialize<std::tuple<std::tuple<int>, int>>(
+        serialize(std::tuple<std::tuple<int, int>>{})));
+  }
+}

--- a/src/struct_pack/tests/test_data_struct.cpp
+++ b/src/struct_pack/tests/test_data_struct.cpp
@@ -1,0 +1,401 @@
+#include "doctest.h"
+#include "struct_pack/struct_pack.hpp"
+#include "test_struct.hpp"
+using namespace struct_pack;
+
+void test_container(auto &v) {
+  auto ret = serialize(v);
+
+  using T = std::remove_cvref_t<decltype(v)>;
+  T v1{};
+  auto ec = deserialize_to(v1, ret.data(), ret.size());
+  CHECK(ec == struct_pack::errc{});
+  CHECK(v == v1);
+
+  v.clear();
+  v1.clear();
+  ret = serialize(v);
+  ec = deserialize_to(v1, ret.data(), ret.size());
+  CHECK(ec == struct_pack::errc{});
+  CHECK(v1.empty());
+  CHECK(v == v1);
+}
+
+TEST_CASE("testing sequence containers") {
+  SUBCASE("test vector") {
+    std::vector<person> v{{20, "tom"}};
+    test_container(v);
+  }
+  SUBCASE("test list") {
+    std::list<person> v{{20, "tom"}};
+    test_container(v);
+  }
+  SUBCASE("test deque") {
+    std::deque<person> v{{20, "tom"}};
+    test_container(v);
+  }
+}
+
+TEST_CASE("testing associative containers") {
+  SUBCASE("test int map") {
+    std::map<int, person> v{{1, {20, "tom"}}, {2, {22, "jerry"}}};
+    test_container(v);
+  }
+
+  SUBCASE("test string map") {
+    std::map<std::string, person> v{{"aa", {20, "tom"}}, {"bb", {22, "jerry"}}};
+    test_container(v);
+  }
+
+  SUBCASE("test multimap") {
+    std::multimap<int, person> v{{1, {20, "tom"}}, {2, {22, "jerry"}}};
+    test_container(v);
+
+    std::multimap<int, person> v1{{1, {20, "tom"}}, {1, {22, "jerry"}}};
+    test_container(v1);
+
+    std::multimap<int, person> v2{
+        {1, {20, "tom"}}, {1, {22, "jerry"}}, {3, {22, "jack"}}};
+    test_container(v2);
+
+    std::multimap<std::string, person> v3{{"aa", {20, "tom"}},
+                                          {"bb", {22, "jerry"}}};
+    test_container(v3);
+
+    std::multimap<std::string, person> v4{
+        {"dd", {20, "tom"}}, {"aa", {22, "jerry"}}, {"aa", {20, "jack"}}};
+    test_container(v4);
+  }
+
+  SUBCASE("test set") {
+    std::set<int> v{1, 2};
+    test_container(v);
+
+    std::set<std::string> v2{"aa", "bb"};
+    test_container(v2);
+
+    std::set<person> v3{{20, "tom"}, {22, "jerry"}};
+    test_container(v3);
+  }
+
+  SUBCASE("test multiset") {
+    std::multiset<int> v{1, 2, 1, 2};
+    test_container(v);
+
+    std::multiset<std::string> v2{"aa", "bb", "aa"};
+    test_container(v2);
+
+    std::multiset<person> v3{{20, "tom"}, {22, "jerry"}, {20, "jack"}};
+    test_container(v3);
+  }
+}
+
+TEST_CASE("testing unordered associative containers") {
+  SUBCASE("test int map") {
+    std::unordered_map<int, person> v{{1, {20, "tom"}}, {2, {22, "jerry"}}};
+    test_container(v);
+  }
+
+  SUBCASE("test string map") {
+    std::unordered_map<std::string, person> v{{"aa", {20, "tom"}},
+                                              {"bb", {22, "jerry"}}};
+    test_container(v);
+  }
+
+  SUBCASE("test multimap") {
+    std::unordered_map<int, person> v{{1, {20, "tom"}}, {2, {22, "jerry"}}};
+    test_container(v);
+
+    std::unordered_map<int, person> v1{{1, {20, "tom"}}, {1, {22, "jerry"}}};
+    test_container(v1);
+
+    std::unordered_map<int, person> v2{
+        {1, {20, "tom"}}, {1, {22, "jerry"}}, {3, {22, "jack"}}};
+    test_container(v2);
+
+    std::unordered_map<std::string, person> v3{{"aa", {20, "tom"}},
+                                               {"bb", {22, "jerry"}}};
+    test_container(v3);
+
+    std::unordered_map<std::string, person> v4{
+        {"dd", {20, "tom"}}, {"aa", {22, "jerry"}}, {"aa", {20, "jack"}}};
+    test_container(v4);
+  }
+}
+
+// We should not inherit from stl container, this case just for testing.
+template <typename T>
+struct my_vector : public std::vector<T> {};
+
+template <typename Key, typename Value>
+struct my_map : public std::map<Key, Value> {};
+
+TEST_CASE("testing nonstd containers") {
+  SUBCASE("test custom vector") {
+    my_vector<int> v;
+    v.push_back(1);
+    v.push_back(2);
+    test_container(v);
+
+    my_vector<std::string> v1;
+    v1.push_back("aa");
+    v1.push_back("bb");
+    test_container(v1);
+
+    my_vector<person> v2;
+    v2.push_back({20, "tom"});
+    test_container(v2);
+  }
+
+  SUBCASE("test custom map") {
+    my_map<int, person> v;
+    v.emplace(1, person{20, "tom"});
+    v.emplace(2, person{22, "jerry"});
+    test_container(v);
+  }
+}
+
+void test_tuple_like(auto &v) {
+  auto ret = serialize(v);
+
+  using T = std::remove_cvref_t<decltype(v)>;
+  T v1{};
+  auto ec = deserialize_to(v1, ret.data(), ret.size());
+  CHECK(ec == struct_pack::errc{});
+  CHECK(v == v1);
+}
+
+TEST_CASE("testing tuple") {
+  std::tuple<int, std::string> v = std::make_tuple(1, "hello");
+  test_tuple_like(v);
+
+  std::tuple<int, std::string> v1{};
+  test_tuple_like(v1);
+
+  std::tuple<int, std::string, person> v2{1, "aa", {20, "tom"}};
+  test_tuple_like(v2);
+}
+
+TEST_CASE("test std::pair") {
+  std::pair<int, std::string> v{1, "hello"};
+  test_tuple_like(v);
+
+  std::pair<std::string, person> v1{"aa", {20, "tom"}};
+  test_tuple_like(v1);
+
+  std::pair<std::string, person> v2{};
+  test_tuple_like(v2);
+}
+
+TEST_CASE("testing std::array") {
+  std::array<int, 3> v{1, 2, 3};
+  test_tuple_like(v);
+
+  std::array<std::string, 2> v1{"tom", "jerry"};
+  test_tuple_like(v1);
+
+  std::array<person, 2> v2{person{20, "tom"}, {22, "jerry"}};
+  test_tuple_like(v2);
+
+  std::array<person, 2> v3{};
+  test_tuple_like(v3);
+}
+
+TEST_CASE("test_trivial_copy_tuple") {
+  tuplet::tuple tp = tuplet::make_tuple(1, 2);
+
+  constexpr auto count = detail::member_count<decltype(tp)>();
+  static_assert(count == 2);
+
+  static_assert(std::is_same_v<decltype(tp), tuplet::tuple<int, int>>);
+  static_assert(!std::is_same_v<decltype(tp), std::tuple<int, int>>);
+
+  static_assert(
+      std::is_same_v<decltype(detail::get_types(tp)), tuplet::tuple<int, int>>);
+  static_assert(
+      !std::is_same_v<decltype(detail::get_types(tp)), std::tuple<int, int>>);
+  static_assert(get_type_code<decltype(tp)>() !=
+                get_type_code<std::tuple<int, int>>());
+  constexpr auto i = get_type_literal<decltype(tp)>();
+  static_assert(get_type_literal<decltype(tp)>() !=
+                get_type_literal<std::tuple<int, int>>());
+
+  auto buf = serialize(tp);
+
+  std::tuple<int, int> v{};
+  auto ec = deserialize_to(v, buf);
+  CHECK(ec != struct_pack::errc{});
+
+  decltype(tp) tp1;
+  auto ec2 = deserialize_to(tp1, buf);
+  CHECK(ec2 == struct_pack::errc{});
+  CHECK(tp == tp1);
+}
+
+struct test_obj {
+  int id;
+  std::string str;
+  tuplet::tuple<int, std::string> tp;
+  int d;
+};
+
+TEST_CASE("test_trivial_copy_tuple in an object") {
+  test_obj obj{1, "hello", {2, "tuple"}, 3};
+  auto buf = serialize(obj);
+
+  test_obj obj1;
+  auto ec = deserialize_to(obj1, buf);
+  CHECK(ec == struct_pack::errc{});
+  CHECK(obj.tp == obj1.tp);
+}
+
+void test_c_array(auto &v) {
+  auto ret = serialize(v);
+
+  using T = std::remove_cvref_t<decltype(v)>;
+  T v1{};
+  auto ec = deserialize_to(v1, ret.data(), ret.size());
+  REQUIRE(ec == struct_pack::errc{});
+
+  auto size = std::extent_v<T>;
+  for (int i = 0; i < size; ++i) {
+    CHECK(v[i] == v1[i]);
+  }
+}
+
+TEST_CASE("testing c array") {
+  int v[3] = {1, 2, 3};
+  test_c_array(v);
+  int v1[2] = {};
+  test_c_array(v1);
+
+  std::string v3[2] = {"hello", "world"};
+  test_c_array(v3);
+
+  person v4[2] = {{20, "tom"}, {22, "jerry"}};
+  test_c_array(v4);
+}
+
+enum class enum_i8 : int8_t { hello, hi };
+enum class enum_i32 : int32_t { hello, hi };
+
+TEST_CASE("testing enum") {
+  {
+    enum_i8 e{enum_i8::hi}, e2;
+    auto ret = serialize(e);
+    std::size_t sz;
+    auto ec = deserialize_to(e2, ret.data(), ret.size(), sz);
+    CHECK(ec == struct_pack::errc{});
+    CHECK(sz == ret.size());
+    CHECK(e == e2);
+  }
+  {
+    enum_i8 e{enum_i8::hi};
+    auto ret = serialize(e);
+    auto ec = deserialize<enum_i32>(ret.data(), ret.size());
+    CHECK(!ec);
+    if (!ec) {
+      CHECK(ec.error() == struct_pack::errc::invalid_argument);
+    }
+  }
+  {
+    constexpr auto code_enum_i8 = get_type_code<enum_i8>();
+    constexpr auto code_enum_i32 = get_type_code<enum_i32>();
+    constexpr auto code_i8 = get_type_code<int8_t>();
+    constexpr auto code_i32 = get_type_code<int32_t>();
+    static_assert(code_enum_i8 != code_enum_i32);
+    static_assert(code_enum_i8 == code_i8);
+    static_assert(code_enum_i32 == code_i32);
+  }
+}
+
+TEST_CASE("testing fundamental types") {
+  {
+    std::array ar = {get_type_code<int8_t>(),   get_type_code<int16_t>(),
+                     get_type_code<int32_t>(),  get_type_code<int64_t>(),
+                     get_type_code<uint8_t>(),  get_type_code<uint16_t>(),
+                     get_type_code<uint32_t>(), get_type_code<uint64_t>(),
+                     get_type_code<char>(),     get_type_code<wchar_t>(),
+                     get_type_code<char16_t>(), get_type_code<char32_t>(),
+                     get_type_code<float>(),    get_type_code<double>()};
+    std::sort(ar.begin(), ar.end());
+    CHECK(std::unique(ar.begin(), ar.end()) == ar.end());
+  }
+  {
+    static_assert(get_type_literal<char>() == get_type_literal<char8_t>());
+    static_assert(get_type_literal<signed char>() ==
+                  get_type_literal<int8_t>());
+    static_assert(get_type_literal<unsigned char>() ==
+                  get_type_literal<uint8_t>());
+  }
+}
+
+TEST_CASE("test variant") {
+  {
+    constexpr auto variant_i = get_type_code<std::variant<int>>();
+    constexpr auto variant_i_f = get_type_code<std::variant<int, float>>();
+    constexpr auto i = get_type_code<int>();
+    constexpr auto tuple_i = get_type_code<std::tuple<int>>();
+    static_assert(variant_i != variant_i_f);
+    static_assert(variant_i != i);
+    static_assert(variant_i != tuple_i);
+  }
+  {
+    std::variant<int, double> var = 1.4, var2;
+    auto ret = struct_pack::serialize(var);
+    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(var2 == var);
+  }
+  {
+    std::variant<int, std::monostate> var = std::monostate{}, var2;
+    auto ret = struct_pack::serialize(var);
+    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(var2 == var);
+  }
+  {
+    std::variant<int, int, int, std::monostate, double, double, double> var{
+        std::in_place_index_t<1>{}, 2},
+        var2;
+    auto ret = struct_pack::serialize(var);
+    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(var2 == var);
+    CHECK(var2.index() == 1);
+  }
+  {
+    std::variant<std::monostate, std::string> var{"hello"}, var2;
+    auto ret = struct_pack::serialize(var);
+    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(var2 == var);
+  }
+  {
+    std::tuple<int, std::variant<int, double>, double,
+               std::variant<int, double>, double>
+        var = {1, 2.0, 3.0, 42, 5.0};
+    auto ret = struct_pack::serialize(var);
+    auto res = struct_pack::get_field<decltype(var), 3>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == std::variant<int, double>(42));
+  }
+  { auto ret = struct_pack::serialize(std::tuple<std::monostate>{}); }
+  {
+    std::variant<
+        int8_t, int8_t, int8_t, int8_t, int8_t, int8_t, int8_t, int8_t, int8_t,
+        int8_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t,
+        int16_t, int16_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t,
+        int32_t, int32_t, int32_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+        int64_t, int64_t, int64_t, int64_t, std::string, std::monostate,
+        std::unordered_map<int, std::variant<std::monostate, double, int>>>
+        big_variant =
+            {std::unordered_map<int, std::variant<std::monostate, double, int>>{
+                {1, 1}, {2, 0.2}, {-1, std::monostate{}}}},
+        big_variant2;
+    auto ret = struct_pack::serialize(big_variant);
+    auto ec = struct_pack::deserialize_to(big_variant2, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(big_variant2 == big_variant);
+  }
+}

--- a/src/struct_pack/tests/test_data_struct2.cpp
+++ b/src/struct_pack/tests/test_data_struct2.cpp
@@ -1,0 +1,345 @@
+#include "doctest.h"
+#include "struct_pack/struct_pack.hpp"
+#include "test_struct.hpp"
+using namespace struct_pack;
+
+TEST_CASE("test monostate") {
+  {
+    std::monostate var, var2;
+#ifdef NDEBUG
+    static_assert(struct_pack::get_needed_size(std::monostate{}) == 4);
+#else
+    static_assert(struct_pack::get_needed_size(std::monostate{}) == 7);
+#endif
+    auto ret = struct_pack::serialize(var);
+    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(var2 == var);
+  }
+}
+
+TEST_CASE("test expected") {
+  {
+    tl::expected<int, struct_pack::errc> exp{42}, exp2;
+    auto ret = serialize(exp);
+    auto res = deserialize_to(exp2, ret.data(), ret.size());
+    CHECK(res == struct_pack::errc{});
+    CHECK(exp2 == exp);
+  }
+  {
+    tl::expected<std::vector<int>, struct_pack::errc> exp{
+        std::vector{41, 42, 43}},
+        exp2;
+    auto ret = serialize(exp);
+    auto res = deserialize_to(exp2, ret.data(), ret.size());
+    CHECK(res == struct_pack::errc{});
+    CHECK(exp2 == exp);
+  }
+  {
+    tl::expected<std::vector<int>, std::errc> exp{
+        tl::unexpected{std::errc::address_in_use}},
+        exp2;
+
+    auto ret = serialize(exp);
+    auto res = deserialize_to(exp2, ret.data(), ret.size());
+    CHECK(res == struct_pack::errc{});
+    CHECK(exp2 == exp);
+  }
+}
+
+TEST_CASE("testing object with containers, enum, tuple array, and pair") {
+  complicated_object v{
+      .color = Color::red,
+      .a = 42,
+      .b = "hello",
+      .c = {{20, "tom"}, {22, "jerry"}},
+      .d = {"hello", "world"},
+      .e = {1, 2},
+      .f = {{1, {20, "tom"}}},
+      .g = {{1, {20, "tom"}}, {1, {22, "jerry"}}},
+      .h = {"aa", "bb"},
+      .i = {1, 2},
+      .j = {{1, {20, "tom"}}, {1, {22, "jerry"}}},
+      .k = {{1, 2}, {1, 3}},
+      .m = {person{20, "tom"}, {22, "jerry"}},
+      .n = {person{20, "tom"}, {22, "jerry"}},
+      .o = std::make_pair("aa", person{20, "tom"}),
+  };
+  auto ret = serialize(v);
+
+  complicated_object v1{};
+  auto ec = deserialize_to(v1, ret.data(), ret.size());
+  CHECK(ec == struct_pack::errc{});
+  CHECK(v.a == v1.a);
+
+  CHECK(v == v1);
+
+  SUBCASE("test nested object") {
+    nested_object nested{.id = 2, .name = "tom", .p = {20, "tom"}, .o = v};
+    ret = serialize(nested);
+
+    nested_object nested1{};
+    auto ec = deserialize_to(nested1, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(nested == nested1);
+  }
+
+  SUBCASE("test get_field") {
+    auto ret = serialize(v);
+    complicated_object v1{};
+    auto ec = deserialize_to(v1, ret.data(), ret.size());
+    auto pair = get_field<complicated_object, 2>(ret.data(), ret.size());
+    CHECK(pair);
+    CHECK(pair.value() == "hello");
+    pair = get_field<complicated_object, 2>(ret);
+    CHECK(pair);
+    CHECK(pair.value() == "hello");
+    auto pair1 = get_field<complicated_object, 14>(ret.data(), ret.size());
+    CHECK(pair1);
+    CHECK(pair1.value() == v.o);
+    pair1 = get_field<complicated_object, 14>(ret);
+    CHECK(pair1);
+    CHECK(pair1.value() == v.o);
+
+    auto res = get_field<complicated_object, 14>(ret.data(), 24);
+    CHECK(!res);
+    if (!res) {
+      CHECK(res.error() == struct_pack::errc::no_buffer_space);
+    }
+  }
+  SUBCASE("test get_field_to") {
+    std::string res1;
+    auto ec = get_field_to<complicated_object, 2>(res1, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(res1 == "hello");
+    ec = get_field_to<complicated_object, 2>(res1, ret);
+    CHECK(ec == struct_pack::errc{});
+    CHECK(res1 == "hello");
+    std::pair<std::string, person> res2;
+    ec = get_field_to<complicated_object, 14>(res2, ret.data(), ret.size());
+    CHECK(ec == struct_pack::errc{});
+    CHECK(res2 == v.o);
+    ec = get_field_to<complicated_object, 14>(res2, ret);
+    CHECK(ec == struct_pack::errc{});
+    CHECK(res2 == v.o);
+
+    auto res = get_field_to<complicated_object, 14>(res2, ret.data(), 24);
+    CHECK(ec == struct_pack::errc{});
+    if (ec != struct_pack::errc{}) {
+      CHECK(ec == struct_pack::errc::no_buffer_space);
+    }
+  }
+}
+
+TEST_CASE("testing string_view deserialize") {
+  using namespace std;
+  {
+    auto ret = serialize("hello"sv);
+    auto res = deserialize<string_view>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == "hello"sv);
+  }
+  {
+    std::u32string_view sv = U"你好";
+    auto ret = serialize(sv);
+    auto res = deserialize<std::u32string_view>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == sv);
+  }
+  {
+    std::u16string_view sv = u"你好";
+    auto ret = serialize(sv);
+    auto res = deserialize<std::u16string_view>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == sv);
+  }
+  {
+    std::u8string_view sv = u8"你好";
+    auto ret = serialize(sv);
+    auto res = deserialize<std::u8string_view>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == sv);
+  }
+  {
+    auto ret = serialize("hello"s);
+    auto res = deserialize<string_view>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == "hello"sv);
+  }
+  {
+    std::u32string sv = U"你好";
+    auto ret = serialize(sv);
+    auto res = deserialize<std::u32string_view>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == sv);
+  }
+  {
+    std::u16string sv = u"你好";
+    auto ret = serialize(sv);
+    auto res = deserialize<std::u16string_view>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == sv);
+  }
+  {
+    std::u8string sv = u8"你好";
+    auto ret = serialize(sv);
+    auto res = deserialize<std::u8string_view>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == sv);
+  }
+}
+
+TEST_CASE("test wide string") {
+  using namespace std;
+  {
+    auto sv = std::wstring(L"你好, struct pack");
+    auto ret = serialize(sv);
+    std::wstring str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == sv);
+  }
+  {
+    auto sv = std::u8string(u8"你好, struct pack");
+    auto ret = serialize(sv);
+    std::u8string str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == sv);
+  }
+  {
+    auto sv = std::u16string(u"你好, struct pack");
+    auto ret = serialize(sv);
+    std::u16string str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == sv);
+  }
+  {
+    auto sv = std::u32string(U"你好, struct pack");
+    auto ret = serialize(sv);
+    std::u32string str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == sv);
+  }
+}
+
+TEST_CASE("test string_view") {
+  using namespace std;
+  {
+    auto ret = serialize("hello struct pack"sv);
+    std::string str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == "hello struct pack"sv);
+  }
+  {
+    auto sv = std::wstring_view(L"你好, struct pack");
+    auto ret = serialize(sv);
+    std::wstring str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == sv);
+  }
+  {
+    auto sv = std::u8string_view(u8"你好, struct pack");
+    auto ret = serialize(sv);
+    std::u8string str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == sv);
+  }
+  {
+    auto sv = std::u16string_view(u"你好, struct pack");
+    auto ret = serialize(sv);
+    std::u16string str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == sv);
+  }
+  {
+    auto sv = std::u32string_view(U"你好, struct pack");
+    auto ret = serialize(sv);
+    std::u32string str;
+    auto ec = deserialize_to(str, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(str == sv);
+  }
+}
+
+TEST_CASE("char test") {
+  {
+    char ch = '1', ch2;
+    auto ret = serialize(ch);
+    auto ec = deserialize_to(ch2, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(ch == ch2);
+  }
+  {
+    signed char ch = '1', ch2;
+    auto ret = serialize(ch);
+    auto ec = deserialize_to(ch2, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(ch == ch2);
+  }
+  {
+    unsigned char ch = '1', ch2;
+    auto ret = serialize(ch);
+    auto ec = deserialize_to(ch2, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(ch == ch2);
+  }
+  {
+    wchar_t ch = L'1', ch2;
+    auto ret = serialize(ch);
+    auto ec = deserialize_to(ch2, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(ch == ch2);
+  }
+  {
+    char8_t ch = u8'1', ch2;
+    auto ret = serialize(ch);
+    auto ec = deserialize_to(ch2, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(ch == ch2);
+  }
+  {
+    char16_t ch = u'1', ch2;
+    auto ret = serialize(ch);
+    auto ec = deserialize_to(ch2, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(ch == ch2);
+  }
+  {
+    char32_t ch = U'1', ch2;
+    auto ret = serialize(ch);
+    auto ec = deserialize_to(ch2, ret.data(), ret.size());
+    REQUIRE(ec == struct_pack::errc{});
+    CHECK(ch == ch2);
+  }
+}
+
+TEST_CASE("test deque") {
+  auto raw = std::deque(1e4, 1);
+  auto ret = struct_pack::serialize(raw);
+  std::deque<int> res;
+  auto ec = struct_pack::deserialize_to(res, ret.data(), ret.size());
+  CHECK(ec == struct_pack::errc{});
+  CHECK(raw == res);
+}
+
+TEST_CASE("testing long long") {
+  if constexpr (sizeof(long long) == 8) {
+    auto ret = serialize(-1ll);
+    auto res = deserialize<long long>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == -1ll);
+  }
+  if constexpr (sizeof(unsigned long long) == 8) {
+    auto ret = serialize(1ull);
+    auto res = deserialize<unsigned long long>(ret.data(), ret.size());
+    CHECK(res);
+    CHECK(res.value() == 1ull);
+  }
+}

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -1104,7 +1104,8 @@ TEST_CASE("test varinat size_type") {
   //   std::string str((1ull << 32) - 1, 'A');
   //   auto ret =
   //       serialize<std::string,
-  //                 serialize_config{.add_type_info = type_info_config::disable}>(
+  //                 serialize_config{.add_type_info =
+  //                 type_info_config::disable}>(
   //           str);
   //   CHECK(ret[4] == 0b10000);
   //   CHECK(ret.size() == (1ull << 32) + 8);
@@ -1116,7 +1117,8 @@ TEST_CASE("test varinat size_type") {
   //   std::string str((1ull << 32), 'A');
   //   auto ret =
   //       serialize<std::string,
-  //                 serialize_config{.add_type_info = type_info_config::disable}>(
+  //                 serialize_config{.add_type_info =
+  //                 type_info_config::disable}>(
   //           str);
   //   CHECK(ret[4] == 0b11000);
   //   CHECK(ret.size() == (1ull << 32) + 13);

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <fstream>
 #include <ratio>
 #include <string_view>
 #include <system_error>
@@ -28,81 +29,11 @@
 #include "struct_pack/struct_pack.hpp"
 #undef private
 
-#include <array>
-#include <deque>
-#include <iostream>
-#include <list>
-#include <map>
-#include <memory>
-#include <set>
-#include <span>
-#include <stack>
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <util/expected.hpp>
-#include <vector>
-
 #include "doctest.h"
+#include "test_struct.hpp"
 using namespace struct_pack;
-// the original <=> operator cannot handle different Size
-template <typename Char, std::size_t Size1, std::size_t Size2>
-constexpr bool operator!=(const string_literal<Char, Size1> &s1,
-                          const string_literal<Char, Size2> &s2) {
-  if constexpr (Size1 == Size2) {
-    return s1 != s2;
-  }
-  return true;
-}
 
-struct person {
-  int age;
-  std::string name;
-  auto operator==(const person &rhs) const {
-    return age == rhs.age && name == rhs.name;
-  }
-  bool operator<(person const &p) const {
-    return age < p.age || (age == p.age && name < p.name);
-  }
-};
-
-struct person1 {
-  int age;
-  std::string name;
-  struct_pack::compatible<int32_t> id;
-  struct_pack::compatible<bool> maybe;
-};
-
-struct empty {};
-
-enum class Color { red, black, white };
-
-struct complicated_object {
-  Color color;
-  int a;
-  std::string b;
-  std::vector<person> c;
-  std::list<std::string> d;
-  std::deque<int> e;
-  std::map<int, person> f;
-  std::multimap<int, person> g;
-  std::set<std::string> h;
-  std::multiset<int> i;
-  std::unordered_map<int, person> j;
-  std::unordered_multimap<int, int> k;
-  std::array<person, 2> m;
-  person n[2];
-  std::pair<std::string, person> o;
-};
-
-struct nested_object {
-  int id;
-  std::string name;
-  person p;
-  complicated_object o;
-};
-
-TEST_CASE("testing deserialize_view") {
+TEST_CASE("testing deserialize") {
   person p{.age = 32, .name = "tom"};
   auto ret = serialize(p);
   {
@@ -267,541 +198,6 @@ void test_container(auto &v) {
   CHECK(v == v1);
 }
 
-TEST_CASE("testing long long") {
-  if constexpr (sizeof(long long) == 8) {
-    auto ret = serialize(-1ll);
-    auto res = deserialize<long long>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == -1ll);
-  }
-  if constexpr (sizeof(unsigned long long) == 8) {
-    auto ret = serialize(1ull);
-    auto res = deserialize<unsigned long long>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == 1ull);
-  }
-}
-
-TEST_CASE("testing sequence containers") {
-  SUBCASE("test vector") {
-    std::vector<person> v{{20, "tom"}};
-    test_container(v);
-  }
-  SUBCASE("test list") {
-    std::list<person> v{{20, "tom"}};
-    test_container(v);
-  }
-  SUBCASE("test deque") {
-    std::deque<person> v{{20, "tom"}};
-    test_container(v);
-  }
-}
-
-TEST_CASE("testing associative containers") {
-  SUBCASE("test int map") {
-    std::map<int, person> v{{1, {20, "tom"}}, {2, {22, "jerry"}}};
-    test_container(v);
-  }
-
-  SUBCASE("test string map") {
-    std::map<std::string, person> v{{"aa", {20, "tom"}}, {"bb", {22, "jerry"}}};
-    test_container(v);
-  }
-
-  SUBCASE("test multimap") {
-    std::multimap<int, person> v{{1, {20, "tom"}}, {2, {22, "jerry"}}};
-    test_container(v);
-
-    std::multimap<int, person> v1{{1, {20, "tom"}}, {1, {22, "jerry"}}};
-    test_container(v1);
-
-    std::multimap<int, person> v2{
-        {1, {20, "tom"}}, {1, {22, "jerry"}}, {3, {22, "jack"}}};
-    test_container(v2);
-
-    std::multimap<std::string, person> v3{{"aa", {20, "tom"}},
-                                          {"bb", {22, "jerry"}}};
-    test_container(v3);
-
-    std::multimap<std::string, person> v4{
-        {"dd", {20, "tom"}}, {"aa", {22, "jerry"}}, {"aa", {20, "jack"}}};
-    test_container(v4);
-  }
-
-  SUBCASE("test set") {
-    std::set<int> v{1, 2};
-    test_container(v);
-
-    std::set<std::string> v2{"aa", "bb"};
-    test_container(v2);
-
-    std::set<person> v3{{20, "tom"}, {22, "jerry"}};
-    test_container(v3);
-  }
-
-  SUBCASE("test multiset") {
-    std::multiset<int> v{1, 2, 1, 2};
-    test_container(v);
-
-    std::multiset<std::string> v2{"aa", "bb", "aa"};
-    test_container(v2);
-
-    std::multiset<person> v3{{20, "tom"}, {22, "jerry"}, {20, "jack"}};
-    test_container(v3);
-  }
-}
-
-TEST_CASE("testing unordered associative containers") {
-  SUBCASE("test int map") {
-    std::unordered_map<int, person> v{{1, {20, "tom"}}, {2, {22, "jerry"}}};
-    test_container(v);
-  }
-
-  SUBCASE("test string map") {
-    std::unordered_map<std::string, person> v{{"aa", {20, "tom"}},
-                                              {"bb", {22, "jerry"}}};
-    test_container(v);
-  }
-
-  SUBCASE("test multimap") {
-    std::unordered_map<int, person> v{{1, {20, "tom"}}, {2, {22, "jerry"}}};
-    test_container(v);
-
-    std::unordered_map<int, person> v1{{1, {20, "tom"}}, {1, {22, "jerry"}}};
-    test_container(v1);
-
-    std::unordered_map<int, person> v2{
-        {1, {20, "tom"}}, {1, {22, "jerry"}}, {3, {22, "jack"}}};
-    test_container(v2);
-
-    std::unordered_map<std::string, person> v3{{"aa", {20, "tom"}},
-                                               {"bb", {22, "jerry"}}};
-    test_container(v3);
-
-    std::unordered_map<std::string, person> v4{
-        {"dd", {20, "tom"}}, {"aa", {22, "jerry"}}, {"aa", {20, "jack"}}};
-    test_container(v4);
-  }
-}
-
-TEST_CASE("testing don't support container adaptors") {
-  std::stack<int> s;
-  s.push(1);
-  s.push(2);
-
-  //  struct_pack::packer o{};
-  //  o.serialize(s); //will compile error
-}
-
-// We should not inherit from stl container, this case just for testing.
-template <typename T>
-struct my_vector : public std::vector<T> {};
-
-template <typename Key, typename Value>
-struct my_map : public std::map<Key, Value> {};
-
-TEST_CASE("testing nonstd containers") {
-  SUBCASE("test custom vector") {
-    my_vector<int> v;
-    v.push_back(1);
-    v.push_back(2);
-    test_container(v);
-
-    my_vector<std::string> v1;
-    v1.push_back("aa");
-    v1.push_back("bb");
-    test_container(v1);
-
-    my_vector<person> v2;
-    v2.push_back({20, "tom"});
-    test_container(v2);
-  }
-
-  SUBCASE("test custom map") {
-    my_map<int, person> v;
-    v.emplace(1, person{20, "tom"});
-    v.emplace(2, person{22, "jerry"});
-    test_container(v);
-  }
-}
-
-void test_tuple_like(auto &v) {
-  auto ret = serialize(v);
-
-  using T = std::remove_cvref_t<decltype(v)>;
-  T v1{};
-  auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
-  CHECK(v == v1);
-}
-
-TEST_CASE("testing tuple") {
-  std::tuple<int, std::string> v = std::make_tuple(1, "hello");
-  test_tuple_like(v);
-
-  std::tuple<int, std::string> v1{};
-  test_tuple_like(v1);
-
-  std::tuple<int, std::string, person> v2{1, "aa", {20, "tom"}};
-  test_tuple_like(v2);
-}
-
-TEST_CASE("test std::pair") {
-  std::pair<int, std::string> v{1, "hello"};
-  test_tuple_like(v);
-
-  std::pair<std::string, person> v1{"aa", {20, "tom"}};
-  test_tuple_like(v1);
-
-  std::pair<std::string, person> v2{};
-  test_tuple_like(v2);
-}
-
-TEST_CASE("testing std::array") {
-  std::array<int, 3> v{1, 2, 3};
-  test_tuple_like(v);
-
-  std::array<std::string, 2> v1{"tom", "jerry"};
-  test_tuple_like(v1);
-
-  std::array<person, 2> v2{person{20, "tom"}, {22, "jerry"}};
-  test_tuple_like(v2);
-
-  std::array<person, 2> v3{};
-  test_tuple_like(v3);
-}
-
-TEST_CASE("test_trivial_copy_tuple") {
-  tuplet::tuple tp = tuplet::make_tuple(1, 2);
-
-  constexpr auto count = detail::member_count<decltype(tp)>();
-  static_assert(count == 2);
-
-  static_assert(std::is_same_v<decltype(tp), tuplet::tuple<int, int>>);
-  static_assert(!std::is_same_v<decltype(tp), std::tuple<int, int>>);
-
-  static_assert(
-      std::is_same_v<decltype(detail::get_types(tp)), tuplet::tuple<int, int>>);
-  static_assert(
-      !std::is_same_v<decltype(detail::get_types(tp)), std::tuple<int, int>>);
-  static_assert(get_type_code<decltype(tp)>() !=
-                get_type_code<std::tuple<int, int>>());
-  constexpr auto i = get_type_literal<decltype(tp)>();
-  static_assert(get_type_literal<decltype(tp)>() !=
-                get_type_literal<std::tuple<int, int>>());
-
-  auto buf = serialize(tp);
-
-  std::tuple<int, int> v{};
-  auto ec = deserialize_to(v, buf);
-  CHECK(ec != struct_pack::errc{});
-
-  decltype(tp) tp1;
-  auto ec2 = deserialize_to(tp1, buf);
-  CHECK(ec2 == struct_pack::errc{});
-  CHECK(tp == tp1);
-}
-
-struct test_obj {
-  int id;
-  std::string str;
-  tuplet::tuple<int, std::string> tp;
-  int d;
-};
-
-TEST_CASE("test_trivial_copy_tuple in an object") {
-  test_obj obj{1, "hello", {2, "tuple"}, 3};
-  auto buf = serialize(obj);
-
-  test_obj obj1;
-  auto ec = deserialize_to(obj1, buf);
-  CHECK(ec == struct_pack::errc{});
-  CHECK(obj.tp == obj1.tp);
-}
-
-void test_c_array(auto &v) {
-  auto ret = serialize(v);
-
-  using T = std::remove_cvref_t<decltype(v)>;
-  T v1{};
-  auto ec = deserialize_to(v1, ret.data(), ret.size());
-  REQUIRE(ec == struct_pack::errc{});
-
-  auto size = std::extent_v<T>;
-  for (int i = 0; i < size; ++i) {
-    CHECK(v[i] == v1[i]);
-  }
-}
-
-TEST_CASE("testing c array") {
-  int v[3] = {1, 2, 3};
-  test_c_array(v);
-  int v1[2] = {};
-  test_c_array(v1);
-
-  std::string v3[2] = {"hello", "world"};
-  test_c_array(v3);
-
-  person v4[2] = {{20, "tom"}, {22, "jerry"}};
-  test_c_array(v4);
-}
-
-enum class enum_i8 : int8_t { hello, hi };
-enum class enum_i32 : int32_t { hello, hi };
-
-TEST_CASE("testing enum") {
-  {
-    enum_i8 e{enum_i8::hi}, e2;
-    auto ret = serialize(e);
-    std::size_t sz;
-    auto ec = deserialize_to(e2, ret.data(), ret.size(), sz);
-    CHECK(ec == struct_pack::errc{});
-    CHECK(sz == ret.size());
-    CHECK(e == e2);
-  }
-  {
-    enum_i8 e{enum_i8::hi};
-    auto ret = serialize(e);
-    auto ec = deserialize<enum_i32>(ret.data(), ret.size());
-    CHECK(!ec);
-    if (!ec) {
-      CHECK(ec.error() == struct_pack::errc::invalid_argument);
-    }
-  }
-  {
-    constexpr auto code_enum_i8 = get_type_code<enum_i8>();
-    constexpr auto code_enum_i32 = get_type_code<enum_i32>();
-    constexpr auto code_i8 = get_type_code<int8_t>();
-    constexpr auto code_i32 = get_type_code<int32_t>();
-    static_assert(code_enum_i8 != code_enum_i32);
-    static_assert(code_enum_i8 == code_i8);
-    static_assert(code_enum_i32 == code_i32);
-  }
-}
-
-TEST_CASE("testing fundamental types") {
-  {
-    std::array ar = {get_type_code<int8_t>(),   get_type_code<int16_t>(),
-                     get_type_code<int32_t>(),  get_type_code<int64_t>(),
-                     get_type_code<uint8_t>(),  get_type_code<uint16_t>(),
-                     get_type_code<uint32_t>(), get_type_code<uint64_t>(),
-                     get_type_code<char>(),     get_type_code<wchar_t>(),
-                     get_type_code<char16_t>(), get_type_code<char32_t>(),
-                     get_type_code<float>(),    get_type_code<double>()};
-    std::sort(ar.begin(), ar.end());
-    CHECK(std::unique(ar.begin(), ar.end()) == ar.end());
-  }
-  {
-    static_assert(get_type_literal<char>() == get_type_literal<char8_t>());
-    static_assert(get_type_literal<signed char>() ==
-                  get_type_literal<int8_t>());
-    static_assert(get_type_literal<unsigned char>() ==
-                  get_type_literal<uint8_t>());
-  }
-}
-
-TEST_CASE("test variant") {
-  {
-    constexpr auto variant_i = get_type_code<std::variant<int>>();
-    constexpr auto variant_i_f = get_type_code<std::variant<int, float>>();
-    constexpr auto i = get_type_code<int>();
-    constexpr auto tuple_i = get_type_code<std::tuple<int>>();
-    static_assert(variant_i != variant_i_f);
-    static_assert(variant_i != i);
-    static_assert(variant_i != tuple_i);
-  }
-  {
-    std::variant<int, double> var = 1.4, var2;
-    auto ret = struct_pack::serialize(var);
-    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(var2 == var);
-  }
-  {
-    std::variant<int, std::monostate> var = std::monostate{}, var2;
-    auto ret = struct_pack::serialize(var);
-    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(var2 == var);
-  }
-  {
-    std::variant<int, int, int, std::monostate, double, double, double> var{
-        std::in_place_index_t<1>{}, 2},
-        var2;
-    auto ret = struct_pack::serialize(var);
-    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(var2 == var);
-    CHECK(var2.index() == 1);
-  }
-  {
-    std::variant<std::monostate, std::string> var{"hello"}, var2;
-    auto ret = struct_pack::serialize(var);
-    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(var2 == var);
-  }
-  {
-    std::tuple<int, std::variant<int, double>, double,
-               std::variant<int, double>, double>
-        var = {1, 2.0, 3.0, 42, 5.0};
-    auto ret = struct_pack::serialize(var);
-    auto res = struct_pack::get_field<decltype(var), 3>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == std::variant<int, double>(42));
-  }
-  { auto ret = struct_pack::serialize(std::tuple<std::monostate>{}); }
-  {
-    std::variant<
-        int8_t, int8_t, int8_t, int8_t, int8_t, int8_t, int8_t, int8_t, int8_t,
-        int8_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t,
-        int16_t, int16_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t,
-        int32_t, int32_t, int32_t, int64_t, int64_t, int64_t, int64_t, int64_t,
-        int64_t, int64_t, int64_t, int64_t, std::string, std::monostate,
-        std::unordered_map<int, std::variant<std::monostate, double, int>>>
-        big_variant =
-            {std::unordered_map<int, std::variant<std::monostate, double, int>>{
-                {1, 1}, {2, 0.2}, {-1, std::monostate{}}}},
-        big_variant2;
-    auto ret = struct_pack::serialize(big_variant);
-    auto ec = struct_pack::deserialize_to(big_variant2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(big_variant2 == big_variant);
-  }
-}
-
-TEST_CASE("test monostate") {
-  {
-    std::monostate var, var2;
-#ifdef NDEBUG
-    static_assert(struct_pack::get_needed_size(std::monostate{}) == 4);
-#else
-    static_assert(struct_pack::get_needed_size(std::monostate{}) == 7);
-#endif
-    auto ret = struct_pack::serialize(var);
-    auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(var2 == var);
-  }
-}
-
-TEST_CASE("test expected") {
-  {
-    tl::expected<int, struct_pack::errc> exp{42}, exp2;
-    auto ret = serialize(exp);
-    auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == struct_pack::errc{});
-    CHECK(exp2 == exp);
-  }
-  {
-    tl::expected<std::vector<int>, struct_pack::errc> exp{
-        std::vector{41, 42, 43}},
-        exp2;
-    auto ret = serialize(exp);
-    auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == struct_pack::errc{});
-    CHECK(exp2 == exp);
-  }
-  {
-    tl::expected<std::vector<int>, std::errc> exp{
-        tl::unexpected{std::errc::address_in_use}},
-        exp2;
-
-    auto ret = serialize(exp);
-    auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == struct_pack::errc{});
-    CHECK(exp2 == exp);
-  }
-}
-
-TEST_CASE("testing object with containers, enum, tuple array, and pair") {
-  complicated_object v{
-      .color = Color::red,
-      .a = 42,
-      .b = "hello",
-      .c = {{20, "tom"}, {22, "jerry"}},
-      .d = {"hello", "world"},
-      .e = {1, 2},
-      .f = {{1, {20, "tom"}}},
-      .g = {{1, {20, "tom"}}, {1, {22, "jerry"}}},
-      .h = {"aa", "bb"},
-      .i = {1, 2},
-      .j = {{1, {20, "tom"}}, {1, {22, "jerry"}}},
-      .k = {{1, 2}, {1, 3}},
-      .m = {person{20, "tom"}, {22, "jerry"}},
-      .n = {person{20, "tom"}, {22, "jerry"}},
-      .o = std::make_pair("aa", person{20, "tom"}),
-  };
-  auto ret = serialize(v);
-
-  complicated_object v1{};
-  auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
-  CHECK(v.g == v1.g);
-  CHECK(v.h == v1.h);
-  CHECK(v.i == v1.i);
-  CHECK(v.j == v1.j);
-  CHECK(v.k == v1.k);
-  CHECK(v.m == v1.m);
-  CHECK(v.o == v1.o);
-
-  SUBCASE("test nested object") {
-    nested_object nested{.id = 2, .name = "tom", .p = {20, "tom"}, .o = v1};
-    ret = serialize(nested);
-
-    nested_object nested1{};
-    auto ec = deserialize_to(nested1, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(nested.p == nested1.p);
-    CHECK(nested.name == nested1.name);
-    CHECK(nested.o.m == nested1.o.m);
-    CHECK(nested.o.o == nested1.o.o);
-  }
-
-  SUBCASE("test get_field") {
-    auto pair = get_field<complicated_object, 2>(ret.data(), ret.size());
-    CHECK(pair);
-    CHECK(pair.value() == "hello");
-    pair = get_field<complicated_object, 2>(ret);
-    CHECK(pair);
-    CHECK(pair.value() == "hello");
-    auto pair1 = get_field<complicated_object, 14>(ret.data(), ret.size());
-    CHECK(pair1);
-    CHECK(pair1.value() == v.o);
-    pair1 = get_field<complicated_object, 14>(ret);
-    CHECK(pair1);
-    CHECK(pair1.value() == v.o);
-
-    auto res = get_field<complicated_object, 14>(ret.data(), 24);
-    CHECK(!res);
-    if (!res) {
-      CHECK(res.error() == struct_pack::errc::no_buffer_space);
-    }
-  }
-  SUBCASE("test get_field_to") {
-    std::string res1;
-    auto ec = get_field_to<complicated_object, 2>(res1, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(res1 == "hello");
-    ec = get_field_to<complicated_object, 2>(res1, ret);
-    CHECK(ec == struct_pack::errc{});
-    CHECK(res1 == "hello");
-    std::pair<std::string, person> res2;
-    ec = get_field_to<complicated_object, 14>(res2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
-    CHECK(res2 == v.o);
-    ec = get_field_to<complicated_object, 14>(res2, ret);
-    CHECK(ec == struct_pack::errc{});
-    CHECK(res2 == v.o);
-
-    auto res = get_field_to<complicated_object, 14>(res2, ret.data(), 24);
-    CHECK(ec == struct_pack::errc{});
-    if (ec != struct_pack::errc{}) {
-      CHECK(ec == struct_pack::errc::no_buffer_space);
-    }
-  }
-}
-
 TEST_CASE("testing exceptions") {
   std::string buffer;
   buffer.resize(2);
@@ -821,7 +217,7 @@ TEST_CASE("testing exceptions") {
   CHECK(ret == 0);
 
   std::map<int, std::string> map{{1, "hello"}};
-  size = get_needed_size(pair);
+  size = get_needed_size(map);
   buffer.resize(size);
   ret = serialize_to(buffer.data(), size - 1, map);
   CHECK(ret == 0);
@@ -1148,64 +544,6 @@ TEST_CASE("testing serialize/deserialize varadic params") {
   }
 }
 
-TEST_CASE("testing string_view deserialize") {
-  using namespace std;
-  {
-    auto ret = serialize("hello"sv);
-    auto res = deserialize<string_view>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == "hello"sv);
-  }
-  {
-    std::u32string_view sv = U"你好";
-    auto ret = serialize(sv);
-    auto res = deserialize<std::u32string_view>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == sv);
-  }
-  {
-    std::u16string_view sv = u"你好";
-    auto ret = serialize(sv);
-    auto res = deserialize<std::u16string_view>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == sv);
-  }
-  {
-    std::u8string_view sv = u8"你好";
-    auto ret = serialize(sv);
-    auto res = deserialize<std::u8string_view>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == sv);
-  }
-  {
-    auto ret = serialize("hello"s);
-    auto res = deserialize<string_view>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == "hello"sv);
-  }
-  {
-    std::u32string sv = U"你好";
-    auto ret = serialize(sv);
-    auto res = deserialize<std::u32string_view>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == sv);
-  }
-  {
-    std::u16string sv = u"你好";
-    auto ret = serialize(sv);
-    auto res = deserialize<std::u16string_view>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == sv);
-  }
-  {
-    std::u8string sv = u8"你好";
-    auto ret = serialize(sv);
-    auto res = deserialize<std::u8string_view>(ret.data(), ret.size());
-    CHECK(res);
-    CHECK(res.value() == sv);
-  }
-}
-
 TEST_CASE("testing deserialization") {
   person p{20, "tom"};
   auto ret = serialize(p);
@@ -1312,137 +650,6 @@ TEST_CASE("testing partial deserialization with index") {
   CHECK(pair1.value() == 20);
 }
 
-TEST_CASE("test use wide string") {
-  using namespace std;
-  {
-    auto sv = std::wstring(L"你好, struct pack");
-    auto ret = serialize(sv);
-    std::wstring str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == sv);
-  }
-  {
-    auto sv = std::u8string(u8"你好, struct pack");
-    auto ret = serialize(sv);
-    std::u8string str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == sv);
-  }
-  {
-    auto sv = std::u16string(u"你好, struct pack");
-    auto ret = serialize(sv);
-    std::u16string str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == sv);
-  }
-  {
-    auto sv = std::u32string(U"你好, struct pack");
-    auto ret = serialize(sv);
-    std::u32string str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == sv);
-  }
-}
-
-TEST_CASE("test use string_view") {
-  using namespace std;
-  {
-    auto ret = serialize("hello struct pack"sv);
-    std::string str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == "hello struct pack"sv);
-  }
-  {
-    auto sv = std::wstring_view(L"你好, struct pack");
-    auto ret = serialize(sv);
-    std::wstring str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == sv);
-  }
-  {
-    auto sv = std::u8string_view(u8"你好, struct pack");
-    auto ret = serialize(sv);
-    std::u8string str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == sv);
-  }
-  {
-    auto sv = std::u16string_view(u"你好, struct pack");
-    auto ret = serialize(sv);
-    std::u16string str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == sv);
-  }
-  {
-    auto sv = std::u32string_view(U"你好, struct pack");
-    auto ret = serialize(sv);
-    std::u32string str;
-    auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(str == sv);
-  }
-}
-
-TEST_CASE("char test") {
-  {
-    char ch = '1', ch2;
-    auto ret = serialize(ch);
-    auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(ch == ch2);
-  }
-  {
-    signed char ch = '1', ch2;
-    auto ret = serialize(ch);
-    auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(ch == ch2);
-  }
-  {
-    unsigned char ch = '1', ch2;
-    auto ret = serialize(ch);
-    auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(ch == ch2);
-  }
-  {
-    wchar_t ch = L'1', ch2;
-    auto ret = serialize(ch);
-    auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(ch == ch2);
-  }
-  {
-    char8_t ch = u8'1', ch2;
-    auto ret = serialize(ch);
-    auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(ch == ch2);
-  }
-  {
-    char16_t ch = u'1', ch2;
-    auto ret = serialize(ch);
-    auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(ch == ch2);
-  }
-  {
-    char32_t ch = U'1', ch2;
-    auto ret = serialize(ch);
-    auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
-    CHECK(ch == ch2);
-  }
-}
-
 namespace array_test {
 std::array<std::string, 1> ar0;
 std::array<std::string, 126> ar1;
@@ -1515,7 +722,7 @@ TEST_CASE("test type info config") {
 #ifdef NDEBUG
     {
       auto size = get_needed_size(person{.age = 24, .name = "Betty"});
-      CHECK(size == 17);
+      CHECK(size == 14);
       auto buffer = serialize(person{.age = 24, .name = "Betty"});
       CHECK(buffer.size() == size);
       static_assert(
@@ -1525,7 +732,7 @@ TEST_CASE("test type info config") {
 #else
     {
       auto size = get_needed_size(person{.age = 24, .name = "Betty"});
-      CHECK(size == 26);
+      CHECK(size == 23);
       auto buffer = serialize(person{.age = 24, .name = "Betty"});
       CHECK(buffer.size() == size);
       static_assert(
@@ -1536,7 +743,7 @@ TEST_CASE("test type info config") {
     {
       auto size = get_needed_size<serialize_config{type_info_config::disable}>(
           person{.age = 24, .name = "Betty"});
-      CHECK(size == 17);
+      CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
           person{.age = 24, .name = "Betty"});
@@ -1548,7 +755,7 @@ TEST_CASE("test type info config") {
     {
       auto size = get_needed_size<serialize_config{type_info_config::enable}>(
           person{.age = 24, .name = "Betty"});
-      CHECK(size == 26);
+      CHECK(size == 23);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
           person{.age = 24, .name = "Betty"});
@@ -1562,7 +769,7 @@ TEST_CASE("test type info config") {
     {
       auto size =
           get_needed_size(person_with_type_info{.age = 24, .name = "Betty"});
-      CHECK(size == 26);
+      CHECK(size == 23);
       auto buffer =
           serialize(person_with_type_info{.age = 24, .name = "Betty"});
       CHECK(buffer.size() == size);
@@ -1573,7 +780,7 @@ TEST_CASE("test type info config") {
     {
       auto size = get_needed_size<serialize_config{type_info_config::disable}>(
           person_with_type_info{.age = 24, .name = "Betty"});
-      CHECK(size == 17);
+      CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
           person_with_type_info{.age = 24, .name = "Betty"});
@@ -1585,7 +792,7 @@ TEST_CASE("test type info config") {
     {
       auto size = get_needed_size<serialize_config{type_info_config::enable}>(
           person_with_type_info{.age = 24, .name = "Betty"});
-      CHECK(size == 26);
+      CHECK(size == 23);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
           person_with_type_info{.age = 24, .name = "Betty"});
@@ -1599,7 +806,7 @@ TEST_CASE("test type info config") {
     {
       auto size =
           get_needed_size(person_with_no_type_info{.age = 24, .name = "Betty"});
-      CHECK(size == 17);
+      CHECK(size == 14);
       auto buffer =
           serialize(person_with_no_type_info{.age = 24, .name = "Betty"});
       CHECK(buffer.size() == size);
@@ -1611,7 +818,7 @@ TEST_CASE("test type info config") {
     {
       auto size = get_needed_size<serialize_config{type_info_config::disable}>(
           person_with_no_type_info{.age = 24, .name = "Betty"});
-      CHECK(size == 17);
+      CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
           person_with_no_type_info{.age = 24, .name = "Betty"});
@@ -1623,7 +830,7 @@ TEST_CASE("test type info config") {
     {
       auto size = get_needed_size<serialize_config{type_info_config::enable}>(
           person_with_no_type_info{.age = 24, .name = "Betty"});
-      CHECK(size == 26);
+      CHECK(size == 23);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
           person_with_no_type_info{.age = 24, .name = "Betty"});
@@ -1662,7 +869,7 @@ TEST_CASE("test get field exceptions") {
   person p{20, "tom"};
   auto ret = serialize(p);
 
-  auto pair = get_field<int, 0>(ret.data(), ret.size());
+  auto pair = get_field<std::pair<int, int>, 0>(ret.data(), ret.size());
   CHECK(!pair);
   if (!pair) {
     CHECK(pair.error() == struct_pack::errc::invalid_argument);
@@ -1684,9 +891,9 @@ TEST_CASE("test set_value") {
   std::string s;
   int v;
   int v2 = -1;
-  auto ret1 = in.set_value<0, 0, int, int>(ec, v, std::move(v2));
+  auto ret1 = in.set_value<0, 0, 0, int, int>(ec, v, std::move(v2));
   CHECK(ret1 == true);
-  auto ret2 = in.set_value<0, 1, int, int>(ec, v, std::move(v2));
+  auto ret2 = in.set_value<0, 0, 1, int, int>(ec, v, std::move(v2));
   CHECK(ret2 == false);
 }
 
@@ -1721,36 +928,6 @@ TEST_CASE("test free functions") {
   auto pair1 = get_field<person, 1>(buffer.data(), buffer.size());
   CHECK(pair1);
   CHECK(pair1.value() == "tom");
-}
-
-struct bug_member_count_struct1 {
-  int i;
-  struct hello {
-    std::optional<int> j;
-  } hi;
-  double k = 3;
-};
-
-struct bug_member_count_struct2 : bug_member_count_struct1 {};
-
-template <>
-constexpr std::size_t struct_pack::members_count<bug_member_count_struct2> = 3;
-
-TEST_CASE("test members_count") {
-  {
-    using t = bug_member_count_struct1;
-    t b;
-    auto res = struct_pack::serialize(b);
-    auto ret = struct_pack::deserialize<t>(res.data(), res.size());
-    CHECK(ret);
-  }
-  {
-    using t = bug_member_count_struct2;
-    t b;
-    auto res = struct_pack::serialize(b);
-    auto ret = struct_pack::deserialize<t>(res.data(), res.size());
-    CHECK(ret);
-  }
 }
 
 TEST_CASE("test compatible") {
@@ -1830,9 +1007,9 @@ TEST_CASE("test compatible") {
     }
     {
 #ifdef NDEBUG
-      constexpr size_t array_sz = 65523;
+      constexpr size_t array_sz = 65525;
 #else
-      constexpr size_t array_sz = 65520;
+      constexpr size_t array_sz = 65522;
 #endif
       std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
       std::get<0>(big).value().resize(array_sz);
@@ -1851,9 +1028,9 @@ TEST_CASE("test compatible") {
     }
     {
 #ifdef NDEBUG
-      constexpr size_t array_sz = 65524;
+      constexpr size_t array_sz = 65526;
 #else
-      constexpr size_t array_sz = 65521;
+      constexpr size_t array_sz = 65523;
 #endif
       std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
       std::get<0>(big).value().resize(array_sz);
@@ -1873,17 +1050,81 @@ TEST_CASE("test compatible") {
     // TODO: test 8byte-len compatible object
   }
 }
-#ifndef NDEBUG
-TEST_CASE("test hash confliet detected") {
-  int32_t value = 42;
-  auto ret = serialize(value);
-  auto fake_hash = struct_pack::get_type_code<float>() | 0b1;
-  memcpy(ret.data(), &fake_hash, sizeof(fake_hash));
-  auto res = deserialize<float>(ret);
-  CHECK(!res);
-  CHECK(res.error() == struct_pack::errc::hash_conflict);
+
+TEST_CASE("test varinat size_type") {
+  {
+    std::string str(255, 'A');
+    auto ret =
+        serialize<std::string,
+                  serialize_config{.add_type_info = type_info_config::disable}>(
+            str);
+    CHECK(ret.size() == 260);
+    auto str2 = deserialize<std::string_view>(ret);
+    CHECK(str == str2);
+  }
+  {
+    std::string str(256, 'A');
+    auto ret =
+        serialize<std::string,
+                  serialize_config{.add_type_info = type_info_config::disable}>(
+            str);
+    CHECK(ret[4] == 0b01000);
+    CHECK(ret.size() == 263);
+    auto str2 = deserialize<std::string_view>(ret);
+    CHECK(str2);
+    CHECK(str == str2);
+  }
+  {
+    std::string str(65535, 'A');
+    auto ret =
+        serialize<std::string,
+                  serialize_config{.add_type_info = type_info_config::disable}>(
+            str);
+    CHECK(ret[4] == 0b01000);
+    CHECK(ret.size() == 65542);
+    auto str2 = deserialize<std::string_view>(ret);
+    CHECK(str2);
+    CHECK(str == str2);
+  }
+  {
+    std::string str(65536, 'A');
+    auto ret =
+        serialize<std::string,
+                  serialize_config{.add_type_info = type_info_config::disable}>(
+            str);
+    CHECK(ret[4] == 0b10000);
+    CHECK(ret.size() == 65545);
+    auto str2 = deserialize<std::string_view>(ret);
+    CHECK(str2);
+    CHECK(str.size() == str2->size());
+    CHECK(str == str2);
+  }
+  // test 8 bytes size_type need at least 4GB memory, so we don't test this case
+  // {
+  //   std::string str((1ull << 32) - 1, 'A');
+  //   auto ret =
+  //       serialize<std::string,
+  //                 serialize_config{.add_type_info = type_info_config::disable}>(
+  //           str);
+  //   CHECK(ret[4] == 0b10000);
+  //   CHECK(ret.size() == (1ull << 32) + 8);
+  //   auto str2 = deserialize<std::string_view>(ret);
+  //   CHECK(str2);
+  //   CHECK(str == str2);
+  // }
+  // {
+  //   std::string str((1ull << 32), 'A');
+  //   auto ret =
+  //       serialize<std::string,
+  //                 serialize_config{.add_type_info = type_info_config::disable}>(
+  //           str);
+  //   CHECK(ret[4] == 0b11000);
+  //   CHECK(ret.size() == (1ull << 32) + 13);
+  //   auto str2 = deserialize<std::string_view>(ret);
+  //   CHECK(str2);
+  //   CHECK(str == str2);
+  // }
 }
-#endif
 
 TEST_CASE("test serialize offset") {
   uint32_t offset = 4;
@@ -1948,335 +1189,10 @@ TEST_CASE("test de_serialize offset") {
   }
 }
 
-TEST_CASE("deque") {
-  auto raw = std::deque(1e4, 1);
-  auto ret = struct_pack::serialize(raw);
-  std::deque<int> res;
-  auto ec = struct_pack::deserialize_to(res, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
-  CHECK(raw == res);
-}
 TEST_CASE("compatible convert to optional") {
   std::optional<std::string> a = "hello world";
   struct_pack::compatible<std::string> b = a;
   a = b;
   CHECK(b.value() == "hello world");
   CHECK(a.value() == "hello world");
-}
-struct compatible_in_nested_class {
-  int a;
-  struct_pack::compatible<int> c;
-};
-
-TEST_CASE("compatible not in the end of struct") {
-  static_assert(
-      detail::check_if_compatible_element_exist<
-          0, int, struct_pack::compatible<short>, std::string>() == -1,
-      "compatible member not in the end is illegal!");
-  static_assert(detail::check_if_compatible_element_exist<
-                    0, int, compatible_in_nested_class>() == -1,
-                "compatible member in the nested class is illegal!");
-  static_assert(
-      detail::check_if_compatible_element_exist<0, compatible_in_nested_class,
-                                                double>() == -1,
-      "compatible member in the nested class is illegal!");
-  static_assert(
-      detail::check_if_compatible_element_exist<
-          0, double, std::tuple<int, double, compatible<std::string>>>() == -1,
-      "compatible member in the nested class is illegal!");
-}
-
-struct type_calculate_test_1 {
-  tuplet::tuple<
-      std::pair<std::map<int, std::string>, std::vector<std::list<int>>>,
-      std::set<int>, std::array<int64_t, 64>, std::optional<int>>
-      a;
-};
-struct type_calculate_test_2 {
-  struct {
-    tuplet::tuple<std::unordered_map<int, std::string>,
-                  std::deque<std::vector<int>>>
-        a;
-    std::multiset<int> b;
-    int64_t c[64];
-    std::optional<int> d;
-  } e;
-};
-
-struct type_calculate_test_3 {
-  struct {
-    std::pair<std::unordered_map<int, std::string>,
-              std::deque<std::vector<double>>>
-        a;
-    std::multiset<int> b;
-    int64_t c[64];
-    std::optional<int> d;
-  } e;
-};
-
-TEST_CASE("type calculate") {
-  static_assert(std::is_trivially_copyable<struct_pack::compatible<int>>::value,
-                "must be true");
-
-  {
-    static_assert(get_type_code<std::vector<int>>() !=
-                      get_type_code<std::vector<float>>(),
-                  "vector<T> with different T should get different MD5");
-    CHECK(!deserialize<std::vector<int>>(serialize(std::vector<float>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::deque<int>>() != get_type_code<std::deque<float>>(),
-        "deque<T> with different T should get different MD5");
-    CHECK(!deserialize<std::deque<int>>(serialize(std::deque<float>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::list<int>>() != get_type_code<std::list<float>>(),
-        "list<T> with different T should get different MD5");
-    CHECK(!deserialize<std::list<int>>(serialize(std::list<float>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::set<int>>() != get_type_code<std::set<float>>(),
-        "set<T> with different T should get different MD5");
-    CHECK(!deserialize<std::set<int>>(serialize(std::set<float>{})));
-  }
-  {
-    static_assert(get_type_code<std::map<int, std::string>>() !=
-                      get_type_code<std::map<float, std::string>>(),
-                  "map<T1,T2> with different T1 should get different MD5");
-    CHECK(!deserialize<std::map<int, std::string>>(
-        serialize(std::map<float, std::string>{})));
-  }
-
-  {
-    static_assert(get_type_code<std::map<std::string, int>>() !=
-                      get_type_code<std::map<std::string, float>>(),
-                  "map<T1,T2> with different T2 should get different MD5");
-    CHECK(!deserialize<std::map<std::string, int>>(
-        serialize(std::map<std::string, float>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::unordered_map<int, std::string>>() !=
-            get_type_code<std::unordered_map<float, std::string>>(),
-        "unordered_map<T1,T2> with different T1 should get different MD5");
-    CHECK(!deserialize<std::unordered_map<int, std::string>>(
-        serialize(std::unordered_map<float, std::string>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::unordered_map<std::string, int>>() !=
-            get_type_code<std::unordered_map<std::string, float>>(),
-        "unordered_map<T1,T2> with different T2 should get different MD5");
-    CHECK(!deserialize<std::unordered_map<std::string, int>>(
-        serialize(std::unordered_map<std::string, float>{})));
-  }
-  {
-    static_assert(get_type_code<std::unordered_set<int>>() !=
-                      get_type_code<std::unordered_set<float>>(),
-                  "unordered_set<T> with different T should get different MD5");
-    CHECK(!deserialize<std::unordered_set<int>>(
-        serialize(std::unordered_set<float>{})));
-  }
-  {
-    static_assert(get_type_code<std::array<int, 5>>() !=
-                      get_type_code<std::array<float, 5>>(),
-                  "array<T,sz> with different T should get different MD5");
-    CHECK(!deserialize<std::array<int, 5>>(serialize(std::array<float, 5>{})));
-  }
-  {
-    static_assert(get_type_code<std::array<int, 5>>() !=
-                      get_type_code<std::array<int, 6>>(),
-                  "array<T,sz> with different sz should get different MD5");
-    CHECK(!deserialize<std::array<int, 5>>(serialize(std::array<int, 6>{})));
-  }
-  {
-    static_assert(get_type_code<int[5]>() != get_type_code<float[5]>(),
-                  "T[sz] with different T should get different MD5");
-    int ar[5] = {};
-    float ar2[5] = {};
-    CHECK(deserialize_to(ar2, serialize(ar)) != struct_pack::errc{});
-  }
-  {
-    static_assert(get_type_code<int[5]>() != get_type_code<int[6]>(),
-                  "T[sz] with different sz should get different MD5");
-    int ar[5] = {};
-    int ar2[6] = {};
-    CHECK(deserialize_to(ar2, serialize(ar)) != struct_pack::errc{});
-  }
-  {
-    static_assert(get_type_code<std::optional<int>>() !=
-                      get_type_code<std::optional<float>>(),
-                  "optional<T> with different T should get different MD5");
-    CHECK(!deserialize<std::array<int, 5>>(serialize(std::array<int, 6>{})));
-  }
-  {
-    static_assert(
-        get_type_code<int, float, int>() != get_type_code<int, int, int>(),
-        "T... with different T... should get different MD5");
-    CHECK(!deserialize<int, int>(serialize(1, 2, 3)));
-  }
-  {
-    static_assert(get_type_code<std::tuple<int, float, int>>() !=
-                      get_type_code<std::tuple<int, int, int>>(),
-                  "tuple<T...> with different T... should get different MD5");
-    CHECK(!deserialize<int, int>(serialize(1, 2, 3)));
-  }
-  {
-    static_assert(get_type_code<std::tuple<int, float, int>>() ==
-                      get_type_code<int, float, int>(),
-                  "tuple<T...> and T... should get same MD5");
-    CHECK(deserialize<std::tuple<int, float, int>>(serialize(1, 2.0f, 3)));
-  }
-  {
-    static_assert(get_type_code<std::pair<int, int>>() !=
-                      get_type_code<std::pair<float, int>>(),
-                  "pair<T1,T2> with different T1 should get different MD5");
-    CHECK(!deserialize<std::pair<int, int>>(serialize(std::pair{1.3f, 1})));
-  }
-  {
-    static_assert(get_type_code<std::pair<int, float>>() !=
-                      get_type_code<std::pair<int, int>>(),
-                  "pair<T1,T2> with different T2 should get different MD5");
-    CHECK(!deserialize<std::pair<int, float>>(serialize(std::pair{1, 1})));
-  }
-  {
-    static_assert(
-        get_type_code<complicated_object>() != get_type_code<person>(),
-        "class{T...} with different T... should get different MD5");
-    CHECK(!deserialize<complicated_object>(serialize(person{})));
-  }
-  {
-    static_assert(
-        get_type_code<compatible<int>>() == get_type_code<compatible<float>>(),
-        "compatible<T> with different T should get same MD5");
-    CHECK(deserialize<compatible<int>>(serialize(compatible<float>{1})));
-  }
-  {
-    static_assert(
-        get_type_code<std::list<int>>() == get_type_code<std::vector<int>>(),
-        "different class accord with container concept should get same MD5");
-    CHECK(deserialize<std::list<int>>(serialize(std::vector<int>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::deque<int>>() == get_type_code<std::vector<int>>(),
-        "different class accord with container concept should get same MD5");
-    CHECK(deserialize<std::deque<int>>(serialize(std::vector<int>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::deque<int>>() == get_type_code<std::list<int>>(),
-        "different class accord with container concept should get same MD5");
-    CHECK(deserialize<std::deque<int>>(serialize(std::list<int>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::array<int, 5>>() == get_type_code<int[5]>(),
-        "different class accord with array concept should get same MD5");
-    int ar[5] = {};
-    CHECK(deserialize<std::array<int, 5>>(serialize(ar)));
-  }
-  {
-    static_assert(
-        get_type_code<std::map<int, int>>() ==
-            get_type_code<std::unordered_map<int, int>>(),
-        "different class accord with map concept should get same MD5");
-    CHECK(deserialize<std::map<int, int>>(
-        serialize(std::unordered_map<int, int>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::set<int>>() ==
-            get_type_code<std::unordered_set<int>>(),
-        "different class accord with set concept should get same MD5");
-    CHECK(deserialize<std::set<int>>(serialize(std::unordered_set<int>{})));
-  }
-  {
-    static_assert(
-        get_type_code<std::pair<int, std::string>>() == get_type_code<person>(),
-        "different class accord with trival_class concept should "
-        "get same MD5");
-    CHECK(deserialize<std::pair<int, std::string>>(serialize(person{})));
-  }
-  {
-    static_assert(get_type_code<tuplet::tuple<int, std::string>>() ==
-                      get_type_code<person>(),
-                  "different class accord with trival_class concept should "
-                  "get same MD5");
-    CHECK(deserialize<tuplet::tuple<int, std::string>>(serialize(person{})));
-  }
-  {
-    static_assert(get_type_code<std::pair<int, std::string>>() ==
-                      get_type_code<tuplet::tuple<int, std::string>>(),
-                  "different class accord with trival_class concept should "
-                  "get same MD5");
-    CHECK(deserialize<std::pair<int, std::string>>(
-        serialize(tuplet::tuple<int, std::string>{})));
-  }
-  {
-    static_assert(get_type_code<std::tuple<int, std::string>>() !=
-                      get_type_code<person>(),
-                  "different class accord and trival_class"
-                  "concept should get different MD5");
-    CHECK(!deserialize<std::tuple<int, std::string>>(serialize(person{})));
-  }
-  {
-    static_assert(get_type_code<std::pair<int, std::string>>() !=
-                      get_type_code<std::tuple<int, std::string>>(),
-                  "different class accord and trival_class concept should "
-                  "get different MD5");
-    CHECK(!deserialize<std::pair<int, std::string>>(
-        serialize(std::tuple<int, std::string>{})));
-  }
-  {
-    static_assert(get_type_code<type_calculate_test_1>() ==
-                      get_type_code<type_calculate_test_2>(),
-                  "struct type_calculate_test_1 && type_calculate_test_2 "
-                  "should get the "
-                  "same MD5");
-    CHECK(
-        deserialize<type_calculate_test_1>(serialize(type_calculate_test_2{})));
-  }
-
-  {
-    static_assert(get_type_code<type_calculate_test_1>() !=
-                      get_type_code<type_calculate_test_3>(),
-                  "struct type_calculate_test_1 && type_calculate_test_3 "
-                  "should get the "
-                  "different MD5");
-    CHECK(!deserialize<type_calculate_test_1>(
-        serialize(type_calculate_test_3{})));
-  }
-
-  {
-    static_assert(get_type_code<int>() != get_type_code<std::tuple<int>>(),
-                  "T & tuple<T> should get different MD5");
-    CHECK(!deserialize<int>(serialize(std::tuple<int>{})));
-  }
-
-  {
-    static_assert(get_type_code<int>() != get_type_code<tuplet::tuple<int>>(),
-                  "T & tuple_::tuple<T> should get different MD5");
-    CHECK(!deserialize<int>(serialize(tuplet::tuple<int>{})));
-  }
-
-  {
-    static_assert(get_type_code<std::tuple<int>>() !=
-                      get_type_code<std::tuple<std::tuple<int>>>(),
-                  "tuple<T> & tuple<tuple<T>> should get different MD5");
-    CHECK(!deserialize<std::tuple<int>>(
-        serialize(std::tuple<std::tuple<int>>{})));
-  }
-
-  {
-    static_assert(
-        get_type_code<std::tuple<int>, int>() !=
-            get_type_code<std::tuple<int, int>>(),
-        "tuple<tuple<T1>,T2> & tuple<tuple<T1,T2>> should get different MD5");
-    CHECK(!deserialize<std::tuple<std::tuple<int>, int>>(
-        serialize(std::tuple<std::tuple<int, int>>{})));
-  }
 }

--- a/src/struct_pack/tests/test_struct.hpp
+++ b/src/struct_pack/tests/test_struct.hpp
@@ -1,0 +1,68 @@
+#include <array>
+#include <deque>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <span>
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <util/expected.hpp>
+#include <vector>
+
+#include "struct_pack/struct_pack.hpp"
+struct person {
+  int age;
+  std::string name;
+  auto operator==(const person &rhs) const {
+    return age == rhs.age && name == rhs.name;
+  }
+  bool operator<(person const &p) const {
+    return age < p.age || (age == p.age && name < p.name);
+  }
+};
+
+struct person1 {
+  int age;
+  std::string name;
+  struct_pack::compatible<int32_t> id;
+  struct_pack::compatible<bool> maybe;
+};
+
+struct empty {};
+
+enum class Color { red, black, white };
+
+struct complicated_object {
+  Color color;
+  int a;
+  std::string b;
+  std::vector<person> c;
+  std::list<std::string> d;
+  std::deque<int> e;
+  std::map<int, person> f;
+  std::multimap<int, person> g;
+  std::set<std::string> h;
+  std::multiset<int> i;
+  std::unordered_map<int, person> j;
+  std::unordered_multimap<int, int> k;
+  std::array<person, 2> m;
+  person n[2];
+  std::pair<std::string, person> o;
+  bool operator==(const complicated_object &o) const {
+    return color == o.color && a == o.a && b == o.b && c == o.c && d == o.d &&
+           e == o.e && f == o.f && g == o.g && h == o.h && i == o.i &&
+           j == o.j && k == o.k && m == o.m && n[0] == o.n[0] &&
+           n[1] == o.n[1] && this->o == o.o;
+  }
+};
+
+struct nested_object {
+  int id;
+  std::string name;
+  person p;
+  complicated_object o;
+  bool operator==(const nested_object &o) const = default;
+};


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The container's size is fixed which is defined by a marco in old version struct_pack. However, it's hard to determine the max size of container/string in compile time. And the binary with different width of container size is not portable.

## What is changing

Now we support variant container size in runtime. User don't need to worry about if they have a big string(There is no limit now).

If the max size of all container in the struct is in the range of [0,256), the size_type's length is 1 byte.   
[0,256) ->1 byte size_type
[256,65536) -> 2 bytes size_type   
[65536,2^32) -> 4 bytes size_type
[2^32,2^64)-> 8 bytes size_type

In Clang 13, The performance is even better (about 10% in serialize & 5% in deserialization) than the old version due to the decrease size of serialize result. However, due to the template code inflation, the binary size & compile time will slower than previous code. We use marco `STRUCT_PACK_OPTIMIZE` to remit this problem. If you like to sacrifice compilation time and binary size for performance, just define this marco.