### PR TITLE
Fix variant layout

### DIFF
--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -172,8 +172,8 @@ constexpr auto get_types(U &&t) {
   }
   else if constexpr (std::is_aggregate_v<T>) {
     return visit_members(
-        std::forward<U>(t), [&]<typename... Args>(Args &&
-                                                  ...) CONSTEXPR_INLINE_LAMBDA {
+        std::forward<U>(t),
+        [&]<typename... Args>(Args &&...) CONSTEXPR_INLINE_LAMBDA {
           return std::tuple<std::remove_cvref_t<Args>...>{};
         });
   }

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -816,7 +816,7 @@ constexpr size_info STRUCT_PACK_INLINE calculate_one_size(const T &item) {
     }
   }
   else if constexpr (variant<type>) {
-    ret.total += sizeof(uint8_t);  // why is 32bit?
+    ret.total += sizeof(uint8_t);
     if (item.index() != std::variant_npos) [[likely]] {
       ret += std::visit(
           [](const auto &e) {

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -660,7 +660,6 @@ std::array<std::string, 127 * 127> ar4;
 std::array<std::string, 127 * 127> ar4_1;
 }  // namespace array_test
 
-
 TEST_CASE("array test") {
   std::string test_str = "Hello Hi Hello Hi Hello Hi Hello Hi Hello Hi";
   using namespace array_test;

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -660,14 +660,6 @@ std::array<std::string, 127 * 127> ar4;
 std::array<std::string, 127 * 127> ar4_1;
 }  // namespace array_test
 
-TEST_CASE("hey") {
-  auto str = struct_pack::get_type_literal<person>();
-  for (auto &e : str) {
-    std::cout << int(e) << ' ';
-  }
-
-  std::cout << std::endl;
-}
 
 TEST_CASE("array test") {
   std::string test_str = "Hello Hi Hello Hi Hello Hi Hello Hi Hello Hi";


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Fix variant Layout.

## What is changing

Now variant index only use 1 bytes in serialize result.
struct_pack serialize will naturely throw exception by std::visit if variant is valueless by exception now.

## Example