### PR TITLE
use ninja for ci and add win32

### DIFF
--- a/.github/workflows/linux_clang.yml
+++ b/.github/workflows/linux_clang.yml
@@ -10,9 +10,10 @@ jobs:
   build:
     strategy:
       matrix:
-        mode: [Release, Debug]
-        libcxx: [OFF]
-        ssl: [ON, OFF]
+        mode: [ Release, Debug ]
+        libcxx: [ OFF ]
+        ssl: [ ON, OFF ]
+
     runs-on: ubuntu-22.04
 
     steps:
@@ -24,8 +25,11 @@ jobs:
           sudo apt-get install openssl
           sudo apt-get install libssl-dev
 
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v3
+
       - name: Configure CMake
-        run: CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DBUILD_WITH_LIBCXX=${{matrix.libcxx}} -DENABLE_SSL=${{matrix.ssl}}
+        run: CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DBUILD_WITH_LIBCXX=${{matrix.libcxx}} -DENABLE_SSL=${{matrix.ssl}} -G Ninja
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.mode}}

--- a/.github/workflows/linux_gcc.yml
+++ b/.github/workflows/linux_gcc.yml
@@ -10,9 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        #mode: [Release, Debug]
-        mode: [Debug] # remove Release to reduce ci time
-        ssl: [ON, OFF]
+        mode: [ Debug ] #[Release, Debug]
+        ssl: [ ON, OFF ]
     runs-on: ubuntu-22.04
 
     steps:
@@ -24,8 +23,11 @@ jobs:
           sudo apt-get install openssl
           sudo apt-get install libssl-dev
 
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v3
+
       - name: Configure CMake
-        run: CXX=g++ CC=gcc cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DENABLE_SSL=${{matrix.ssl}}
+        run: CXX=g++ CC=gcc cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DENABLE_SSL=${{matrix.ssl}} -G Ninja
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.mode}}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -6,17 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-
 jobs:
   build:
     strategy:
       matrix:
-        #mode: [Release, Debug]
-        mode: [Debug] # remove Release to reduce ci time
-        ssl: [ON, OFF]
+        mode: [ Debug ]  #mode: [Release, Debug]
+        ssl: [ ON, OFF ]
 
     runs-on: macos-12
 
@@ -31,8 +26,11 @@ jobs:
       - name: Install Dependencies
         run: brew install openssl
 
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v3
+
       - name: Configure CMake
-        run: OPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DENABLE_SSL=${{matrix.ssl}}
+        run: OPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DENABLE_SSL=${{matrix.ssl}} -G Ninja
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.mode}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,45 +6,34 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  # Customize the CMake build type here (Release, Debug, etc.)
-  BUILD_TYPE: Release
-
 jobs:
   build:
     runs-on: windows-latest
 
     strategy:
       matrix:
-        #mode: [ Release, Debug ]
-        mode: [ Debug ]
-        #arch: [ Win32, x64, ARM, ARM64 ]
-        #TODO: support Win32
-        arch: [ x64 ]
-        #ssl: [ON, OFF]
-        ssl: [ OFF ]
-
-    env:
-      CXX: cl.exe
-      CC: cl.exe
+        mode: [ Debug ] #[ Release, Debug ]
+        arch: [ amd64, x86 ] #[ amd64,x86 ]
+        ssl: [ OFF ] #[ ON, OFF ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: SetUp Vcpkg
-        uses: friendlyanon/setup-vcpkg@v1
-        with: { committish: 63aa65e65b9d2c08772ea15d25fb8fdb0d32e557 }
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v3
 
-      - name: test env
-        run: echo $VCPKG_ROOT
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1.12.0
+        with:
+          arch: ${{ matrix.arch }}
 
-      - name: Generate Project
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DyaLanTingLibs_ENABLE_PROJECTS=all -DENABLE_SSL=${{matrix.ssl}} -A ${{ matrix.arch }} -D "CMAKE_TOOLCHAIN_FILE=${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake"
+      - name: Configure CMake
+        run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DENABLE_SSL=${{matrix.ssl}} -G Ninja -B ${{github.workspace}}/build
 
-      - name: Build struct_pack
+      - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{ matrix.mode }}
 
-      - name: Test struct_pack
+      - name: Test
         working-directory: ${{github.workspace}}/build
         run: ctest -C ${{matrix.mode}} -j 1 -V

--- a/cmake/module.cmake
+++ b/cmake/module.cmake
@@ -13,7 +13,7 @@ foreach(proj ${yLT_ALL_PROJECTS})
     endif()
 endforeach()
 
-message(STATUS "--------------yLT_ENABLE_PROJECTS: ${yLT_ENABLE_PROJECTS}")
+message(STATUS "yLT_ENABLE_PROJECTS: ${yLT_ENABLE_PROJECTS}")
 
 foreach(module ${yLT_ENABLE_PROJECTS})
     set(module_location ${CMAKE_SOURCE_DIR}/src/${module})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
CI is very slow for the project

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing
every platfome use ninja as Cmake-generator and Cmake-Makeprogram . 
This version with ninja will be the fastest CI version !!!

add win32 support for CI . 
with ninja CI test for win64 and win32 faster than win64 only. haha 


## Example
Window Server with  `msvc+msbuild` `cmake-configure 9min` `cmake-generate 16min`
But now, when you ues ninja   `msvc+ninja` `cmake-configure 20s` `cmake-generate 6min`

By the way , linux ,macos CI will improve too.

I have tested before  pr , all you want to know about `CI impovement ` can be found at my own fork.
website here ..........
https://github.com/sunflower-knight/yalantinglibs/actions

Strongly recommend developers can accept this pr

##Add`
it will be easier for developer to test `window-across-platform` in the new `Window-CI-yml`  

