### PR TITLE
[coro_rpc] Workaround for MSVC C4737.

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -10,3 +10,5 @@ endif()
 # --------------------- Msvc
 # Resolves C1128 complained by MSVC: number of sections exceeded object file format limit: compile with /bigobj.
 add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/bigobj>")
+# Resolves C4737 complained by MSVC: C4737: Unable to perform required tail call. Performance may be degraded.
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/EHa>")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Closes #99

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

Add option `/EHa` for msvc to workaround Compile Error C4737 in msvc release.

## Example