### PR TITLE
refactor struct_pack benchmark

### DIFF
--- a/src/struct_pack/benchmark/CMakeLists.txt
+++ b/src/struct_pack/benchmark/CMakeLists.txt
@@ -1,10 +1,40 @@
 option(MSGPACK_USE_BOOST OFF)
-find_package(Protobuf REQUIRED)
-execute_process(
-        COMMAND protoc benchmark.proto --cpp_out=. -I ${CMAKE_CURRENT_SOURCE_DIR}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/benchmark
-)
-add_executable(struct_pack_benchmark benchmark.cpp no_op.cpp ${CMAKE_BINARY_DIR}/benchmark/benchmark.pb.cc)
-target_include_directories(struct_pack_benchmark PUBLIC ${CMAKE_BINARY_DIR}/benchmark/)
-target_link_libraries(struct_pack_benchmark ${Protobuf_LIBRARIES})
-target_compile_definitions(struct_pack_benchmark PRIVATE MSGPACK_NO_BOOST STRUCT_PACK_OPTIMIZE)
+find_package(Protobuf)
+find_package(msgpack)
+add_executable(struct_pack_benchmark benchmark.cpp no_op.cpp)
+target_link_libraries(struct_pack_benchmark PRIVATE libstruct_pack)
+target_compile_definitions(struct_pack_benchmark PRIVATE STRUCT_PACK_OPTIMIZE)
+if (Protobuf_FOUND)
+    message(STATUS "Protobuf_FOUND: ${Protobuf_FOUND}")
+    target_link_libraries(struct_pack_benchmark PRIVATE protobuf::libprotobuf)
+    target_compile_definitions(struct_pack_benchmark PRIVATE HAVE_PROTOBUF)
+    protobuf_generate_cpp(STRUCT_PACK_BENCHMARK_PROTO_SRCS STRUCT_PACK_BENCHMARK_PROTO_HDRS benchmark.proto)
+    target_include_directories(struct_pack_benchmark PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+    target_sources(struct_pack_benchmark PRIVATE
+            ${STRUCT_PACK_BENCHMARK_PROTO_SRCS}
+            ${STRUCT_PACK_BENCHMARK_PROTO_HDRS}
+            )
+    message(STATUS "STRUCT_PACK_BENCHMARK_PROTO_SRCS: ${STRUCT_PACK_BENCHMARK_PROTO_SRCS}")
+    message(STATUS "STRUCT_PACK_BENCHMARK_PROTO_HDRS: ${STRUCT_PACK_BENCHMARK_PROTO_HDRS}")
+endif ()
+if (msgpack_FOUND)
+    message(STATUS "msgpack_FOUND: ${msgpack_FOUND}")
+    target_link_libraries(struct_pack_benchmark PRIVATE msgpackc-cxx)
+    target_compile_definitions(struct_pack_benchmark PRIVATE MSGPACK_NO_BOOST)
+    target_compile_definitions(struct_pack_benchmark PRIVATE HAVE_MSGPACK)
+endif ()
+if (EXISTS ${CMAKE_SOURCE_DIR}/thirdparty/protopuf/include)
+    message(STATUS "struct_pack benchmark HAVE_PROTOPUF")
+    target_include_directories(struct_pack_benchmark PRIVATE
+            ${CMAKE_SOURCE_DIR}/thirdparty/protopuf/include
+            )
+    target_compile_definitions(struct_pack_benchmark PRIVATE HAVE_PROTOPUF)
+endif ()
+
+if (EXISTS ${CMAKE_SOURCE_DIR}/thirdparty/protozero/include)
+    message(STATUS "struct_pack benchmark HAVE_PROTOZERO")
+    target_include_directories(struct_pack_benchmark PRIVATE
+            ${CMAKE_SOURCE_DIR}/thirdparty/protozero/include
+            )
+    target_compile_definitions(struct_pack_benchmark PRIVATE HAVE_PROTOZERO)
+endif ()

--- a/src/struct_pack/benchmark/README.md
+++ b/src/struct_pack/benchmark/README.md
@@ -1,0 +1,37 @@
+# struct_pack benchmark
+
+## How to?
+
+- download dependencies
+
+assume in `REPO_ROOT`
+
+msgpack, see https://github.com/msgpack/msgpack-c/tree/cpp_master
+
+protobuf, see https://github.com/protocolbuffers/protobuf
+
+```shell
+cd thirdparty
+git clone https://github.com/PragmaTwice/protopuf.git
+git clone https://github.com/mapbox/protozero.git
+```
+
+- build
+
+assume in `REPO_ROOT`
+
+```shell
+mkdir build
+cd build
+cmake ..
+make -j struct_pack_benchmark
+```
+- run
+
+assume in `REPO_ROOT`
+
+```shell
+cd build
+./src/struct_pack/benchmark/struct_pack_benchmark
+```
+

--- a/src/struct_pack/benchmark/ScopedTimer.hpp
+++ b/src/struct_pack/benchmark/ScopedTimer.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <chrono>
+#include <iostream>
+
+class ScopedTimer {
+ public:
+  ScopedTimer(const char *name)
+      : m_name(name), m_beg(std::chrono::high_resolution_clock::now()) {}
+  ScopedTimer(const char *name, uint64_t &ns) : ScopedTimer(name) {
+    m_ns = &ns;
+  }
+  ~ScopedTimer() {
+    auto end = std::chrono::high_resolution_clock::now();
+    auto dur =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end - m_beg);
+    if (m_ns)
+      *m_ns = dur.count();
+    else
+      std::cout << m_name << " : " << dur.count() << " ns\n";
+  }
+
+ private:
+  const char *m_name;
+  std::chrono::time_point<std::chrono::high_resolution_clock> m_beg;
+  uint64_t *m_ns = nullptr;
+};

--- a/src/struct_pack/benchmark/bench.hpp
+++ b/src/struct_pack/benchmark/bench.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <iostream>
+
+#include "config.hpp"
+
+template <typename BaselineSample, typename ContenderSample>
+void report_cmp_serialize(const std::string& tag,
+                          const BaselineSample& baseline,
+                          const ContenderSample& contender) {
+  std::cout << tag << " ";
+  std::cout << pretty_name(baseline.name()) << "   serialize is ";
+  std::cout << pretty_float((double)get_avg(contender.serialize_cost_) /
+                            get_avg(baseline.serialize_cost_));
+  std::cout << " times faster than " << pretty_name(contender.name());
+  std::cout << std::endl;
+}
+template <typename BaselineSample, typename ContenderSample>
+void report_cmp_deserialize(const std::string& tag,
+                            const BaselineSample& baseline,
+                            const ContenderSample& contender) {
+  std::cout << tag << " ";
+  std::cout << pretty_name(baseline.name()) << " deserialize is ";
+  std::cout << pretty_float((double)get_avg(contender.deserialize_cost_) /
+                            get_avg(baseline.deserialize_cost_));
+  std::cout << " times faster than " << pretty_name(contender.name());
+  std::cout << std::endl;
+}
+
+template <typename BaselineSample, typename... ContenderSamples>
+void bench(std::string tag, BaselineSample baseline,
+           ContenderSamples... contenders) {
+  std::cout << "------- start benchmark " << tag << " -------" << std::endl;
+  baseline.clear_buffer();
+  (contenders.clear_buffer(), ...);
+  baseline.reserve_buffer();
+  (contenders.reserve_buffer(), ...);
+  for (std::size_t i = 0; i < RUN_COUNT; ++i) {
+    baseline.clear_buffer();
+    (contenders.clear_buffer(), ...);
+    baseline.do_serialization(i);
+    (contenders.do_serialization(i), ...);
+  }
+  for (std::size_t i = 0; i < RUN_COUNT; ++i) {
+    baseline.clear_data();
+    (contenders.clear_data(), ...);
+    baseline.do_deserialization(i);
+    (contenders.do_deserialization(i), ...);
+  }
+  baseline.report_metric(tag);
+  (contenders.report_metric(tag), ...);
+  (report_cmp_serialize(tag, baseline, contenders), ...);
+  (report_cmp_deserialize(tag, baseline, contenders), ...);
+  std::cout << "------- end benchmark   " << tag << " -------";
+  std::cout << std::endl;
+  std::cout << std::endl;
+}

--- a/src/struct_pack/benchmark/benchmark.cpp
+++ b/src/struct_pack/benchmark/benchmark.cpp
@@ -1,469 +1,54 @@
-/*
- * Copyright (c) 2022, Alibaba Group Holding Limited;
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-#include <atomic>
-#include <msgpack.hpp>
-#include <numeric>
-#include <thread>
-#include <valarray>
+#include "struct_pack_sample.hpp"
+#ifdef HAVE_MSGPACK
+#include "msgpack_sample.hpp"
+#endif
+#ifdef HAVE_PROTOBUF
+#include "protobuf_sample.hpp"
+#endif
+#ifdef HAVE_PROTOPUF
+#include "protopuf_sample.hpp"
+#endif
+#ifdef HAVE_PROTOZERO
+#include "protozero_sample.hpp"
+#endif
 
-#include "benchmark.pb.h"
-#include "no_op.h"
-#include "struct_pack/struct_pack.hpp"
+#include <string>
 
-class ScopedTimer {
- public:
-  ScopedTimer(const char *name)
-      : m_name(name), m_beg(std::chrono::high_resolution_clock::now()) {}
-  ScopedTimer(const char *name, uint64_t &ns) : ScopedTimer(name) {
-    m_ns = &ns;
-  }
-  ~ScopedTimer() {
-    auto end = std::chrono::high_resolution_clock::now();
-    auto dur =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(end - m_beg);
-    if (m_ns)
-      *m_ns = dur.count();
-    else
-      std::cout << m_name << " : " << dur.count() << " ns\n";
-  }
+#include "bench.hpp"
+#include "config.hpp"
+using namespace std::string_literals;
 
- private:
-  const char *m_name;
-  std::chrono::time_point<std::chrono::high_resolution_clock> m_beg;
-  uint64_t *m_ns = nullptr;
-};
-
-struct person {
-  int32_t id;
-  std::string name;
-  int age;
-  double salary;
-  MSGPACK_DEFINE(id, name, age, salary);
-};
-
-namespace struct_pack {
-template <>
-constexpr inline auto enable_type_info<person> = type_info_config::disable;
-};
-
-namespace struct_pack {
-template <>
-constexpr inline auto enable_type_info<std::vector<person>> =
-    type_info_config::disable;
-};
-
-template <typename T>
-T get_max() {
-  if constexpr (std::is_same_v<T, int8_t>) {
-    return 127;
-  }
-  else if constexpr (std::is_same_v<T, uint8_t>) {
-    return 255;
-  }
-  else if constexpr (std::is_same_v<T, int16_t>) {
-    return 32767;
-  }
-  else if constexpr (std::is_same_v<T, uint16_t>) {
-    return 65535;
-  }
-  else if constexpr (std::is_same_v<T, int32_t>) {
-    return INT_MAX - 1;
-  }
-  else if constexpr (std::is_same_v<T, uint32_t>) {
-    return UINT_MAX - 1;
-  }
-  else if constexpr (std::is_same_v<T, int64_t>) {
-    return LLONG_MAX - 1;
-  }
-  else if constexpr (std::is_same_v<T, uint64_t>) {
-    return ULLONG_MAX - 1;
-  }
-
-  return {};
+template <SampleType sample_type>
+void bench_struct_pack() {
+  std::string tag = get_tag_name<sample_type>();
+  bench(tag, create_sample<sample_type>()
+#ifdef HAVE_MSGPACK
+                 ,
+        msgpack_sample::create_sample<sample_type>()
+#endif
+#ifdef HAVE_PROTOBUF
+            ,
+        protobuf_sample::create_sample<sample_type>()
+#endif
+#ifdef HAVE_PROTOPUF
+            ,
+        protopuf_sample::create_sample<sample_type>()
+#endif
+#ifdef HAVE_PROTOZERO
+            ,
+        protozero_sample::create_sample<sample_type>()
+#endif
+  );
 }
 
-template <typename T>
-struct rect {
-  T x = get_max<T>();
-  T y = get_max<T>();
-  T width = get_max<T>();
-  T height = get_max<T>();
-  MSGPACK_DEFINE(x, y, width, height);
-};
-
-namespace struct_pack {
-template <>
-constexpr inline auto enable_type_info<rect<int32_t>> =
-    type_info_config::disable;
-};
-
-namespace struct_pack {
-template <>
-constexpr inline auto enable_type_info<std::vector<rect<int32_t>>> =
-    type_info_config::disable;
-};
-
-enum Color : uint8_t { Red, Green, Blue };
-
-struct Vec3 {
-  float x;
-  float y;
-  float z;
-
-  bool operator==(const Vec3 &rhs) const {
-    std::valarray<float> lh({x, y, z});
-    std::valarray<float> rh({rhs.x, rhs.y, rhs.z});
-    return (std::abs(lh - rh) < 0.05f).min();
-  };
-  MSGPACK_DEFINE(x, y, z);
-};
-
-struct Weapon {
-  std::string name;
-  int16_t damage;
-
-  bool operator==(const Weapon &rhs) const {
-    return name == rhs.name && damage == rhs.damage;
-  };
-  MSGPACK_DEFINE(name, damage);
-};
-
-struct Monster {
-  Vec3 pos;
-  int16_t mana;
-  int16_t hp;
-  std::string name;
-  std::vector<uint8_t> inventory;
-  Color color;
-  std::vector<Weapon> weapons;
-  Weapon equipped;
-  std::vector<Vec3> path;
-
-  bool operator==(const Monster &rhs) const {
-    return pos == rhs.pos && mana == rhs.mana && hp == rhs.hp &&
-           name == rhs.name && inventory == rhs.inventory &&
-           color == rhs.color && weapons == rhs.weapons &&
-           equipped == rhs.equipped && path == rhs.path;
-  };
-  MSGPACK_DEFINE(pos, mana, hp, name, inventory, (int &)color, weapons,
-                 equipped, path);
-};
-
-namespace struct_pack {
-template <>
-constexpr inline auto enable_type_info<Monster> = type_info_config::disable;
-};
-
-namespace struct_pack {
-template <>
-constexpr inline auto enable_type_info<std::vector<Monster>> =
-    type_info_config::disable;
-};
-
-static constexpr int OBJECT_COUNT = 20;
-static constexpr int SAMPLES_COUNT = 100000;
-
-template <typename T>
-inline uint64_t get_avg(const T &v) {
-  uint64_t sum = std::accumulate(v.begin(), v.end(), uint64_t(0));
-  return sum / v.size();
+void bench_all_struct_pack() {
+  bench_struct_pack<SampleType::MONSTER>();
+  bench_struct_pack<SampleType::MONSTERS>();
 }
+int main(int argc, char** argv) {
+  std::cout << "OBJECT_COUNT : " << OBJECT_COUNT << std::endl;
+  std::cout << "SAMPLES_COUNT: " << SAMPLES_COUNT << std::endl;
 
-struct tbuffer : public std::vector<char> {
-  void write(const char *src, size_t sz) {
-    this->resize(this->size() + sz);
-    auto pos = this->data() + this->size() - sz;
-    std::memcpy(pos, src, sz);
-  }
-};
-
-std::vector<char> buffer1;
-tbuffer buffer2;
-std::string buffer3;
-
-template <typename T, typename PB>
-void bench(T &t, PB &p, std::string tag) {
-  buffer1.clear();
-  buffer2.clear();
-  buffer3.clear();
-
-  std::cout << "------- start benchmark " << tag << " -------\n";
-
-  buffer1.reserve(struct_pack::get_needed_size(t));
-  msgpack::pack(buffer2, t);
-  buffer2.reserve(buffer2.size() * SAMPLES_COUNT);
-  auto pb_sz = p.SerializeAsString().size();
-  buffer3.reserve(pb_sz * SAMPLES_COUNT);
-
-  std::array<std::array<uint64_t, 10>, 6> arr;
-
-  for (int i = 0; i < 10; ++i) {
-    buffer1.clear();
-    buffer2.clear();
-    buffer3.clear();
-    {
-      ScopedTimer timer("serialize structpack", arr[0][i]);
-      for (int j = 0; j < SAMPLES_COUNT; j++) {
-        struct_pack::serialize_to(buffer1, t);
-      }
-      no_op();
-    }
-    {
-      ScopedTimer timer("serialize msgpack   ", arr[1][i]);
-      for (int j = 0; j < SAMPLES_COUNT; j++) {
-        msgpack::pack(buffer2, t);
-      }
-      no_op();
-    }
-    {
-      ScopedTimer timer("serialize protobuf", arr[2][i]);
-      for (int j = 0; j < SAMPLES_COUNT; j++) {
-        buffer3.resize(buffer3.size() + pb_sz);
-        p.SerializeToArray(buffer3.data() + buffer3.size() - pb_sz, pb_sz);
-      }
-      no_op();
-    }
-  }
-
-  msgpack::unpacked unpacked;
-  for (int i = 0; i < 10; ++i) {
-    {
-      ScopedTimer timer("deserialize structpack", arr[3][i]);
-      std::size_t len = 0;
-      for (size_t j = 0; j < SAMPLES_COUNT; j++) {
-        auto ec = struct_pack::deserialize_to_with_offset(t, buffer1, len);
-        if (ec != struct_pack::errc{}) [[unlikely]] {
-          exit(1);
-        }
-        no_op();
-      }
-    }
-    {
-      ScopedTimer timer("deserialize msgpack   ", arr[4][i]);
-      for (size_t pos = 0, j = 0; j < SAMPLES_COUNT; j++) {
-        msgpack::unpack(unpacked, buffer2.data(), buffer2.size(), pos);
-        t = unpacked.get().as<T>();
-        no_op();
-      }
-    }
-    {
-      ScopedTimer timer("deserialize protobuf", arr[5][i]);
-      for (size_t pos = 0, j = 0; j < SAMPLES_COUNT; j++) {
-        if (!(p.ParseFromArray(buffer3.data() + pos, pb_sz))) [[unlikely]] {
-          exit(1);
-        }
-        pos += pb_sz;
-        no_op();
-      }
-    }
-  }
-
-  std::cout << tag << " "
-            << "struct_pack serialize average: " << get_avg(arr[0])
-            << ", deserialize average:  " << get_avg(arr[3])
-            << ", buf size: " << buffer1.size() / SAMPLES_COUNT << "\n";
-  std::cout << tag << " "
-            << "msgpack serialize average:     " << get_avg(arr[1])
-            << ", deserialize average: " << get_avg(arr[4])
-            << ", buf size: " << buffer2.size() / SAMPLES_COUNT << "\n";
-  std::cout << tag << " "
-            << "protobuf serialize average:    " << get_avg(arr[2])
-            << ", deserialize average: " << get_avg(arr[5])
-            << ", buf size: " << buffer3.size() / SAMPLES_COUNT << "\n";
-  std::cout << tag << " "
-            << "struct_pack serialize is   "
-            << (double)get_avg(arr[1]) / get_avg(arr[0])
-            << " times faster than msgpack\n";
-  std::cout << tag << " "
-            << "struct_pack serialize is   "
-            << (double)get_avg(arr[2]) / get_avg(arr[0])
-            << " times faster than protobuf\n";
-  std::cout << tag << " "
-            << "struct_pack deserialize is "
-            << (double)get_avg(arr[4]) / get_avg(arr[3])
-            << " times faster than msgpack\n";
-  std::cout << tag << " "
-            << "struct_pack deserialize is "
-            << (double)get_avg(arr[5]) / get_avg(arr[3])
-            << " times faster than protobuf\n";
-  std::cout << "------- end benchmark   " << tag << " -------\n\n";
-}
-
-auto create_rects(size_t object_count) {
-  rect<int32_t> rc{65536, 65536, 65536, 65536};
-  std::vector<rect<int32_t>> v{};
-  for (int i = 0; i < object_count; i++) {
-    v.push_back(rc);
-  }
-  return v;
-}
-
-auto create_rects_pb(size_t object_count) {
-  mygame::rect32s rcs{};
-  for (int i = 0; i < object_count; i++) {
-    mygame::rect32 *rc = rcs.add_rect32_list();
-    rc->set_height(65536);
-    rc->set_width(65536);
-    rc->set_x(65536);
-    rc->set_y(65536);
-  }
-  return rcs;
-}
-
-auto create_persons(size_t object_count) {
-  std::vector<person> v{};
-  person p{65536, "tom", 65536, 65536.42};
-  for (int i = 0; i < object_count; i++) {
-    v.push_back(p);
-  }
-  return v;
-}
-
-mygame::persons create_persons_pb(size_t object_count) {
-  mygame::persons ps;
-  for (int i = 0; i < object_count; i++) {
-    auto *p = ps.add_person_list();
-    p->set_age(65536);
-    p->set_name("tom");
-    p->set_id(65536);
-    p->set_salary(65536.42);
-  }
-  return ps;
-}
-
-std::vector<Monster> create_monsters(size_t object_count) {
-  std::vector<Monster> v{};
-  Monster m = {
-      .pos = {1, 2, 3},
-      .mana = 16,
-      .hp = 24,
-      .name = "it is a test",
-      .inventory = {1, 2, 3, 4},
-      .color = Color::Red,
-      .weapons = {{"gun", 42}, {"mission", 56}},
-      .equipped = {"air craft", 67},
-      .path = {{7, 8, 9}},
-  };
-
-  Monster m1 = {
-      .pos = {11, 22, 33},
-      .mana = 161,
-      .hp = 241,
-      .name = "it is a test, ok",
-      .inventory = {24, 25, 25, 24},
-      .color = Color::Red,
-      .weapons = {{"gun", 421}, {"mission", 561}},
-      .equipped = {"air craft", 671},
-      .path = {{71, 82, 93}},
-  };
-
-  for (int i = 0; i < object_count / 2; i++) {
-    v.push_back(m);
-    v.push_back(m1);
-  }
-
-  return v;
-}
-
-mygame::Monsters create_monsters_pb(size_t object_count) {
-  mygame::Monsters Monsters;
-  for (int i = 0; i < object_count / 2; i++) {
-    {
-      auto m = Monsters.add_monsters();
-      auto vec = new mygame::Vec3;
-      vec->set_x(1);
-      vec->set_y(2);
-      vec->set_z(3);
-      m->set_allocated_pos(vec);
-      m->set_mana(16);
-      m->set_hp(24);
-      m->set_name("it is a test");
-      m->set_inventory("\1\2\3\4");
-      m->set_color(::mygame::Monster_Color::Monster_Color_Red);
-      auto w1 = m->add_weapons();
-      w1->set_name("gun");
-      w1->set_damage(42);
-      auto w2 = m->add_weapons();
-      w1->set_name("mission");
-      w1->set_damage(56);
-      auto w3 = new mygame::Weapon;
-      w3->set_name("air craft");
-      w3->set_damage(67);
-      m->set_allocated_equipped(w3);
-      auto p1 = m->add_path();
-      p1->set_x(7);
-      p1->set_y(8);
-      p1->set_z(9);
-    }
-    {
-      auto m = Monsters.add_monsters();
-      auto vec = new mygame::Vec3;
-      vec->set_x(11);
-      vec->set_y(22);
-      vec->set_z(33);
-      m->set_allocated_pos(vec);
-      m->set_mana(161);
-      m->set_hp(241);
-      m->set_name("it is a test, ok");
-      m->set_inventory("\24\25\26\24");
-      m->set_color(::mygame::Monster_Color::Monster_Color_Red);
-      auto w1 = m->add_weapons();
-      w1->set_name("gun");
-      w1->set_damage(421);
-      auto w2 = m->add_weapons();
-      w1->set_name("mission");
-      w1->set_damage(561);
-      auto w3 = new mygame::Weapon;
-      w3->set_name("air craft");
-      w3->set_damage(671);
-      m->set_allocated_equipped(w3);
-      auto p1 = m->add_path();
-      p1->set_x(71);
-      p1->set_y(82);
-      p1->set_z(93);
-    }
-  }
-  return Monsters;
-}
-
-auto v = create_rects(OBJECT_COUNT);
-auto pbs = create_rects_pb(OBJECT_COUNT);
-auto pb = *(pbs.rect32_list().begin());
-
-auto v1 = create_persons(OBJECT_COUNT);
-auto pbs1 = create_persons_pb(OBJECT_COUNT);
-auto pb1 = *(pbs1.person_list().begin());
-
-auto v2 = create_monsters(OBJECT_COUNT);
-auto pbs2 = create_monsters_pb(OBJECT_COUNT);
-auto pb2 = *(pbs2.monsters().begin());
-
-int main() {
-  {
-    bench(v[0], pb, "1 rect");
-    bench(v, pbs, "20 rect");
-  }
-
-  {
-    bench(v1[0], pb1, "1 person");
-    bench(v1, pbs1, "20 person");
-  }
-
-  {
-    bench(v2[0], pb2, "1 monster");
-    bench(v2, pbs2, "20 monster");
-  }
+  bench_all_struct_pack();
+  return 0;
 }

--- a/src/struct_pack/benchmark/config.hpp
+++ b/src/struct_pack/benchmark/config.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <cstdint>
+static constexpr int OBJECT_COUNT = 20;
+#ifdef NDEBUG
+static constexpr int SAMPLES_COUNT = 10000;  // 0;
+#else
+static constexpr int SAMPLES_COUNT = 100;
+#endif
+constexpr static std::size_t RUN_COUNT = 10;
+enum class SampleName {
+  STRUCT_PACK,
+  STRUCT_PB,
+  MSGPACK,
+  PROTOBUF,
+  PROTOPUF,
+  PROTOZERO
+};
+enum class SampleType { RECT, RECTS, PERSON, PERSONS, MONSTER, MONSTERS };
+
+template <SampleType sample_type>
+inline auto get_tag_name() {
+  if constexpr (sample_type == SampleType::RECT) {
+    return "1 rect";
+  }
+  else if constexpr (sample_type == SampleType::RECTS) {
+    return "20 rects";
+  }
+  else if constexpr (sample_type == SampleType::PERSON) {
+    return "1 person";
+  }
+  else if constexpr (sample_type == SampleType::PERSONS) {
+    return "20 persons";
+  }
+  else if constexpr (sample_type == SampleType::MONSTER) {
+    return "1 monster";
+  }
+  else if constexpr (sample_type == SampleType::MONSTERS) {
+    return "20 monsters";
+  }
+  else {
+    return "";
+  }
+}

--- a/src/struct_pack/benchmark/data_def.hpp
+++ b/src/struct_pack/benchmark/data_def.hpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#ifdef HAVE_MSGPACK
+#include <msgpack.hpp>
+#endif
+#include <atomic>
+#include <climits>
+#include <numeric>
+#include <thread>
+#include <valarray>
+#include <vector>
+
+struct person {
+  int32_t id;
+  std::string name;
+  int age;
+  double salary;
+#ifdef HAVE_MSGPACK
+  MSGPACK_DEFINE(id, name, age, salary);
+#endif
+};
+
+template <typename T>
+T get_max() {
+  if constexpr (std::is_same_v<T, int8_t>) {
+    return 127;
+  }
+  else if constexpr (std::is_same_v<T, uint8_t>) {
+    return 255;
+  }
+  else if constexpr (std::is_same_v<T, int16_t>) {
+    return 32767;
+  }
+  else if constexpr (std::is_same_v<T, uint16_t>) {
+    return 65535;
+  }
+  else if constexpr (std::is_same_v<T, int32_t>) {
+    return INT_MAX - 1;
+  }
+  else if constexpr (std::is_same_v<T, uint32_t>) {
+    return UINT_MAX - 1;
+  }
+  else if constexpr (std::is_same_v<T, int64_t>) {
+    return LLONG_MAX - 1;
+  }
+  else if constexpr (std::is_same_v<T, uint64_t>) {
+    return ULLONG_MAX - 1;
+  }
+
+  return {};
+}
+
+template <typename T>
+struct rect {
+  T x = get_max<T>();
+  T y = get_max<T>();
+  T width = get_max<T>();
+  T height = get_max<T>();
+#ifdef HAVE_MSGPACK
+  MSGPACK_DEFINE(x, y, width, height);
+#endif
+};
+
+enum Color : uint8_t { Red, Green, Blue };
+
+struct Vec3 {
+  float x;
+  float y;
+  float z;
+
+  bool operator==(const Vec3 &rhs) const {
+    std::valarray<float> lh({x, y, z});
+    std::valarray<float> rh({rhs.x, rhs.y, rhs.z});
+    return (std::abs(lh - rh) < 0.05f).min();
+  };
+#ifdef HAVE_MSGPACK
+  MSGPACK_DEFINE(x, y, z);
+#endif
+};
+
+struct Weapon {
+  std::string name;
+  int16_t damage;
+
+  bool operator==(const Weapon &rhs) const {
+    return name == rhs.name && damage == rhs.damage;
+  };
+#ifdef HAVE_MSGPACK
+  MSGPACK_DEFINE(name, damage);
+#endif
+};
+
+struct Monster {
+  Vec3 pos;
+  int16_t mana;
+  int16_t hp;
+  std::string name;
+  std::string inventory;
+  Color color;
+  std::vector<Weapon> weapons;
+  Weapon equipped;
+  std::vector<Vec3> path;
+
+  bool operator==(const Monster &rhs) const {
+    return pos == rhs.pos && mana == rhs.mana && hp == rhs.hp &&
+           name == rhs.name && inventory == rhs.inventory &&
+           color == rhs.color && weapons == rhs.weapons &&
+           equipped == rhs.equipped && path == rhs.path;
+  };
+#ifdef HAVE_MSGPACK
+  MSGPACK_DEFINE(pos, mana, hp, name, inventory, (int &)color, weapons,
+                 equipped, path);
+#endif
+};
+
+inline auto create_rects(size_t object_count) {
+  rect<int32_t> rc{65536, 65536, 65536, 65536};
+  std::vector<rect<int32_t>> v{};
+  for (std::size_t i = 0; i < object_count; i++) {
+    v.push_back(rc);
+  }
+  return v;
+}
+
+inline auto create_persons(size_t object_count) {
+  std::vector<person> v{};
+  person p{65536, "tom", 65536, 65536.42};
+  for (std::size_t i = 0; i < object_count; i++) {
+    v.push_back(p);
+  }
+  return v;
+}
+
+inline std::vector<Monster> create_monsters(size_t object_count) {
+  std::vector<Monster> v{};
+  Monster m = {
+      .pos = {1, 2, 3},
+      .mana = 16,
+      .hp = 24,
+      .name = "it is a test",
+      .inventory = "\1\2\3\4",
+      .color = Color::Red,
+      .weapons = {{"gun", 42}, {"mission", 56}},
+      .equipped = {"air craft", 67},
+      .path = {{7, 8, 9}},
+  };
+
+  Monster m1 = {
+      .pos = {11, 22, 33},
+      .mana = 161,
+      .hp = 241,
+      .name = "it is a test, ok",
+      .inventory = "\24\25\26\24",
+      .color = Color::Red,
+      .weapons = {{"gun", 421}, {"mission", 561}},
+      .equipped = {"air craft", 671},
+      .path = {{71, 82, 93}},
+  };
+
+  for (std::size_t i = 0; i < object_count / 2; i++) {
+    v.push_back(m);
+    v.push_back(m1);
+  }
+
+  return v;
+}

--- a/src/struct_pack/benchmark/msgpack_sample.hpp
+++ b/src/struct_pack/benchmark/msgpack_sample.hpp
@@ -1,0 +1,99 @@
+#pragma once
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "ScopedTimer.hpp"
+#include "data_def.hpp"
+#include "no_op.h"
+#include "sample.hpp"
+template <typename Data, typename Buffer>
+struct Sample<SampleName::MSGPACK, Data, Buffer> : public SampleBase {
+  Sample(Data data) : data_(std::move(data)) {
+    msgpack::pack(buffer_, data_);
+    size_ = buffer_.size();
+  }
+  void clear_data() override {
+    if constexpr (std::same_as<Data, std::vector<Monster>>) {
+      data_.clear();
+    }
+  }
+  void clear_buffer() override { buffer_.clear(); }
+  void reserve_buffer() override { buffer_.reserve(size_ * SAMPLES_COUNT); }
+  size_t buffer_size() const override { return buffer_.size(); }
+  std::string name() const override { return "msgpack"; }
+  void do_serialization(int run_idx) override {
+    ScopedTimer timer(("serialize " + name()).c_str(),
+                      serialize_cost_[run_idx]);
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      msgpack::pack(buffer_, data_);
+    }
+    no_op();
+  }
+  void do_deserialization(int run_idx) override {
+    msgpack::unpacked unpacked;
+    ScopedTimer timer(("deserialize " + name()).c_str(),
+                      deserialize_cost_[run_idx]);
+    std::size_t pos = 0;
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      msgpack::unpack(unpacked, buffer_.data(), buffer_.size(), pos);
+      data_ = unpacked.get().as<Data>();
+    }
+    no_op();
+  }
+
+ private:
+  Data data_;
+  Buffer buffer_;
+  std::size_t size_;
+};
+
+struct tbuffer : public std::vector<char> {
+  void write(const char *src, size_t sz) {
+    this->resize(this->size() + sz);
+    auto pos = this->data() + this->size() - sz;
+    std::memcpy(pos, src, sz);
+  }
+};
+
+namespace msgpack_sample {
+template <SampleType sample_type>
+auto create_sample() {
+  using Buffer = tbuffer;
+  if constexpr (sample_type == SampleType::RECT) {
+    using Data = rect<int32_t>;
+    auto rects = create_rects(OBJECT_COUNT);
+    return Sample<SampleName::MSGPACK, Data, Buffer>(rects[0]);
+  }
+  else if constexpr (sample_type == SampleType::RECTS) {
+    using Data = std::vector<rect<int32_t>>;
+    auto rects = create_rects(OBJECT_COUNT);
+    return Sample<SampleName::MSGPACK, Data, Buffer>(rects);
+  }
+  else if constexpr (sample_type == SampleType::PERSON) {
+    using Data = person;
+    auto persons = create_persons(OBJECT_COUNT);
+    auto person = persons[0];
+    return Sample<SampleName::MSGPACK, Data, Buffer>(person);
+  }
+  else if constexpr (sample_type == SampleType::PERSONS) {
+    using Data = std::vector<person>;
+    auto persons = create_persons(OBJECT_COUNT);
+    return Sample<SampleName::MSGPACK, Data, Buffer>(persons);
+  }
+  else if constexpr (sample_type == SampleType::MONSTER) {
+    using Data = Monster;
+    auto monsters = create_monsters(OBJECT_COUNT);
+    auto monster = monsters[0];
+    return Sample<SampleName::MSGPACK, Data, Buffer>(monster);
+  }
+  else if constexpr (sample_type == SampleType::MONSTERS) {
+    using Data = std::vector<Monster>;
+    auto monsters = create_monsters(OBJECT_COUNT);
+    return Sample<SampleName::MSGPACK, Data, Buffer>(monsters);
+  }
+  else {
+    return sample_type;
+  }
+}
+}  // namespace msgpack_sample

--- a/src/struct_pack/benchmark/protobuf_sample.hpp
+++ b/src/struct_pack/benchmark/protobuf_sample.hpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ScopedTimer.hpp"
+#include "benchmark.pb.h"
+#include "config.hpp"
+#include "sample.hpp"
+namespace protobuf_sample {
+auto create_rects(size_t object_count) {
+  mygame::rect32s rcs{};
+  for (std::size_t i = 0; i < object_count; i++) {
+    mygame::rect32 *rc = rcs.add_rect32_list();
+    rc->set_height(65536);
+    rc->set_width(65536);
+    rc->set_x(65536);
+    rc->set_y(65536);
+  }
+  return rcs;
+}
+
+mygame::persons create_persons(size_t object_count) {
+  mygame::persons ps;
+  for (std::size_t i = 0; i < object_count; i++) {
+    auto *p = ps.add_person_list();
+    p->set_age(65536);
+    p->set_name("tom");
+    p->set_id(65536);
+    p->set_salary(65536.42);
+  }
+  return ps;
+}
+
+mygame::Monsters create_monsters(size_t object_count) {
+  mygame::Monsters Monsters;
+  for (std::size_t i = 0; i < object_count / 2; i++) {
+    {
+      auto m = Monsters.add_monsters();
+      auto vec = new mygame::Vec3;
+      vec->set_x(1);
+      vec->set_y(2);
+      vec->set_z(3);
+      m->set_allocated_pos(vec);
+      m->set_mana(16);
+      m->set_hp(24);
+      m->set_name("it is a test");
+      m->set_inventory("\1\2\3\4");
+      m->set_color(::mygame::Monster_Color::Monster_Color_Red);
+      auto w1 = m->add_weapons();
+      w1->set_name("gun");
+      w1->set_damage(42);
+      auto w2 = m->add_weapons();
+      w2->set_name("mission");
+      w2->set_damage(56);
+      auto w3 = new mygame::Weapon;
+      w3->set_name("air craft");
+      w3->set_damage(67);
+      m->set_allocated_equipped(w3);
+      auto p1 = m->add_path();
+      p1->set_x(7);
+      p1->set_y(8);
+      p1->set_z(9);
+    }
+    {
+      auto m = Monsters.add_monsters();
+      auto vec = new mygame::Vec3;
+      vec->set_x(11);
+      vec->set_y(22);
+      vec->set_z(33);
+      m->set_allocated_pos(vec);
+      m->set_mana(161);
+      m->set_hp(241);
+      m->set_name("it is a test, ok");
+      m->set_inventory("\24\25\26\24");
+      m->set_color(::mygame::Monster_Color::Monster_Color_Red);
+      auto w1 = m->add_weapons();
+      w1->set_name("gun");
+      w1->set_damage(421);
+      auto w2 = m->add_weapons();
+      w2->set_name("mission");
+      w2->set_damage(561);
+      auto w3 = new mygame::Weapon;
+      w3->set_name("air craft");
+      w3->set_damage(671);
+      m->set_allocated_equipped(w3);
+      auto p1 = m->add_path();
+      p1->set_x(71);
+      p1->set_y(82);
+      p1->set_z(93);
+    }
+  }
+  return Monsters;
+}
+}  // namespace protobuf_sample
+template <typename Data, typename Buffer>
+struct Sample<SampleName::PROTOBUF, Data, Buffer> : public SampleBase {
+  Sample(Data data) : data_(std::move(data)) {
+    pb_size_ = data_.SerializeAsString().size();
+  }
+  void clear_data() override {
+    if constexpr (std::same_as<Data, mygame::Monsters>) {
+      data_.clear_monsters();
+    }
+    else if constexpr (std::same_as<Data, mygame::Monster>) {
+      data_.clear_pos();
+      data_.set_mana(0);
+      data_.set_hp(0);
+      data_.clear_name();
+      data_.clear_inventory();
+      data_.clear_color();
+      data_.clear_weapons();
+      data_.clear_equipped();
+      data_.clear_path();
+    }
+  }
+  void clear_buffer() override { buffer_.clear(); }
+  void reserve_buffer() override { buffer_.reserve(pb_size_ * SAMPLES_COUNT); }
+  size_t buffer_size() const override { return buffer_.size(); }
+  std::string name() const override { return "protobuf"; }
+  void do_serialization(int run_idx = 0) override {
+    ScopedTimer timer(("serialize " + name()).c_str(),
+                      serialize_cost_[run_idx]);
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      buffer_.resize(buffer_.size() + pb_size_);
+      data_.SerializeToArray(buffer_.data() + buffer_.size() - pb_size_,
+                             pb_size_);
+    }
+  }
+  void do_deserialization(int run_idx) override {
+    ScopedTimer timer(("deserialize " + name()).c_str(),
+                      deserialize_cost_[run_idx]);
+    std::size_t pos = 0;
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      if (!data_.ParseFromArray(buffer_.data() + pos, pb_size_)) [[unlikely]] {
+        std::exit(1);
+      }
+      pos += pb_size_;
+      clear_data();
+    }
+  }
+
+ private:
+  Data data_;
+  Buffer buffer_;
+  std::size_t pb_size_;
+};
+namespace protobuf_sample {
+template <SampleType sample_type>
+auto create_sample() {
+  using Buffer = std::string;
+  if constexpr (sample_type == SampleType::RECT) {
+    using Data = mygame::rect32;
+    auto pbs = create_rects(OBJECT_COUNT);
+    auto pb = *(pbs.rect32_list().begin());
+    return Sample<SampleName::PROTOBUF, Data, Buffer>(pb);
+  }
+  else if constexpr (sample_type == SampleType::RECTS) {
+    using Data = mygame::rect32s;
+    auto pbs = create_rects(OBJECT_COUNT);
+    return Sample<SampleName::PROTOBUF, Data, Buffer>(pbs);
+  }
+  else if constexpr (sample_type == SampleType::PERSON) {
+    using Data = mygame::person;
+    auto pbs = create_persons(OBJECT_COUNT);
+    auto pb = *(pbs.person_list().begin());
+    return Sample<SampleName::PROTOBUF, Data, Buffer>(pb);
+  }
+  else if constexpr (sample_type == SampleType::PERSONS) {
+    using Data = mygame::persons;
+    auto pbs = create_persons(OBJECT_COUNT);
+    return Sample<SampleName::PROTOBUF, Data, Buffer>(pbs);
+  }
+  else if constexpr (sample_type == SampleType::MONSTER) {
+    using Data = mygame::Monster;
+    auto monsters = create_monsters(OBJECT_COUNT);
+    auto monster = *(monsters.monsters().begin());
+    return Sample<SampleName::PROTOBUF, Data, Buffer>(monster);
+  }
+  else if constexpr (sample_type == SampleType::MONSTERS) {
+    using Data = mygame::Monsters;
+    auto monsters = create_monsters(OBJECT_COUNT);
+    return Sample<SampleName::PROTOBUF, Data, Buffer>(monsters);
+  }
+  else {
+    return sample_type;
+  }
+}
+}  // namespace protobuf_sample

--- a/src/struct_pack/benchmark/protopuf_sample.hpp
+++ b/src/struct_pack/benchmark/protopuf_sample.hpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "protopuf/message.h"
+namespace protopuf_sample {
+using namespace pp;
+
+using Vec3 =
+    message<float_field<"x", 1>, float_field<"y", 2>, float_field<"z", 3> >;
+using Weapon = message<string_field<"name", 1>, int32_field<"damage", 2> >;
+enum class Color {
+  Red = 0,
+  Green = 1,
+  Blue = 2,
+};
+using Monster =
+    message<message_field<"pos", 1, Vec3>, int32_field<"mana", 2>,
+            int32_field<"hp", 3>, string_field<"name", 4>,
+            bytes_field<"inventory", 5>, enum_field<"color", 6, Color>,
+            message_field<"weapons", 7, Weapon, repeated>,
+            message_field<"equipped", 8, Weapon>,
+            message_field<"path", 9, Vec3, repeated> >;
+using Monsters = message<message_field<"monsters", 1, Monster, repeated> >;
+using rect32 = message<int32_field<"x", 1>, int32_field<"y", 2>,
+                       int32_field<"width", 3>, int32_field<"height", 4> >;
+using rect32s = message<message_field<"rect32_list", 1, rect32, repeated> >;
+using person = message<int32_field<"id", 1>, string_field<"name", 2>,
+                       int32_field<"age", 3>, double_field<"salary", 4> >;
+using persons = message<message_field<"person_list", 1, person, repeated> >;
+
+auto create_rects(std::size_t object_count) {
+  rect32s rcs;
+  for (std::size_t i = 0; i < object_count; ++i) {
+    rect32 rc{65536, 65536, 65536, 65536};
+    rcs["rect32_list"_f].push_back(rc);
+  }
+  return rcs;
+}
+auto create_persons(std::size_t object_count) {
+  persons ps;
+  for (std::size_t i = 0; i < object_count; ++i) {
+    person p{65536, "tom", 65536, 65536.42};
+    ps["person_list"_f].push_back(p);
+  }
+  return ps;
+}
+auto create_monsters(std::size_t object_count) {
+  Monsters monsters;
+  for (std::size_t i = 0; i < object_count / 2; ++i) {
+    {
+      Monster m;
+      m["pos"_f] = Vec3{1, 2, 3};
+      m["mana"_f] = 16;
+      m["hp"_f] = 24;
+      m["name"_f] = "it is a test";
+      m["inventory"_f] = std::vector<unsigned char>{'\1', '\2', '\3', '\4'};
+      // LLVM crash
+      // static_assert(std::same_as<decltype(m["inventory"_f]), int32_t>);
+      m["color"_f] = Color::Red;
+      m["weapons"_f].emplace_back("gun", 42);
+      m["weapons"_f].emplace_back("mission", 56);
+      m["equipped"_f] = Weapon{"air craft", 67};
+      m["path"_f] = std::vector<Vec3>{Vec3{7, 8, 9}};
+      monsters["monsters"_f].push_back(m);
+    }
+    {
+      Monster m;
+      m["pos"_f] = Vec3{11, 22, 33};
+      m["mana"_f] = 161;
+      m["hp"_f] = 241;
+      m["name"_f] = "it is a test, ok";
+      m["inventory"_f] = std::vector<unsigned char>{'\24', '\25', '\26', '\24'};
+      m["color"_f] = Color::Red;
+      m["weapons"_f].emplace_back("gun", 421);
+      m["weapons"_f].emplace_back("mission", 561);
+      m["equipped"_f] = Weapon{"air craft", 671};
+      m["path"_f] = std::vector<Vec3>{Vec3{71, 82, 93}};
+      monsters["monsters"_f].push_back(m);
+    }
+  }
+  return monsters;
+}
+}  // namespace protopuf_sample
+
+template <typename Data, typename Buffer>
+struct Sample<SampleName::PROTOPUF, Data, Buffer> : public SampleBase {
+  Sample(Data data) : data_(std::move(data)) {}
+  void clear_data() override {
+    using namespace pp;
+    if constexpr (std::same_as<Data, protopuf_sample::Monsters>) {
+      data_["monsters"_f].clear();
+    }
+  }
+  void clear_buffer() override { buffer_ = Buffer{}; }
+  void reserve_buffer() override {}
+  size_t buffer_size() const override { return buffer_.size(); }
+  std::string name() const override { return "protopuf"; }
+  void do_serialization(int run_idx) override {
+    ScopedTimer timer(("serialize " + name()).c_str(),
+                      serialize_cost_[run_idx]);
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      pp::message_coder<Data>::encode(data_, buffer_);
+    }
+  }
+  void do_deserialization(int run_idx) override {
+    ScopedTimer timer(("deserialize " + name()).c_str(),
+                      deserialize_cost_[run_idx]);
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      pp::message_coder<Data>::decode(buffer_);
+    }
+  }
+
+ private:
+  Data data_;
+  Buffer buffer_;
+};
+namespace protopuf_sample {
+template <SampleType sample_type>
+auto create_sample() {
+  using pp::operator""_f;
+  using Buffer = std::array<std::byte, 3000 * OBJECT_COUNT>;
+  if constexpr (sample_type == SampleType::RECT) {
+    using Data = protopuf_sample::rect32;
+    auto rects = protopuf_sample::create_rects(OBJECT_COUNT);
+    auto rect = rects["rect32_list"_f][0];
+    return Sample<SampleName::PROTOPUF, Data, Buffer>(rect);
+  }
+  else if constexpr (sample_type == SampleType::RECTS) {
+    using Data = protopuf_sample::rect32s;
+    auto rects = protopuf_sample::create_rects(OBJECT_COUNT);
+    return Sample<SampleName::PROTOPUF, Data, Buffer>(rects);
+  }
+  else if constexpr (sample_type == SampleType::PERSON) {
+    using Data = protopuf_sample::person;
+    auto persons = protopuf_sample::create_persons(OBJECT_COUNT);
+    auto person = persons["person_list"_f][0];
+    return Sample<SampleName::PROTOPUF, Data, Buffer>(person);
+  }
+  else if constexpr (sample_type == SampleType::PERSONS) {
+    using Data = protopuf_sample::persons;
+    auto persons = protopuf_sample::create_persons(OBJECT_COUNT);
+    return Sample<SampleName::PROTOPUF, Data, Buffer>(persons);
+  }
+  else if constexpr (sample_type == SampleType::MONSTER) {
+    using Data = protopuf_sample::Monster;
+    auto monsters = protopuf_sample::create_monsters(OBJECT_COUNT);
+    auto monster = monsters["monsters"_f][0];
+    return Sample<SampleName::PROTOPUF, Data, Buffer>(monster);
+  }
+  else if constexpr (sample_type == SampleType::MONSTERS) {
+    using Data = protopuf_sample::Monsters;
+    auto monsters = protopuf_sample::create_monsters(OBJECT_COUNT);
+    return Sample<SampleName::PROTOPUF, Data, Buffer>(monsters);
+  }
+  else {
+    return sample_type;
+  }
+}
+}  // namespace protopuf_sample

--- a/src/struct_pack/benchmark/protozero_sample.hpp
+++ b/src/struct_pack/benchmark/protozero_sample.hpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "data_def.hpp"
+#include "protozero/pbf_reader.hpp"
+#include "protozero/pbf_writer.hpp"
+
+namespace protozero_sample {
+using namespace protozero;
+void serialize(const Vec3& vec3, pbf_writer& writer) {
+  writer.add_float(1, vec3.x);
+  writer.add_float(2, vec3.y);
+  writer.add_float(3, vec3.z);
+}
+void serialize(const Weapon& weapon, pbf_writer& writer) {
+  writer.add_string(1, weapon.name);
+  writer.add_int32(2, weapon.damage);
+}
+void serialize(const Monster& monster, pbf_writer& writer) {
+  {
+    pbf_writer pbf_sub{writer, 1};
+    serialize(monster.pos, pbf_sub);
+  }
+  writer.add_int32(2, monster.mana);
+  writer.add_int32(3, monster.hp);
+  writer.add_string(4, monster.name);
+  writer.add_bytes(5, monster.inventory);
+  writer.add_enum(6, monster.color);
+  {
+    for (const auto& weapon : monster.weapons) {
+      pbf_writer pbf_sub{writer, 7};
+      serialize(weapon, pbf_sub);
+    }
+  }
+  {
+    pbf_writer pbf_sub{writer, 8};
+    serialize(monster.equipped, pbf_sub);
+  }
+  for (const auto& v : monster.path) {
+    pbf_writer pbf_sub{writer, 9};
+    serialize(v, pbf_sub);
+  }
+}
+template <typename T>
+void serialize(const std::vector<T>& ms, pbf_writer& writer) {
+  for (const auto& m : ms) {
+    pbf_writer pbf_sub{writer, 1};
+    serialize(m, pbf_sub);
+  }
+}
+void deserialize(Vec3& vec3, pbf_reader& reader) {
+  while (reader.next()) {
+    switch (reader.tag()) {
+      case 1:
+        vec3.x = reader.get_float();
+        break;
+      case 2:
+        vec3.y = reader.get_float();
+        break;
+      case 3:
+        vec3.z = reader.get_float();
+        break;
+      default:
+        reader.skip();
+    }
+  }
+}
+void deserialize(Weapon& weapon, pbf_reader& reader) {
+  while (reader.next()) {
+    switch (reader.tag()) {
+      case 1:
+        weapon.name = reader.get_string();
+        break;
+      case 2:
+        weapon.damage = reader.get_int32();
+        break;
+      default:
+        reader.skip();
+    }
+  }
+}
+void deserialize(Monster& monster, pbf_reader& reader) {
+  while (reader.next()) {
+    switch (reader.tag()) {
+      case 1: {
+        auto reader_sub = reader.get_message();
+        deserialize(monster.pos, reader_sub);
+        break;
+      }
+      case 2:
+        monster.mana = reader.get_int32();
+        break;
+      case 3:
+        monster.hp = reader.get_int32();
+        break;
+      case 4:
+        monster.name = reader.get_string();
+        break;
+      case 5: {
+        monster.inventory = reader.get_string();
+        break;
+      }
+      case 6:
+        monster.color = static_cast<Color>(reader.get_enum());
+        break;
+      case 7: {
+        auto reader_sub = reader.get_message();
+        Weapon w{};
+        deserialize(w, reader_sub);
+        monster.weapons.push_back(w);
+        break;
+      }
+      case 8: {
+        auto reader_sub = reader.get_message();
+        deserialize(monster.equipped, reader_sub);
+        break;
+      }
+      case 9: {
+        auto reader_sub = reader.get_message();
+        Vec3 v{};
+        deserialize(v, reader_sub);
+        monster.path.push_back(v);
+        break;
+      }
+    }
+  }
+}
+template <typename T>
+void deserialize(std::vector<T>& ms, pbf_reader& reader) {
+  while (reader.next()) {
+    switch (reader.tag()) {
+      case 1: {
+        auto reader_sub = reader.get_message();
+        T m{};
+        deserialize(m, reader_sub);
+        ms.push_back(m);
+        break;
+      }
+      default: {
+        reader.skip();
+      }
+    }
+  }
+}
+}  // namespace protozero_sample
+
+template <typename Data, typename Buffer>
+struct Sample<SampleName::PROTOZERO, Data, Buffer> : public SampleBase {
+  Sample(Data data) : data_(std::move(data)) {
+    protozero::pbf_writer writer{buffer_};
+    protozero_sample::serialize(data_, writer);
+    size_ = buffer_.size();
+  }
+  void clear_data() override {
+    if constexpr (std::same_as<Data, std::vector<Monster>>) {
+      data_.clear();
+    }
+  }
+  void clear_buffer() override { buffer_.clear(); }
+  void reserve_buffer() override {
+    buffer_.resize(buffer_.size() * SAMPLES_COUNT);
+  }
+  size_t buffer_size() const override { return buffer_.size(); }
+  std::string name() const override { return "protozero"; }
+  void do_serialization(int run_idx) override {
+    ScopedTimer timer(("serialize " + name()).c_str(),
+                      serialize_cost_[run_idx]);
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      protozero::pbf_writer writer{buffer_};
+      protozero_sample::serialize(data_, writer);
+    }
+  }
+  void do_deserialization(int run_idx) override {
+    ScopedTimer timer(("deserialize " + name()).c_str(),
+                      deserialize_cost_[run_idx]);
+    std::size_t pos = 0;
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      protozero::pbf_reader reader{buffer_.data() + pos, size_};
+      protozero_sample::deserialize(data_, reader);
+      pos += size_;
+    }
+  }
+
+ private:
+  Data data_;
+  Buffer buffer_;
+  std::size_t size_;
+};
+namespace protozero_sample {
+template <SampleType sample_type>
+auto create_sample() {
+  using Buffer = std::string;
+  if constexpr (sample_type == SampleType::RECT) {
+    using Data = rect<int32_t>;
+    auto rects = create_rects(OBJECT_COUNT);
+    return Sample<SampleName::PROTOZERO, Data, Buffer>(rects[0]);
+  }
+  else if constexpr (sample_type == SampleType::RECTS) {
+    using Data = std::vector<rect<int32_t>>;
+    auto rects = create_rects(OBJECT_COUNT);
+    return Sample<SampleName::PROTOZERO, Data, Buffer>(rects);
+  }
+  else if constexpr (sample_type == SampleType::PERSON) {
+    using Data = person;
+    auto persons = create_persons(OBJECT_COUNT);
+    auto person = persons[0];
+    return Sample<SampleName::PROTOZERO, Data, Buffer>(person);
+  }
+  else if constexpr (sample_type == SampleType::PERSONS) {
+    using Data = std::vector<person>;
+    auto persons = create_persons(OBJECT_COUNT);
+    return Sample<SampleName::PROTOZERO, Data, Buffer>(persons);
+  }
+  else if constexpr (sample_type == SampleType::MONSTER) {
+    using Data = Monster;
+    auto monsters = create_monsters(OBJECT_COUNT);
+    auto monster = monsters[0];
+    return Sample<SampleName::PROTOZERO, Data, Buffer>(monster);
+  }
+  else if constexpr (sample_type == SampleType::MONSTERS) {
+    using Data = std::vector<Monster>;
+    auto monsters = create_monsters(OBJECT_COUNT);
+    return Sample<SampleName::PROTOZERO, Data, Buffer>(monsters);
+  }
+  else {
+    return sample_type;
+  }
+}
+}  // namespace protozero_sample

--- a/src/struct_pack/benchmark/sample.hpp
+++ b/src/struct_pack/benchmark/sample.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <array>
+#include <numeric>
+
+#include "config.hpp"
+
+template <SampleName sample_name, typename Data, typename Buffer>
+struct Sample;
+
+template <typename T>
+inline uint64_t get_avg(const T& v) {
+  uint64_t sum = std::accumulate(v.begin(), v.end(), uint64_t(0));
+  return sum / v.size();
+}
+std::string pretty_int(int v) {
+  auto str = std::to_string(v);
+  for (int i = str.size(); i < 15; ++i) {
+    str = ' ' + str;
+  }
+  return str;
+}
+std::string pretty_float(double v) {
+  int vv = v * 100;
+  std::string str{};
+  str += std::to_string(vv / 100);
+  str += ".";
+  auto right = std::to_string(vv % 100);
+  while (right.size() < 2) {
+    right += '0';
+  }
+  str += right;
+  for (int i = str.size(); i < 5; ++i) {
+    str = ' ' + str;
+  }
+  return str;
+}
+std::string pretty_name(std::string name) {
+  for (int i = name.size(); i < 12; ++i) {
+    name += ' ';
+  }
+  return name;
+}
+struct SampleBase {
+  virtual void clear_data() = 0;
+  virtual void clear_buffer() = 0;
+  virtual void reserve_buffer() = 0;
+  virtual std::size_t buffer_size() const = 0;
+  virtual std::string name() const = 0;
+  virtual void do_serialization(int run_idx = 0) = 0;
+  virtual void do_deserialization(int run_idx) = 0;
+  void report_metric(std::string_view tag) const {
+    std::cout << tag << " ";
+    std::cout << pretty_name(name())
+              << " serialize average: " << pretty_int(get_avg(serialize_cost_));
+    std::cout << ", deserialize average: "
+              << pretty_int(get_avg(deserialize_cost_));
+    std::cout << ", buf size: " << pretty_int(buffer_size() / SAMPLES_COUNT);
+    std::cout << std::endl;
+  }
+  std::array<uint64_t, RUN_COUNT> serialize_cost_{};
+  std::array<uint64_t, RUN_COUNT> deserialize_cost_{};
+
+ private:
+};
+
+template <typename T>
+bool verify(const T& ground_truth, const T& t) {
+  return ground_truth == t;
+}

--- a/src/struct_pack/benchmark/struct_pack_sample.hpp
+++ b/src/struct_pack/benchmark/struct_pack_sample.hpp
@@ -1,0 +1,117 @@
+#pragma once
+#include "ScopedTimer.hpp"
+#include "data_def.hpp"
+#include "sample.hpp"
+#include "struct_pack/struct_pack.hpp"
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<person> = type_info_config::disable;
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<std::vector<person>> =
+    type_info_config::disable;
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<rect<int32_t>> =
+    type_info_config::disable;
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<std::vector<rect<int32_t>>> =
+    type_info_config::disable;
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<Monster> = type_info_config::disable;
+};
+
+namespace struct_pack {
+template <>
+constexpr inline auto enable_type_info<std::vector<Monster>> =
+    type_info_config::disable;
+};
+
+template <typename Data, typename Buffer>
+struct Sample<SampleName::STRUCT_PACK, Data, Buffer> : public SampleBase {
+  Sample(Data data) : data_(std::move(data)) {}
+
+  void clear_data() override {
+    if constexpr (std::same_as<Data, std::vector<Monster>>) {
+      data_.clear();
+    }
+  }
+  void clear_buffer() override { buffer_.clear(); }
+  void reserve_buffer() override {
+    buffer_.reserve(struct_pack::get_needed_size(data_));
+  }
+  size_t buffer_size() const override { return buffer_.size(); }
+  std::string name() const override { return "struct_pack"; }
+  void do_serialization(int run_idx) override {
+    ScopedTimer timer(("serialize " + name()).c_str(),
+                      serialize_cost_[run_idx]);
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      struct_pack::serialize_to(buffer_, data_);
+    }
+  }
+  void do_deserialization(int run_idx) override {
+    ScopedTimer timer(("deserialize " + name()).c_str(),
+                      deserialize_cost_[run_idx]);
+    for (std::size_t i = 0; i < SAMPLES_COUNT; ++i) {
+      std::size_t len = 0;
+      auto ec = struct_pack::deserialize_to_with_offset(data_, buffer_, len);
+      if (ec != struct_pack::errc{}) [[unlikely]] {
+        std::exit(1);
+      }
+    }
+  }
+
+ private:
+  Data data_;
+  Buffer buffer_;
+};
+template <SampleType sample_type>
+auto create_sample() {
+  using Buffer = std::string;
+  if constexpr (sample_type == SampleType::RECT) {
+    using Data = rect<int32_t>;
+    auto rects = create_rects(OBJECT_COUNT);
+    return Sample<SampleName::STRUCT_PACK, Data, Buffer>(rects[0]);
+  }
+  else if constexpr (sample_type == SampleType::RECTS) {
+    using Data = std::vector<rect<int32_t>>;
+    auto rects = create_rects(OBJECT_COUNT);
+    return Sample<SampleName::STRUCT_PACK, Data, Buffer>(rects);
+  }
+  else if constexpr (sample_type == SampleType::PERSON) {
+    using Data = person;
+    auto persons = create_persons(OBJECT_COUNT);
+    auto person = persons[0];
+    return Sample<SampleName::STRUCT_PACK, Data, Buffer>(person);
+  }
+  else if constexpr (sample_type == SampleType::PERSONS) {
+    using Data = std::vector<person>;
+    auto persons = create_persons(OBJECT_COUNT);
+    return Sample<SampleName::STRUCT_PACK, Data, Buffer>(persons);
+  }
+  else if constexpr (sample_type == SampleType::MONSTER) {
+    using Data = Monster;
+    auto monsters = create_monsters(OBJECT_COUNT);
+    auto monster = monsters[0];
+    return Sample<SampleName::STRUCT_PACK, Data, Buffer>(monster);
+  }
+  else if constexpr (sample_type == SampleType::MONSTERS) {
+    using Data = std::vector<Monster>;
+    auto monsters = create_monsters(OBJECT_COUNT);
+    return Sample<SampleName::STRUCT_PACK, Data, Buffer>(monsters);
+  }
+  else {
+    return sample_type;
+  }
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

the old one is not suitable for leaderboard


## What is changing

- re-design benchmark framework
- split sample

## Example



- download dependencies

assume in `REPO_ROOT`

msgpack, see https://github.com/msgpack/msgpack-c/tree/cpp_master

protobuf, see https://github.com/protocolbuffers/protobuf

```shell
cd thirdparty
git clone https://github.com/PragmaTwice/protopuf.git
git clone https://github.com/mapbox/protozero.git
```

- build

assume in `REPO_ROOT`

```shell
mkdir build
cd build
cmake ..
make -j struct_pack_benchmark
```
- run

assume in `REPO_ROOT`

```shell
cd build
./src/struct_pack/benchmark/struct_pack_benchmark
```

