### PR TITLE
[struct_pack] Add support for serialize to stream

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -4,7 +4,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     #-ftree-slp-vectorize with coroutine cause link error. disable it util gcc fix.
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-tree-slp-vectorize")
 endif()
-add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wa,-mbig-obj>")
 # --------------------- Clang
 
 # --------------------- Msvc

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -4,7 +4,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     #-ftree-slp-vectorize with coroutine cause link error. disable it util gcc fix.
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-tree-slp-vectorize")
 endif()
-
+add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wa,-mbig-obj>")
 # --------------------- Clang
 
 # --------------------- Msvc

--- a/include/coro_rpc/coro_rpc/async_connection.hpp
+++ b/include/coro_rpc/coro_rpc/async_connection.hpp
@@ -129,8 +129,7 @@ class async_connection : public std::enable_shared_from_this<async_connection> {
     auto buf = struct_pack::serialize_with_offset(RESPONSE_HEADER_LEN, ret);
     rpc_header resp_header = header_;
     resp_header.length = buf.size() - RESPONSE_HEADER_LEN;
-    constexpr auto info = struct_pack::get_serialize_info(rpc_header{});
-    struct_pack::serialize_to(buf.data(), info, resp_header);
+    struct_pack::serialize_to(buf.data(), RPC_HEAD_LEN, resp_header);
 
     io_context_.post([this, buf = std::move(buf), self = shared_from_this()] {
       if (has_closed()) [[unlikely]] {
@@ -236,8 +235,7 @@ class async_connection : public std::enable_shared_from_this<async_connection> {
 
     rpc_header resp_header = header_;
     resp_header.length = buf.size() - RESPONSE_HEADER_LEN;
-    constexpr auto info = struct_pack::get_serialize_info(rpc_header{});
-    struct_pack::serialize_to(buf.data(), info, resp_header);
+    struct_pack::serialize_to(buf.data(), RPC_HEAD_LEN, resp_header);
 
     write(std::move(buf));
 

--- a/include/coro_rpc/coro_rpc/async_connection.hpp
+++ b/include/coro_rpc/coro_rpc/async_connection.hpp
@@ -129,8 +129,8 @@ class async_connection : public std::enable_shared_from_this<async_connection> {
     auto buf = struct_pack::serialize_with_offset(RESPONSE_HEADER_LEN, ret);
     rpc_header resp_header = header_;
     resp_header.length = buf.size() - RESPONSE_HEADER_LEN;
-    [[maybe_unused]] auto sz =
-        struct_pack::serialize_to(buf.data(), RESPONSE_HEADER_LEN, resp_header);
+    constexpr auto info = struct_pack::get_serialize_info(rpc_header{});
+    struct_pack::serialize_to(buf.data(), info, resp_header);
 
     io_context_.post([this, buf = std::move(buf), self = shared_from_this()] {
       if (has_closed()) [[unlikely]] {
@@ -236,8 +236,8 @@ class async_connection : public std::enable_shared_from_this<async_connection> {
 
     rpc_header resp_header = header_;
     resp_header.length = buf.size() - RESPONSE_HEADER_LEN;
-    [[maybe_unused]] auto sz =
-        struct_pack::serialize_to(buf.data(), RESPONSE_HEADER_LEN, resp_header);
+    constexpr auto info = struct_pack::get_serialize_info(rpc_header{});
+    struct_pack::serialize_to(buf.data(), info, resp_header);
 
     write(std::move(buf));
 

--- a/include/coro_rpc/coro_rpc/coro_connection.hpp
+++ b/include/coro_rpc/coro_rpc/coro_connection.hpp
@@ -197,8 +197,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
 
       rpc_header resp_header = header_;
       resp_header.length = buf.size() - RESPONSE_HEADER_LEN;
-      [[maybe_unused]] auto sz = struct_pack::serialize_to(
-          buf.data(), RESPONSE_HEADER_LEN, resp_header);
+      constexpr auto info = struct_pack::get_serialize_info(rpc_header{});
+      struct_pack::serialize_to(buf.data(), info, resp_header);
 
 #ifdef UNIT_TEST_INJECT
       if (g_action == inject_action::close_socket_after_send_length) {
@@ -250,8 +250,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     auto buf = struct_pack::serialize_with_offset(RESPONSE_HEADER_LEN, ret);
     rpc_header resp_header = header_;
     resp_header.length = buf.size() - RESPONSE_HEADER_LEN;
-    [[maybe_unused]] auto sz =
-        struct_pack::serialize_to(buf.data(), RESPONSE_HEADER_LEN, resp_header);
+    constexpr auto info = struct_pack::get_serialize_info(rpc_header{});
+    struct_pack::serialize_to(buf.data(), info, resp_header);
 
     auto self = shared_from_this();
     response(std::move(buf), std::move(self)).via(&executor_).detach();

--- a/include/coro_rpc/coro_rpc/coro_connection.hpp
+++ b/include/coro_rpc/coro_rpc/coro_connection.hpp
@@ -197,8 +197,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
 
       rpc_header resp_header = header_;
       resp_header.length = buf.size() - RESPONSE_HEADER_LEN;
-      constexpr auto info = struct_pack::get_serialize_info(rpc_header{});
-      struct_pack::serialize_to(buf.data(), info, resp_header);
+      struct_pack::serialize_to(buf.data(), RPC_HEAD_LEN, resp_header);
 
 #ifdef UNIT_TEST_INJECT
       if (g_action == inject_action::close_socket_after_send_length) {
@@ -250,8 +249,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     auto buf = struct_pack::serialize_with_offset(RESPONSE_HEADER_LEN, ret);
     rpc_header resp_header = header_;
     resp_header.length = buf.size() - RESPONSE_HEADER_LEN;
-    constexpr auto info = struct_pack::get_serialize_info(rpc_header{});
-    struct_pack::serialize_to(buf.data(), info, resp_header);
+    struct_pack::serialize_to(buf.data(), RPC_HEAD_LEN, resp_header);
 
     auto self = shared_from_this();
     response(std::move(buf), std::move(self)).via(&executor_).detach();

--- a/include/coro_rpc/coro_rpc/coro_rpc_client.hpp
+++ b/include/coro_rpc/coro_rpc/coro_rpc_client.hpp
@@ -548,9 +548,9 @@ class coro_rpc_client {
 #ifdef UNIT_TEST_INJECT
     }
 #endif
-    [[maybe_unused]] auto sz =
-        struct_pack::serialize_to(buffer.data(), RPC_HEAD_LEN, header);
-    assert(sz == RPC_HEAD_LEN);
+    constexpr auto info = struct_pack::get_serialize_info(header);
+    static_assert(info.size() == RPC_HEAD_LEN);
+    struct_pack::serialize_to((char *)buffer.data(), info, header);
     return buffer;
   }
 
@@ -558,7 +558,7 @@ class coro_rpc_client {
   rpc_result<T> handle_response_buffer(const std::byte *buffer,
                                        std::size_t len) {
     rpc_return_type_t<T> ret;
-    auto ec = struct_pack::deserialize_to(ret, buffer, len);
+    auto ec = struct_pack::deserialize_to(ret, (const char *)buffer, len);
     if (ec == struct_pack::errc::ok) {
       if constexpr (std::is_same_v<T, void>) {
         return {};
@@ -569,7 +569,7 @@ class coro_rpc_client {
     }
     else {
       rpc_error err;
-      auto ec = struct_pack::deserialize_to(err, buffer, len);
+      auto ec = struct_pack::deserialize_to(err, (const char *)buffer, len);
       if (ec != struct_pack::errc::ok) {
         // if deserialize failed again,
         // we can do nothing but give an error code.

--- a/include/coro_rpc/coro_rpc/coro_rpc_client.hpp
+++ b/include/coro_rpc/coro_rpc/coro_rpc_client.hpp
@@ -548,9 +548,7 @@ class coro_rpc_client {
 #ifdef UNIT_TEST_INJECT
     }
 #endif
-    constexpr auto info = struct_pack::get_serialize_info(header);
-    static_assert(info.size() == RPC_HEAD_LEN);
-    struct_pack::serialize_to((char *)buffer.data(), info, header);
+    struct_pack::serialize_to((char *)buffer.data(), RPC_HEAD_LEN, header);
     return buffer;
   }
 

--- a/include/coro_rpc/coro_rpc/rpc_protocol.h
+++ b/include/coro_rpc/coro_rpc/rpc_protocol.h
@@ -76,11 +76,10 @@ using unexpected = tl::unexpected<T>;
 using unexpect_t = tl::unexpect_t;
 #endif
 
-constexpr int RPC_HEAD_LEN =
-    struct_pack::get_serialize_info(rpc_header{}).size();
+constexpr auto RPC_HEAD_LEN = struct_pack::get_needed_size(rpc_header{});
 static_assert(RPC_HEAD_LEN == 16);
 
-constexpr int RESPONSE_HEADER_LEN = RPC_HEAD_LEN;
+constexpr auto RESPONSE_HEADER_LEN = RPC_HEAD_LEN;
 constexpr int FUNCTION_ID_LEN = 4;
 
 constexpr int8_t magic_number = 21;

--- a/include/coro_rpc/coro_rpc/rpc_protocol.h
+++ b/include/coro_rpc/coro_rpc/rpc_protocol.h
@@ -76,7 +76,8 @@ using unexpected = tl::unexpected<T>;
 using unexpect_t = tl::unexpect_t;
 #endif
 
-constexpr int RPC_HEAD_LEN = struct_pack::get_needed_size(rpc_header{});
+constexpr int RPC_HEAD_LEN =
+    struct_pack::get_serialize_info(rpc_header{}).size();
 static_assert(RPC_HEAD_LEN == 16);
 
 constexpr int RESPONSE_HEADER_LEN = RPC_HEAD_LEN;

--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -168,86 +168,38 @@ STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal() {
 }
 
 template <serialize_config conf = serialize_config{}, typename... Args>
-[[nodiscard]] STRUCT_PACK_INLINE constexpr size_t get_needed_size(
-    const Args &...args) {
-  return detail::get_serialize_runtime_info<conf>(args...).len;
+[[nodiscard]] STRUCT_PACK_INLINE constexpr serialize_runtime_info
+get_serialize_info(const Args &...args) {
+  return detail::get_serialize_runtime_info<conf>(args...);
 }
 
 template <serialize_config conf = serialize_config{},
-          detail::struct_pack_byte Byte, typename... Args>
-std::size_t STRUCT_PACK_INLINE serialize_to(Byte *buffer, std::size_t len,
-                                            const Args &...args) noexcept {
+          struct_pack::writer_t Writer, typename... Args>
+STRUCT_PACK_INLINE void serialize_to(Writer &writer, const Args &...args) {
   static_assert(sizeof...(args) > 0);
-  auto config = detail::get_serialize_runtime_info<conf>(args...);
-  if (config.len > len) [[unlikely]] {
-    return 0;
-  }
-  detail::packer<Byte, detail::get_args_type<Args...>> o(buffer, config);
-  switch ((config.metainfo & 0b11000) >> 3) {
-    case 0:
-      o.template serialize<conf, 1>(args...);
-      break;
-#ifdef STRUCT_PACK_OPTIMIZE
-    case 1:
-      o.template serialize<conf, 2>(args...);
-      break;
-    case 2:
-      o.template serialize<conf, 4>(args...);
-      break;
-    case 3:
-      o.template serialize<conf, 8>(args...);
-      break;
-#else
-    case 1:
-    case 2:
-    case 3:
-      o.template serialize<conf, 2>(args...);
-      break;
-#endif
-    default:
-      detail::unreachable();
-      break;
-  };
-  return config.len;
+  auto info = detail::get_serialize_runtime_info<conf>(args...);
+  struct_pack::detail::serialize_to<conf>(writer, info, args...);
+}
+
+template <serialize_config conf = serialize_config{}, typename... Args>
+void STRUCT_PACK_INLINE serialize_to(char *buffer, serialize_runtime_info info,
+                                     const Args &...args) noexcept {
+  static_assert(sizeof...(args) > 0);
+  auto writer = struct_pack::detail::memory_writer{(char *)buffer};
+  struct_pack::detail::serialize_to<conf>(writer, info, args...);
 }
 
 template <serialize_config conf = serialize_config{},
           detail::struct_pack_buffer Buffer, typename... Args>
-STRUCT_PACK_INLINE void serialize_to(Buffer &buffer, const Args &...args) {
+void STRUCT_PACK_INLINE serialize_to(Buffer &buffer, const Args &...args) {
   static_assert(sizeof...(args) > 0);
   auto data_offset = buffer.size();
-  auto config = detail::get_serialize_runtime_info<conf>(args...);
-  auto total = data_offset + config.len;
+  auto info = detail::get_serialize_runtime_info<conf>(args...);
+  auto total = data_offset + info.size();
   buffer.resize(total);
-
-  detail::packer<std::remove_reference_t<decltype(*buffer.data())>,
-                 detail::get_args_type<Args...>>
-      o(buffer.data() + data_offset, config);
-  switch ((config.metainfo & 0b11000) >> 3) {
-    case 0:
-      o.template serialize<conf, 1>(args...);
-      break;
-#ifdef STRUCT_PACK_OPTIMIZE
-    case 1:
-      o.template serialize<conf, 2>(args...);
-      break;
-    case 2:
-      o.template serialize<conf, 4>(args...);
-      break;
-    case 3:
-      o.template serialize<conf, 8>(args...);
-      break;
-#else
-    case 1:
-    case 2:
-    case 3:
-      o.template serialize<conf, 2>(args...);
-      break;
-#endif
-    default:
-      detail::unreachable();
-      break;
-  };
+  auto writer =
+      struct_pack::detail::memory_writer{(char *)buffer.data() + data_offset};
+  struct_pack::detail::serialize_to<conf>(writer, info, args...);
 }
 
 template <serialize_config conf = serialize_config{},
@@ -256,8 +208,12 @@ void STRUCT_PACK_INLINE serialize_to_with_offset(Buffer &buffer,
                                                  std::size_t offset,
                                                  const Args &...args) {
   static_assert(sizeof...(args) > 0);
-  buffer.resize(buffer.size() + offset);
-  serialize_to<conf>(buffer, args...);
+  auto info = detail::get_serialize_runtime_info<conf>(args...);
+  auto old_size = buffer.size();
+  buffer.resize(old_size + offset + info.size());
+  auto writer = struct_pack::detail::memory_writer{(char *)buffer.data() +
+                                                   old_size + offset};
+  struct_pack::detail::serialize_to<conf>(writer, info, args...);
 }
 
 template <detail::struct_pack_buffer Buffer = std::vector<char>,
@@ -275,55 +231,104 @@ template <detail::struct_pack_buffer Buffer = std::vector<char>,
 serialize_with_offset(std::size_t offset, const Args &...args) {
   static_assert(sizeof...(args) > 0);
   Buffer buffer;
-  buffer.resize(offset);
-  serialize_to<conf>(buffer, args...);
+  serialize_to_with_offset<conf>(buffer, offset, args...);
   return buffer;
 }
 
 template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
     T &t, const View &v, Args &...args) {
-  detail::unpacker in(v.data(), v.size());
+  detail::memory_reader reader{(const char *)v.data(),
+                               (const char *)v.data() + v.size()};
+  detail::unpacker in(reader);
   return in.deserialize(t, args...);
 }
 
-template <typename T, typename... Args, detail::struct_pack_byte Byte>
+template <typename T, typename... Args>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
-    T &t, const Byte *data, size_t size, Args &...args) {
-  detail::unpacker in(data, size);
+    T &t, const char *data, size_t size, Args &...args) {
+  detail::memory_reader reader{data, data + size};
+  detail::unpacker in(reader);
   return in.deserialize(t, args...);
+}
+
+template <typename T, typename... Args, struct_pack::reader_t Reader>
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
+    T &t, Reader &reader, Args &...args) {
+  detail::unpacker in(reader);
+  std::size_t consume_len;
+  auto old_pos = reader.tellg();
+  auto ret = in.deserialize_with_len(consume_len, t, args...);
+  std::size_t delta = reader.tellg() - old_pos;
+  if (ret == errc{}) [[likely]] {
+    if (consume_len > 0) [[likely]] {
+      if (delta > consume_len) [[unlikely]] {
+        ret = struct_pack::errc::invalid_buffer;
+        if constexpr (struct_pack::seek_reader_t<Reader>)
+          if (!reader.seekg(old_pos)) [[unlikely]] {
+            return struct_pack::errc::seek_failed;
+          }
+      }
+      else {
+        reader.ignore(consume_len - delta);
+      }
+    }
+  }
+  else {
+    if constexpr (struct_pack::seek_reader_t<Reader>)
+      if (!reader.seekg(old_pos)) [[unlikely]] {
+        return struct_pack::errc::seek_failed;
+      }
+  }
+  return ret;
 }
 
 template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
     T &t, const View &v, size_t &consume_len, Args &...args) {
-  detail::unpacker in(v.data(), v.size());
-  return in.deserialize(consume_len, t, args...);
+  detail::memory_reader reader{(const char *)v.data(),
+                               (const char *)v.data() + v.size()};
+  detail::unpacker in(reader);
+  auto ret = in.deserialize_with_len(consume_len, t, args...);
+  if (ret == errc{}) [[likely]] {
+    consume_len = std::max((size_t)(reader.now - v.data()), consume_len);
+  }
+  else {
+    consume_len = 0;
+  }
+  return ret;
 }
 
-template <typename T, typename... Args, detail::struct_pack_byte Byte>
+template <typename T, typename... Args>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to(
-    T &t, const Byte *data, size_t size, size_t &consume_len, Args &...args) {
-  detail::unpacker in(data, size);
-  return in.deserialize(consume_len, t, args...);
+    T &t, const char *data, size_t size, size_t &consume_len, Args &...args) {
+  detail::memory_reader reader{data, data + size};
+  detail::unpacker in(reader);
+  auto ret = in.deserialize_with_len(consume_len, t, args...);
+  if (ret == errc{}) [[likely]] {
+    consume_len = std::max((size_t)(reader.now - data), consume_len);
+  }
+  else {
+    consume_len = 0;
+  }
+  return ret;
 }
 
 template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to_with_offset(
     T &t, const View &v, size_t &offset, Args &...args) {
-  detail::unpacker in(v.data() + offset, v.size() - offset);
   size_t sz;
-  auto ret = in.deserialize(sz, t, args...);
+  auto ret =
+      deserialize_to(t, v.data() + offset, v.size() - offset, sz, args...);
   offset += sz;
   return ret;
 }
 
-template <typename T, typename... Args, detail::struct_pack_byte Byte>
+template <typename T, typename... Args>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_to_with_offset(
-    T &t, const Byte *data, size_t size, size_t &offset, Args &...args) {
-  detail::unpacker in(data + offset, size - offset);
+    T &t, const char *data, size_t size, size_t &offset, Args &...args) {
   size_t sz;
-  auto ret = in.deserialize(sz, t, args...);
+  auto ret = deserialize_to(t, data + offset, size - offset, sz, args...);
   offset += sz;
   return ret;
 }
@@ -331,18 +336,29 @@ template <typename T, typename... Args, detail::struct_pack_byte Byte>
 template <typename T, typename... Args, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const View &v) {
   expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
-  if (auto errc = deserialize_to(ret.value(), v); errc != struct_pack::errc{}) {
+  if (auto errc = deserialize_to(ret.value(), v); errc != struct_pack::errc{})
+      [[unlikely]] {
     ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
 
-template <typename T, typename... Args, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const Byte *data,
+template <typename T, typename... Args>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const char *data,
                                                   size_t size) {
   expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to(ret.value(), data, size);
       errc != struct_pack::errc{}) {
+    ret = unexpected<struct_pack::errc>{errc};
+  }
+  return ret;
+}
+
+template <typename T, typename... Args, struct_pack::reader_t Reader>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(Reader &v) {
+  expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
+  if (auto errc = deserialize_to(ret.value(), v); errc != struct_pack::errc{})
+      [[unlikely]] {
     ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
@@ -353,18 +369,18 @@ template <typename T, typename... Args, detail::deserialize_view View>
                                                   size_t &consume_len) {
   expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to(ret.value(), v, consume_len);
-      errc != struct_pack::errc{}) {
+      errc != struct_pack::errc{}) [[unlikely]] {
     ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
 
-template <typename T, typename... Args, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const Byte *data, size_t size,
+template <typename T, typename... Args>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize(const char *data, size_t size,
                                                   size_t &consume_len) {
   expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to(ret.value(), data, size, consume_len);
-      errc != struct_pack::errc{}) {
+      errc != struct_pack::errc{}) [[unlikely]] {
     ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
@@ -375,19 +391,19 @@ template <typename T, typename... Args, detail::deserialize_view View>
                                                               size_t &offset) {
   expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to_with_offset(ret.value(), v, offset);
-      errc != struct_pack::errc{}) {
+      errc != struct_pack::errc{}) [[unlikely]] {
     ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
 }
 
-template <typename T, typename... Args, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE auto deserialize_with_offset(const Byte *data,
+template <typename T, typename... Args>
+[[nodiscard]] STRUCT_PACK_INLINE auto deserialize_with_offset(const char *data,
                                                               size_t size,
                                                               size_t &offset) {
   expected<detail::get_args_type<T, Args...>, struct_pack::errc> ret;
   if (auto errc = deserialize_to_with_offset(ret.value(), data, size, offset);
-      errc != struct_pack::errc{}) {
+      errc != struct_pack::errc{}) [[unlikely]] {
     ret = unexpected<struct_pack::errc>{errc};
   }
   return ret;
@@ -401,19 +417,34 @@ template <typename T, size_t I, typename Field, detail::deserialize_view View>
   static_assert(std::is_same_v<Field, T_Field>,
                 "The dst's type is not correct. It should be as same as the "
                 "T's Ith field's type");
-  detail::unpacker in(v.data(), v.size());
+  detail::memory_reader reader((const char *)v.data(),
+                               (const char *)v.data() + v.size());
+  detail::unpacker in(reader);
   return in.template get_field<T, I>(dst);
 }
 
-template <typename T, size_t I, typename Field, detail::struct_pack_byte Byte>
+template <typename T, size_t I, typename Field>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc get_field_to(
-    Field &dst, const Byte *data, size_t size) {
+    Field &dst, const char *data, size_t size) {
   using T_Field =
       std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
   static_assert(std::is_same_v<Field, T_Field>,
                 "The dst's type is not correct. It should be as same as the "
                 "T's Ith field's type");
-  detail::unpacker in(data, size);
+  detail::memory_reader reader{data, data + size};
+  detail::unpacker in(reader);
+  return in.template get_field<T, I>(dst);
+}
+
+template <typename T, size_t I, typename Field, struct_pack::reader_t Reader>
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc get_field_to(
+    Field &dst, Reader &reader) {
+  using T_Field =
+      std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
+  static_assert(std::is_same_v<Field, T_Field>,
+                "The dst's type is not correct. It should be as same as the "
+                "T's Ith field's type");
+  detail::unpacker in(reader);
   return in.template get_field<T, I>(dst);
 }
 
@@ -421,24 +452,33 @@ template <typename T, size_t I, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE auto get_field(const View &v) {
   using T_Field =
       std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
-  detail::unpacker in(v.data(), v.size());
   expected<T_Field, struct_pack::errc> ret;
-
-  if (auto ec = get_field_to<T, I>(ret.value(), v); ec != struct_pack::errc{}) {
+  if (auto ec = get_field_to<T, I>(ret.value(), v); ec != struct_pack::errc{})
+      [[unlikely]] {
     ret = unexpected<struct_pack::errc>{ec};
   }
   return ret;
 }
 
-template <typename T, size_t I, detail::struct_pack_byte Byte>
-[[nodiscard]] STRUCT_PACK_INLINE auto get_field(const Byte *data, size_t size) {
+template <typename T, size_t I>
+[[nodiscard]] STRUCT_PACK_INLINE auto get_field(const char *data, size_t size) {
   using T_Field =
       std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
-  detail::unpacker in(data, size);
   expected<T_Field, struct_pack::errc> ret;
-
   if (auto ec = get_field_to<T, I>(ret.value(), data, size);
-      ec != struct_pack::errc{}) {
+      ec != struct_pack::errc{}) [[unlikely]] {
+    ret = unexpected<struct_pack::errc>{ec};
+  }
+  return ret;
+}
+
+template <typename T, size_t I, struct_pack::reader_t Reader>
+[[nodiscard]] STRUCT_PACK_INLINE auto get_field(Reader &reader) {
+  using T_Field =
+      std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
+  expected<T_Field, struct_pack::errc> ret;
+  if (auto ec = get_field_to<T, I>(ret.value(), reader);
+      ec != struct_pack::errc{}) [[unlikely]] {
     ret = unexpected<struct_pack::errc>{ec};
   }
   return ret;

--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -168,8 +168,8 @@ STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal() {
 }
 
 template <serialize_config conf = serialize_config{}, typename... Args>
-[[nodiscard]] STRUCT_PACK_INLINE constexpr serialize_runtime_info
-get_serialize_info(const Args &...args) {
+[[nodiscard]] STRUCT_PACK_INLINE constexpr serialize_buffer_size
+get_needed_size(const Args &...args) {
   return detail::get_serialize_runtime_info<conf>(args...);
 }
 
@@ -182,7 +182,7 @@ STRUCT_PACK_INLINE void serialize_to(Writer &writer, const Args &...args) {
 }
 
 template <serialize_config conf = serialize_config{}, typename... Args>
-void STRUCT_PACK_INLINE serialize_to(char *buffer, serialize_runtime_info info,
+void STRUCT_PACK_INLINE serialize_to(char *buffer, serialize_buffer_size info,
                                      const Args &...args) noexcept {
   static_assert(sizeof...(args) > 0);
   auto writer = struct_pack::detail::memory_writer{(char *)buffer};

--- a/include/struct_pack/struct_pack/error_code.h
+++ b/include/struct_pack/struct_pack/error_code.h
@@ -6,8 +6,9 @@ namespace struct_pack {
 enum class errc {
   ok = 0,
   no_buffer_space,
-  invalid_argument,
+  invalid_buffer,
   hash_conflict,
+  seek_failed,
 };
 
 namespace detail {
@@ -24,7 +25,7 @@ class struct_pack_category : public std::error_category {
         return "ok";
       case errc::no_buffer_space:
         return "no buffer space";
-      case errc::invalid_argument:
+      case errc::invalid_buffer:
         return "invalid argument";
       case errc::hash_conflict:
         return "hash conflict";

--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -67,6 +67,7 @@ concept seek_reader_t = reader_t<T> && requires(T t) {
   t.seekg(std::size_t{});
 };
 
+//clang-format off
 namespace detail {
   template <typename Type>
   concept deserialize_view = requires(Type container) {

--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include <cstddef>
+#include <cstring>
 #include <set>
 #include <string>
 #include <string_view>
@@ -44,1299 +45,1342 @@ constexpr std::size_t members_count = 0;
 template <typename T>
 constexpr std::size_t min_alignment = 0;
 
+template <typename T>
+concept writer_t = requires(T t) {
+  t.write((const char *)nullptr, std::size_t{});
+};
+
+template <typename T>
+concept reader_t = requires(T t) {
+  t.read((char *)nullptr, std::size_t{});
+  t.ignore(std::size_t{});
+  t.tellg();
+};
+
+template <typename T>
+concept view_reader_t = reader_t<T> && requires(T t) {
+  { t.read_view(std::size_t{}) } -> std::convertible_to<const char *>;
+};
+
+template <typename T>
+concept seek_reader_t = reader_t<T> && requires(T t) {
+  t.seekg(std::size_t{});
+};
+
 namespace detail {
-template <typename Type>
-concept deserialize_view = requires(Type container) {
-  container.size();
-  container.data();
-};
+  template <typename Type>
+  concept deserialize_view = requires(Type container) {
+    container.size();
+    container.data();
+  };
 
-template <typename Type>
-concept container_adapter = requires(Type container) {
-  typename std::remove_cvref_t<Type>::value_type;
-  container.size();
-  container.pop();
-};
+  struct memory_writer {
+    char *buffer;
+    STRUCT_PACK_INLINE void write(const char *data, std::size_t len) {
+      memcpy(buffer, data, len);
+      buffer += len;
+    }
+  };
 
-template <typename Type>
-concept container = requires(Type container) {
-  typename std::remove_cvref_t<Type>::value_type;
-  container.size();
-  container.begin();
-  container.end();
-};
+  template <typename Type>
+  concept container_adapter = requires(Type container) {
+    typename std::remove_cvref_t<Type>::value_type;
+    container.size();
+    container.pop();
+  };
 
-template <typename Type>
-concept is_char_t = std::is_same_v<Type, signed char> ||
-    std::is_same_v<Type, char> || std::is_same_v<Type, unsigned char> ||
-    std::is_same_v<Type, wchar_t> || std::is_same_v<Type, char16_t> ||
-    std::is_same_v<Type, char32_t> || std::is_same_v<Type, char8_t>;
+  template <typename Type>
+  concept container = requires(Type container) {
+    typename std::remove_cvref_t<Type>::value_type;
+    container.size();
+    container.begin();
+    container.end();
+  };
 
-template <typename Type>
-concept string = container<Type> && requires(Type container) {
-  requires is_char_t<typename std::remove_cvref_t<Type>::value_type>;
-  container.length();
-  container.data();
-};
+  template <typename Type>
+  concept is_char_t = std::is_same_v<Type, signed char> ||
+      std::is_same_v<Type, char> || std::is_same_v<Type, unsigned char> ||
+      std::is_same_v<Type, wchar_t> || std::is_same_v<Type, char16_t> ||
+      std::is_same_v<Type, char32_t> || std::is_same_v<Type, char8_t>;
 
-template <typename Type>
-concept string_view = string<Type> && !requires(Type container) {
-  container.resize(std::size_t{});
-};
+  template <typename Type>
+  concept string = container<Type> && requires(Type container) {
+    requires is_char_t<typename std::remove_cvref_t<Type>::value_type>;
+    container.length();
+    container.data();
+  };
+
+  template <typename Type>
+  concept string_view = string<Type> && !requires(Type container) {
+    container.resize(std::size_t{});
+  };
 
 #if __cpp_lib_span >= 202002L
 
-template <typename Type>
-concept continuous_container = string<Type> ||
-    (container<Type> &&requires(Type container) {
-      std::span{container};
-      container.resize(std::size_t{});
-    });
+  template <typename Type>
+  concept continuous_container =
+      string<Type> ||(container<Type> && requires(Type container) {
+        std::span{container};
+        container.resize(std::size_t{});
+      });
 
 #else
 
 #include <string>
 #include <vector>
 
-template <typename Type>
-constexpr inline bool is_std_basic_string_v = false;
+  template <typename Type>
+  constexpr inline bool is_std_basic_string_v = false;
 
-template <typename... args>
-constexpr inline bool is_std_basic_string_v<std::basic_string<args...>> = true;
+  template <typename... args>
+  constexpr inline bool is_std_basic_string_v<std::basic_string<args...>> =
+      true;
 
-template <typename Type>
-constexpr inline bool is_std_vector_v = false;
+  template <typename Type>
+  constexpr inline bool is_std_vector_v = false;
 
-template <typename... args>
-constexpr inline bool is_std_vector_v<std::vector<args...>> = true;
+  template <typename... args>
+  constexpr inline bool is_std_vector_v<std::vector<args...>> = true;
 
-template <typename Type>
-concept continuous_container = container<Type> &&
-    (is_std_vector_v<Type> || is_std_basic_string_v<Type>);
+  template <typename Type>
+  concept continuous_container =
+      container<Type> &&(is_std_vector_v<Type> || is_std_basic_string_v<Type>);
 #endif
 
-template <typename Type>
-concept map_container = container<Type> && requires(Type container) {
-  typename std::remove_cvref_t<Type>::mapped_type;
-};
-
-template <typename Type>
-concept set_container = container<Type> && requires(Type container) {
-  typename std::remove_cvref_t<Type>::key_type;
-};
-
-template <typename Type>
-concept tuple = requires(Type tuple) {
-  std::get<0>(tuple);
-  sizeof(std::tuple_size<std::remove_cvref_t<Type>>);
-};
-
-template <typename Type>
-concept tuple_size = requires(Type tuple) {
-  sizeof(std::tuple_size<std::remove_cvref_t<Type>>);
-};
-
-template <typename Type>
-concept array = requires(Type arr) {
-  arr.size();
-  std::tuple_size<std::remove_cvref_t<Type>>{};
-};
-
-// this version not work, can't checkout the is_xx_v in ```require(Type){...}```
-template <typename Type>
-concept c_array1 = requires(Type arr) {
-  std::is_array_v<Type> == true;
-};
-
-template <class T>
-concept c_array = std::is_array_v<T> && std::extent_v<std::remove_cvref_t<T>> >
-0;
-
-template <typename Type>
-concept pair = requires(Type p) {
-  typename std::remove_cvref_t<Type>::first_type;
-  typename std::remove_cvref_t<Type>::second_type;
-  p.first;
-  p.second;
-};
-
-template <typename Type>
-concept expected = requires(Type e) {
-  typename std::remove_cvref_t<Type>::value_type;
-  typename std::remove_cvref_t<Type>::error_type;
-  typename std::remove_cvref_t<Type>::unexpected_type;
-  e.has_value();
-  e.error();
-  requires std::is_same_v<void,
-                          typename std::remove_cvref_t<Type>::value_type> ||
-      requires(Type e) {
-    e.value();
+  template <typename Type>
+  concept map_container = container<Type> && requires(Type container) {
+    typename std::remove_cvref_t<Type>::mapped_type;
   };
-};
 
-template <typename Type>
-concept optional = !expected<Type> && requires(Type optional) {
-  optional.value();
-  optional.has_value();
-  optional.operator*();
-  typename std::remove_cvref_t<Type>::value_type;
-};
+  template <typename Type>
+  concept set_container = container<Type> && requires(Type container) {
+    typename std::remove_cvref_t<Type>::key_type;
+  };
 
-template <typename Type>
-concept unique_ptr = requires(Type ptr) {
-  ptr.operator*();
-  typename std::remove_cvref_t<Type>::element_type;
-}
-&&!requires(Type ptr, Type ptr2) { ptr = ptr2; };
+  template <typename Type>
+  concept tuple = requires(Type tuple) {
+    std::get<0>(tuple);
+    sizeof(std::tuple_size<std::remove_cvref_t<Type>>);
+  };
 
-template <typename Type>
-constexpr inline bool is_variant_v = false;
+  template <typename Type>
+  concept tuple_size = requires(Type tuple) {
+    sizeof(std::tuple_size<std::remove_cvref_t<Type>>);
+  };
 
-template <typename... args>
-constexpr inline bool is_variant_v<std::variant<args...>> = true;
+  template <typename Type>
+  concept array = requires(Type arr) {
+    arr.size();
+    std::tuple_size<std::remove_cvref_t<Type>>{};
+  };
 
-template <typename T>
-concept variant = is_variant_v<T>;
+  // this version not work, can't checkout the is_xx_v in
+  // ```require(Type){...}```
+  template <typename Type>
+  concept c_array1 = requires(Type arr) {
+    std::is_array_v<Type> == true;
+  };
 
-struct UniversalType {
+  template <class T>
+  concept c_array =
+      std::is_array_v<T> && std::extent_v<std::remove_cvref_t<T>> >
+  0;
+
+  template <typename Type>
+  concept pair = requires(Type p) {
+    typename std::remove_cvref_t<Type>::first_type;
+    typename std::remove_cvref_t<Type>::second_type;
+    p.first;
+    p.second;
+  };
+
+  template <typename Type>
+  concept expected = requires(Type e) {
+    typename std::remove_cvref_t<Type>::value_type;
+    typename std::remove_cvref_t<Type>::error_type;
+    typename std::remove_cvref_t<Type>::unexpected_type;
+    e.has_value();
+    e.error();
+    requires std::is_same_v<void,
+                            typename std::remove_cvref_t<Type>::value_type> ||
+        requires(Type e) {
+      e.value();
+    };
+  };
+
+  template <typename Type>
+  concept unique_ptr = requires(Type ptr) {
+    ptr.operator*();
+    typename std::remove_cvref_t<Type>::element_type;
+  }
+  &&!requires(Type ptr, Type ptr2) { ptr = ptr2; };
+
+  template <typename Type>
+  concept optional = !expected<Type> && requires(Type optional) {
+    optional.value();
+    optional.has_value();
+    optional.operator*();
+    typename std::remove_cvref_t<Type>::value_type;
+  };
+
+  template <typename Type>
+  constexpr inline bool is_variant_v = false;
+
+  template <typename... args>
+  constexpr inline bool is_variant_v<std::variant<args...>> = true;
+
   template <typename T>
-  operator T();
-};
+  concept variant = is_variant_v<T>;
 
-template <typename T>
-concept integral = std::is_integral_v<T>;
+  struct UniversalType {
+    template <typename T>
+    operator T();
+  };
 
-struct UniversalIntegralType {
-  template <integral T>
-  operator T();
-};
+  template <typename T>
+  concept integral = std::is_integral_v<T>;
 
-struct UniversalOptionalType {
-  template <optional U>
-  operator U();
-};
+  struct UniversalIntegralType {
+    template <integral T>
+    operator T();
+  };
 
-struct UniversalNullptrType {
-  operator std::nullptr_t();
-};
+  struct UniversalNullptrType {
+    operator std::nullptr_t();
+  };
 
-template <typename T, typename... Args>
-consteval std::size_t member_count_impl() {
-  if constexpr (requires { T{{Args{}}..., {UniversalType{}}}; } == true) {
-    return member_count_impl<T, Args..., UniversalType>();
-  }
-  else if constexpr (requires {
-                       T{{Args{}}..., {UniversalOptionalType{}}};
-                     } == true) {
-    return member_count_impl<T, Args..., UniversalOptionalType>();
-  }
-  else if constexpr (requires {
-                       T{{Args{}}..., {UniversalIntegralType{}}};
-                     } == true) {
-    return member_count_impl<T, Args..., UniversalIntegralType>();
-  }
-  else if constexpr (requires {
-                       T{{Args{}}..., {UniversalNullptrType{}}};
-                     } == true) {
-    return member_count_impl<T, Args..., UniversalNullptrType>();
-  }
-  else {
-    return sizeof...(Args);
-  }
-}
+  struct UniversalOptionalType {
+    template <optional U>
+    operator U();
+  };
 
-template <typename T>
-consteval std::size_t member_count() {
-  if constexpr (struct_pack::members_count < T >> 0) {
-    return struct_pack::members_count<T>;
+  template <typename T, typename... Args>
+  consteval std::size_t member_count_impl() {
+    if constexpr (requires { T{{Args{}}..., {UniversalType{}}}; } == true) {
+      return member_count_impl<T, Args..., UniversalType>();
+    }
+    else if constexpr (requires {
+                         T{{Args{}}..., {UniversalOptionalType{}}};
+                       } == true) {
+      return member_count_impl<T, Args..., UniversalOptionalType>();
+    }
+    else if constexpr (requires {
+                         T{{Args{}}..., {UniversalIntegralType{}}};
+                       } == true) {
+      return member_count_impl<T, Args..., UniversalIntegralType>();
+    }
+    else if constexpr (requires {
+                         T{{Args{}}..., {UniversalNullptrType{}}};
+                       } == true) {
+      return member_count_impl<T, Args..., UniversalNullptrType>();
+    }
+    else {
+      return sizeof...(Args);
+    }
   }
-  else if constexpr (tuple_size<T>) {
-    return std::tuple_size<T>::value;
-  }
-  else {
-    return member_count_impl<T>();
-  }
-}
-// add extension like `members_count`
-template <typename T>
-consteval std::size_t min_align() {
-  if constexpr (struct_pack::min_alignment < T >> 0) {
-    return struct_pack::min_alignment<T>;
-  }
-  else {
-    // don't use \0 as 0
-    // due to \0 is a special flag for struct_pack
-    // '0' ascii code is 48
-    return '0';
-  }
-}
-// similar to `min_align`
-template <typename T>
-consteval std::size_t max_align() {
-  static_assert(std::alignment_of_v<T> > 0);
-  return std::alignment_of_v<T>;
-}
 
-constexpr static auto MaxVisitMembers = 64;
+  template <typename T>
+  consteval std::size_t member_count() {
+    if constexpr (struct_pack::members_count < T >> 0) {
+      return struct_pack::members_count<T>;
+    }
+    else if constexpr (tuple_size<T>) {
+      return std::tuple_size<T>::value;
+    }
+    else {
+      return member_count_impl<T>();
+    }
+  }
+  // add extension like `members_count`
+  template <typename T>
+  consteval std::size_t min_align() {
+    if constexpr (struct_pack::min_alignment < T >> 0) {
+      return struct_pack::min_alignment<T>;
+    }
+    else {
+      // don't use \0 as 0
+      // due to \0 is a special flag for struct_pack
+      // '0' ascii code is 48
+      return '0';
+    }
+  }
+  // similar to `min_align`
+  template <typename T>
+  consteval std::size_t max_align() {
+    static_assert(std::alignment_of_v<T> > 0);
+    return std::alignment_of_v<T>;
+  }
 
-constexpr decltype(auto) STRUCT_PACK_INLINE visit_members(auto &&object,
-                                                          auto &&visitor) {
-  using type = std::remove_cvref_t<decltype(object)>;
-  constexpr auto Count = member_count<type>();
-  if constexpr (Count == 0 && std::is_class_v<type> &&
-                !std::is_same_v<type, std::monostate>) {
-    static_assert(!sizeof(type), "empty struct/class is not allowed!");
-  }
-  static_assert(Count <= MaxVisitMembers, "exceed max visit members");
-  // If you see any structured binding error in the follow line, it
-  // means struct_pack can't calculate your struct's members count
-  // correctly. You need to mark it manually.
-  //
-  // For example, there is a struct named Hello,
-  // and it has 3 members.
-  //
-  // You can mark it as:
-  //
-  // template <>
-  // constexpr size_t struct_pack::members_count<Hello> = 3;
+  constexpr static auto MaxVisitMembers = 64;
 
-  if constexpr (Count == 0) {
-    return visitor();
-  }
-  else if constexpr (Count == 1) {
-    auto &&[a1] = object;
-    return visitor(a1);
-  }
-  else if constexpr (Count == 2) {
-    auto &&[a1, a2] = object;
-    return visitor(a1, a2);
-  }
-  else if constexpr (Count == 3) {
-    auto &&[a1, a2, a3] = object;
-    return visitor(a1, a2, a3);
-  }
-  else if constexpr (Count == 4) {
-    auto &&[a1, a2, a3, a4] = object;
-    return visitor(a1, a2, a3, a4);
-  }
-  else if constexpr (Count == 5) {
-    auto &&[a1, a2, a3, a4, a5] = object;
-    return visitor(a1, a2, a3, a4, a5);
-  }
-  else if constexpr (Count == 6) {
-    auto &&[a1, a2, a3, a4, a5, a6] = object;
-    return visitor(a1, a2, a3, a4, a5, a6);
-  }
-  else if constexpr (Count == 7) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7);
-  }
-  else if constexpr (Count == 8) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8);
-  }
-  else if constexpr (Count == 9) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9);
-  }
-  else if constexpr (Count == 10) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
-  }
-  else if constexpr (Count == 11) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11);
-  }
-  else if constexpr (Count == 12) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
-  }
-  else if constexpr (Count == 13) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
-  }
-  else if constexpr (Count == 14) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14] =
-        object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
-  }
-  else if constexpr (Count == 15) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15] =
-        object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15);
-  }
-  else if constexpr (Count == 16) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16);
-  }
-  else if constexpr (Count == 17) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17);
-  }
-  else if constexpr (Count == 18) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18);
-  }
-  else if constexpr (Count == 19) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19);
-  }
-  else if constexpr (Count == 20) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20);
-  }
-  else if constexpr (Count == 21) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21);
-  }
-  else if constexpr (Count == 22) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22);
-  }
-  else if constexpr (Count == 23) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23);
-  }
-  else if constexpr (Count == 24) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24);
-  }
-  else if constexpr (Count == 25) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25);
-  }
-  else if constexpr (Count == 26) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26);
-  }
-  else if constexpr (Count == 27) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27] =
-        object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27);
-  }
-  else if constexpr (Count == 28) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28] =
-        object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28);
-  }
-  else if constexpr (Count == 29) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29);
-  }
-  else if constexpr (Count == 30) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30);
-  }
-  else if constexpr (Count == 31) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31);
-  }
-  else if constexpr (Count == 32) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32);
-  }
-  else if constexpr (Count == 33) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33);
-  }
-  else if constexpr (Count == 34) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34);
-  }
-  else if constexpr (Count == 35) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35);
-  }
-  else if constexpr (Count == 36) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36);
-  }
-  else if constexpr (Count == 37) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37);
-  }
-  else if constexpr (Count == 38) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38);
-  }
-  else if constexpr (Count == 39) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39);
-  }
-  else if constexpr (Count == 40) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40] =
-        object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40);
-  }
-  else if constexpr (Count == 41) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41] =
-        object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41);
-  }
-  else if constexpr (Count == 42) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42);
-  }
-  else if constexpr (Count == 43) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43);
-  }
-  else if constexpr (Count == 44) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44);
-  }
-  else if constexpr (Count == 45) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45);
-  }
-  else if constexpr (Count == 46) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46);
-  }
-  else if constexpr (Count == 47) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47);
-  }
-  else if constexpr (Count == 48) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48);
-  }
-  else if constexpr (Count == 49) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49);
-  }
-  else if constexpr (Count == 50) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50);
-  }
-  else if constexpr (Count == 51) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51);
-  }
-  else if constexpr (Count == 52) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52);
-  }
-  else if constexpr (Count == 53) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53] =
-        object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53);
-  }
-  else if constexpr (Count == 54) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54] =
-        object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54);
-  }
-  else if constexpr (Count == 55) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55);
-  }
-  else if constexpr (Count == 56) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56);
-  }
-  else if constexpr (Count == 57) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56, a57] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56, a57);
-  }
-  else if constexpr (Count == 58) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56, a57, a58] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56, a57, a58);
-  }
-  else if constexpr (Count == 59) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56, a57, a58, a59] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56, a57, a58, a59);
-  }
-  else if constexpr (Count == 60) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56, a57, a58, a59, a60] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56, a57, a58, a59, a60);
-  }
-  else if constexpr (Count == 61) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56, a57, a58, a59, a60, a61] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61);
-  }
-  else if constexpr (Count == 62) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56, a57, a58, a59, a60, a61, a62] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61, a62);
-  }
-  else if constexpr (Count == 63) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56, a57, a58, a59, a60, a61, a62, a63] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61, a62,
-                   a63);
-  }
-  else if constexpr (Count == 64) {
-    auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
-            a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
-            a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
-            a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
-            a55, a56, a57, a58, a59, a60, a61, a62, a63, a64] = object;
-    return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
-                   a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
-                   a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38,
-                   a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50,
-                   a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61, a62,
-                   a63, a64);
-  }
-}
+  constexpr decltype(auto) STRUCT_PACK_INLINE visit_members(auto &&object,
+                                                            auto &&visitor) {
+    using type = std::remove_cvref_t<decltype(object)>;
+    constexpr auto Count = member_count<type>();
+    if constexpr (Count == 0 && std::is_class_v<type> &&
+                  !std::is_same_v<type, std::monostate>) {
+      static_assert(!sizeof(type), "empty struct/class is not allowed!");
+    }
+    static_assert(Count <= MaxVisitMembers, "exceed max visit members");
+    // If you see any structured binding error in the follow line, it
+    // means struct_pack can't calculate your struct's members count
+    // correctly. You need to mark it manually.
+    //
+    // For example, there is a struct named Hello,
+    // and it has 3 members.
+    //
+    // You can mark it as:
+    //
+    // template <>
+    // constexpr size_t struct_pack::members_count<Hello> = 3;
 
-template <template <size_t index, typename...> typename Func, typename... Args>
-constexpr decltype(auto) STRUCT_PACK_INLINE template_switch(std::size_t index,
-                                                            auto &...args) {
-  switch (index) {
-    case 0:
-      return Func<0, Args...>::run(args...);
-    case 1:
-      return Func<1, Args...>::run(args...);
-    case 2:
-      return Func<2, Args...>::run(args...);
-    case 3:
-      return Func<3, Args...>::run(args...);
-    case 4:
-      return Func<4, Args...>::run(args...);
-    case 5:
-      return Func<5, Args...>::run(args...);
-    case 6:
-      return Func<6, Args...>::run(args...);
-    case 7:
-      return Func<7, Args...>::run(args...);
-    case 8:
-      return Func<8, Args...>::run(args...);
-    case 9:
-      return Func<9, Args...>::run(args...);
-    case 10:
-      return Func<10, Args...>::run(args...);
-    case 11:
-      return Func<11, Args...>::run(args...);
-    case 12:
-      return Func<12, Args...>::run(args...);
-    case 13:
-      return Func<13, Args...>::run(args...);
-    case 14:
-      return Func<14, Args...>::run(args...);
-    case 15:
-      return Func<15, Args...>::run(args...);
-    case 16:
-      return Func<16, Args...>::run(args...);
-    case 17:
-      return Func<17, Args...>::run(args...);
-    case 18:
-      return Func<18, Args...>::run(args...);
-    case 19:
-      return Func<19, Args...>::run(args...);
-    case 20:
-      return Func<20, Args...>::run(args...);
-    case 21:
-      return Func<21, Args...>::run(args...);
-    case 22:
-      return Func<22, Args...>::run(args...);
-    case 23:
-      return Func<23, Args...>::run(args...);
-    case 24:
-      return Func<24, Args...>::run(args...);
-    case 25:
-      return Func<25, Args...>::run(args...);
-    case 26:
-      return Func<26, Args...>::run(args...);
-    case 27:
-      return Func<27, Args...>::run(args...);
-    case 28:
-      return Func<28, Args...>::run(args...);
-    case 29:
-      return Func<29, Args...>::run(args...);
-    case 30:
-      return Func<30, Args...>::run(args...);
-    case 31:
-      return Func<31, Args...>::run(args...);
-    case 32:
-      return Func<32, Args...>::run(args...);
-    case 33:
-      return Func<33, Args...>::run(args...);
-    case 34:
-      return Func<34, Args...>::run(args...);
-    case 35:
-      return Func<35, Args...>::run(args...);
-    case 36:
-      return Func<36, Args...>::run(args...);
-    case 37:
-      return Func<37, Args...>::run(args...);
-    case 38:
-      return Func<38, Args...>::run(args...);
-    case 39:
-      return Func<39, Args...>::run(args...);
-    case 40:
-      return Func<40, Args...>::run(args...);
-    case 41:
-      return Func<41, Args...>::run(args...);
-    case 42:
-      return Func<42, Args...>::run(args...);
-    case 43:
-      return Func<43, Args...>::run(args...);
-    case 44:
-      return Func<44, Args...>::run(args...);
-    case 45:
-      return Func<45, Args...>::run(args...);
-    case 46:
-      return Func<46, Args...>::run(args...);
-    case 47:
-      return Func<47, Args...>::run(args...);
-    case 48:
-      return Func<48, Args...>::run(args...);
-    case 49:
-      return Func<49, Args...>::run(args...);
-    case 50:
-      return Func<50, Args...>::run(args...);
-    case 51:
-      return Func<51, Args...>::run(args...);
-    case 52:
-      return Func<52, Args...>::run(args...);
-    case 53:
-      return Func<53, Args...>::run(args...);
-    case 54:
-      return Func<54, Args...>::run(args...);
-    case 55:
-      return Func<55, Args...>::run(args...);
-    case 56:
-      return Func<56, Args...>::run(args...);
-    case 57:
-      return Func<57, Args...>::run(args...);
-    case 58:
-      return Func<58, Args...>::run(args...);
-    case 59:
-      return Func<59, Args...>::run(args...);
-    case 60:
-      return Func<60, Args...>::run(args...);
-    case 61:
-      return Func<61, Args...>::run(args...);
-    case 62:
-      return Func<62, Args...>::run(args...);
-    case 63:
-      return Func<63, Args...>::run(args...);
-    case 64:
-      return Func<64, Args...>::run(args...);
-    case 65:
-      return Func<65, Args...>::run(args...);
-    case 66:
-      return Func<66, Args...>::run(args...);
-    case 67:
-      return Func<67, Args...>::run(args...);
-    case 68:
-      return Func<68, Args...>::run(args...);
-    case 69:
-      return Func<69, Args...>::run(args...);
-    case 70:
-      return Func<70, Args...>::run(args...);
-    case 71:
-      return Func<71, Args...>::run(args...);
-    case 72:
-      return Func<72, Args...>::run(args...);
-    case 73:
-      return Func<73, Args...>::run(args...);
-    case 74:
-      return Func<74, Args...>::run(args...);
-    case 75:
-      return Func<75, Args...>::run(args...);
-    case 76:
-      return Func<76, Args...>::run(args...);
-    case 77:
-      return Func<77, Args...>::run(args...);
-    case 78:
-      return Func<78, Args...>::run(args...);
-    case 79:
-      return Func<79, Args...>::run(args...);
-    case 80:
-      return Func<80, Args...>::run(args...);
-    case 81:
-      return Func<81, Args...>::run(args...);
-    case 82:
-      return Func<82, Args...>::run(args...);
-    case 83:
-      return Func<83, Args...>::run(args...);
-    case 84:
-      return Func<84, Args...>::run(args...);
-    case 85:
-      return Func<85, Args...>::run(args...);
-    case 86:
-      return Func<86, Args...>::run(args...);
-    case 87:
-      return Func<87, Args...>::run(args...);
-    case 88:
-      return Func<88, Args...>::run(args...);
-    case 89:
-      return Func<89, Args...>::run(args...);
-    case 90:
-      return Func<90, Args...>::run(args...);
-    case 91:
-      return Func<91, Args...>::run(args...);
-    case 92:
-      return Func<92, Args...>::run(args...);
-    case 93:
-      return Func<93, Args...>::run(args...);
-    case 94:
-      return Func<94, Args...>::run(args...);
-    case 95:
-      return Func<95, Args...>::run(args...);
-    case 96:
-      return Func<96, Args...>::run(args...);
-    case 97:
-      return Func<97, Args...>::run(args...);
-    case 98:
-      return Func<98, Args...>::run(args...);
-    case 99:
-      return Func<99, Args...>::run(args...);
-    case 100:
-      return Func<100, Args...>::run(args...);
-    case 101:
-      return Func<101, Args...>::run(args...);
-    case 102:
-      return Func<102, Args...>::run(args...);
-    case 103:
-      return Func<103, Args...>::run(args...);
-    case 104:
-      return Func<104, Args...>::run(args...);
-    case 105:
-      return Func<105, Args...>::run(args...);
-    case 106:
-      return Func<106, Args...>::run(args...);
-    case 107:
-      return Func<107, Args...>::run(args...);
-    case 108:
-      return Func<108, Args...>::run(args...);
-    case 109:
-      return Func<109, Args...>::run(args...);
-    case 110:
-      return Func<110, Args...>::run(args...);
-    case 111:
-      return Func<111, Args...>::run(args...);
-    case 112:
-      return Func<112, Args...>::run(args...);
-    case 113:
-      return Func<113, Args...>::run(args...);
-    case 114:
-      return Func<114, Args...>::run(args...);
-    case 115:
-      return Func<115, Args...>::run(args...);
-    case 116:
-      return Func<116, Args...>::run(args...);
-    case 117:
-      return Func<117, Args...>::run(args...);
-    case 118:
-      return Func<118, Args...>::run(args...);
-    case 119:
-      return Func<119, Args...>::run(args...);
-    case 120:
-      return Func<120, Args...>::run(args...);
-    case 121:
-      return Func<121, Args...>::run(args...);
-    case 122:
-      return Func<122, Args...>::run(args...);
-    case 123:
-      return Func<123, Args...>::run(args...);
-    case 124:
-      return Func<124, Args...>::run(args...);
-    case 125:
-      return Func<125, Args...>::run(args...);
-    case 126:
-      return Func<126, Args...>::run(args...);
-    case 127:
-      return Func<127, Args...>::run(args...);
-    case 128:
-      return Func<128, Args...>::run(args...);
-    case 129:
-      return Func<129, Args...>::run(args...);
-    case 130:
-      return Func<130, Args...>::run(args...);
-    case 131:
-      return Func<131, Args...>::run(args...);
-    case 132:
-      return Func<132, Args...>::run(args...);
-    case 133:
-      return Func<133, Args...>::run(args...);
-    case 134:
-      return Func<134, Args...>::run(args...);
-    case 135:
-      return Func<135, Args...>::run(args...);
-    case 136:
-      return Func<136, Args...>::run(args...);
-    case 137:
-      return Func<137, Args...>::run(args...);
-    case 138:
-      return Func<138, Args...>::run(args...);
-    case 139:
-      return Func<139, Args...>::run(args...);
-    case 140:
-      return Func<140, Args...>::run(args...);
-    case 141:
-      return Func<141, Args...>::run(args...);
-    case 142:
-      return Func<142, Args...>::run(args...);
-    case 143:
-      return Func<143, Args...>::run(args...);
-    case 144:
-      return Func<144, Args...>::run(args...);
-    case 145:
-      return Func<145, Args...>::run(args...);
-    case 146:
-      return Func<146, Args...>::run(args...);
-    case 147:
-      return Func<147, Args...>::run(args...);
-    case 148:
-      return Func<148, Args...>::run(args...);
-    case 149:
-      return Func<149, Args...>::run(args...);
-    case 150:
-      return Func<150, Args...>::run(args...);
-    case 151:
-      return Func<151, Args...>::run(args...);
-    case 152:
-      return Func<152, Args...>::run(args...);
-    case 153:
-      return Func<153, Args...>::run(args...);
-    case 154:
-      return Func<154, Args...>::run(args...);
-    case 155:
-      return Func<155, Args...>::run(args...);
-    case 156:
-      return Func<156, Args...>::run(args...);
-    case 157:
-      return Func<157, Args...>::run(args...);
-    case 158:
-      return Func<158, Args...>::run(args...);
-    case 159:
-      return Func<159, Args...>::run(args...);
-    case 160:
-      return Func<160, Args...>::run(args...);
-    case 161:
-      return Func<161, Args...>::run(args...);
-    case 162:
-      return Func<162, Args...>::run(args...);
-    case 163:
-      return Func<163, Args...>::run(args...);
-    case 164:
-      return Func<164, Args...>::run(args...);
-    case 165:
-      return Func<165, Args...>::run(args...);
-    case 166:
-      return Func<166, Args...>::run(args...);
-    case 167:
-      return Func<167, Args...>::run(args...);
-    case 168:
-      return Func<168, Args...>::run(args...);
-    case 169:
-      return Func<169, Args...>::run(args...);
-    case 170:
-      return Func<170, Args...>::run(args...);
-    case 171:
-      return Func<171, Args...>::run(args...);
-    case 172:
-      return Func<172, Args...>::run(args...);
-    case 173:
-      return Func<173, Args...>::run(args...);
-    case 174:
-      return Func<174, Args...>::run(args...);
-    case 175:
-      return Func<175, Args...>::run(args...);
-    case 176:
-      return Func<176, Args...>::run(args...);
-    case 177:
-      return Func<177, Args...>::run(args...);
-    case 178:
-      return Func<178, Args...>::run(args...);
-    case 179:
-      return Func<179, Args...>::run(args...);
-    case 180:
-      return Func<180, Args...>::run(args...);
-    case 181:
-      return Func<181, Args...>::run(args...);
-    case 182:
-      return Func<182, Args...>::run(args...);
-    case 183:
-      return Func<183, Args...>::run(args...);
-    case 184:
-      return Func<184, Args...>::run(args...);
-    case 185:
-      return Func<185, Args...>::run(args...);
-    case 186:
-      return Func<186, Args...>::run(args...);
-    case 187:
-      return Func<187, Args...>::run(args...);
-    case 188:
-      return Func<188, Args...>::run(args...);
-    case 189:
-      return Func<189, Args...>::run(args...);
-    case 190:
-      return Func<190, Args...>::run(args...);
-    case 191:
-      return Func<191, Args...>::run(args...);
-    case 192:
-      return Func<192, Args...>::run(args...);
-    case 193:
-      return Func<193, Args...>::run(args...);
-    case 194:
-      return Func<194, Args...>::run(args...);
-    case 195:
-      return Func<195, Args...>::run(args...);
-    case 196:
-      return Func<196, Args...>::run(args...);
-    case 197:
-      return Func<197, Args...>::run(args...);
-    case 198:
-      return Func<198, Args...>::run(args...);
-    case 199:
-      return Func<199, Args...>::run(args...);
-    case 200:
-      return Func<200, Args...>::run(args...);
-    case 201:
-      return Func<201, Args...>::run(args...);
-    case 202:
-      return Func<202, Args...>::run(args...);
-    case 203:
-      return Func<203, Args...>::run(args...);
-    case 204:
-      return Func<204, Args...>::run(args...);
-    case 205:
-      return Func<205, Args...>::run(args...);
-    case 206:
-      return Func<206, Args...>::run(args...);
-    case 207:
-      return Func<207, Args...>::run(args...);
-    case 208:
-      return Func<208, Args...>::run(args...);
-    case 209:
-      return Func<209, Args...>::run(args...);
-    case 210:
-      return Func<210, Args...>::run(args...);
-    case 211:
-      return Func<211, Args...>::run(args...);
-    case 212:
-      return Func<212, Args...>::run(args...);
-    case 213:
-      return Func<213, Args...>::run(args...);
-    case 214:
-      return Func<214, Args...>::run(args...);
-    case 215:
-      return Func<215, Args...>::run(args...);
-    case 216:
-      return Func<216, Args...>::run(args...);
-    case 217:
-      return Func<217, Args...>::run(args...);
-    case 218:
-      return Func<218, Args...>::run(args...);
-    case 219:
-      return Func<219, Args...>::run(args...);
-    case 220:
-      return Func<220, Args...>::run(args...);
-    case 221:
-      return Func<221, Args...>::run(args...);
-    case 222:
-      return Func<222, Args...>::run(args...);
-    case 223:
-      return Func<223, Args...>::run(args...);
-    case 224:
-      return Func<224, Args...>::run(args...);
-    case 225:
-      return Func<225, Args...>::run(args...);
-    case 226:
-      return Func<226, Args...>::run(args...);
-    case 227:
-      return Func<227, Args...>::run(args...);
-    case 228:
-      return Func<228, Args...>::run(args...);
-    case 229:
-      return Func<229, Args...>::run(args...);
-    case 230:
-      return Func<230, Args...>::run(args...);
-    case 231:
-      return Func<231, Args...>::run(args...);
-    case 232:
-      return Func<232, Args...>::run(args...);
-    case 233:
-      return Func<233, Args...>::run(args...);
-    case 234:
-      return Func<234, Args...>::run(args...);
-    case 235:
-      return Func<235, Args...>::run(args...);
-    case 236:
-      return Func<236, Args...>::run(args...);
-    case 237:
-      return Func<237, Args...>::run(args...);
-    case 238:
-      return Func<238, Args...>::run(args...);
-    case 239:
-      return Func<239, Args...>::run(args...);
-    case 240:
-      return Func<240, Args...>::run(args...);
-    case 241:
-      return Func<241, Args...>::run(args...);
-    case 242:
-      return Func<242, Args...>::run(args...);
-    case 243:
-      return Func<243, Args...>::run(args...);
-    case 244:
-      return Func<244, Args...>::run(args...);
-    case 245:
-      return Func<245, Args...>::run(args...);
-    case 246:
-      return Func<246, Args...>::run(args...);
-    case 247:
-      return Func<247, Args...>::run(args...);
-    case 248:
-      return Func<248, Args...>::run(args...);
-    case 249:
-      return Func<249, Args...>::run(args...);
-    case 250:
-      return Func<250, Args...>::run(args...);
-    case 251:
-      return Func<251, Args...>::run(args...);
-    case 252:
-      return Func<252, Args...>::run(args...);
-    case 253:
-      return Func<253, Args...>::run(args...);
-    case 254:
-      return Func<254, Args...>::run(args...);
-    case 255:
-      return Func<255, Args...>::run(args...);
-    default:
-      return Func<256, Args...>::run(args...);
-      // index shouldn't bigger than 256
+    if constexpr (Count == 0) {
+      return visitor();
+    }
+    else if constexpr (Count == 1) {
+      auto &&[a1] = object;
+      return visitor(a1);
+    }
+    else if constexpr (Count == 2) {
+      auto &&[a1, a2] = object;
+      return visitor(a1, a2);
+    }
+    else if constexpr (Count == 3) {
+      auto &&[a1, a2, a3] = object;
+      return visitor(a1, a2, a3);
+    }
+    else if constexpr (Count == 4) {
+      auto &&[a1, a2, a3, a4] = object;
+      return visitor(a1, a2, a3, a4);
+    }
+    else if constexpr (Count == 5) {
+      auto &&[a1, a2, a3, a4, a5] = object;
+      return visitor(a1, a2, a3, a4, a5);
+    }
+    else if constexpr (Count == 6) {
+      auto &&[a1, a2, a3, a4, a5, a6] = object;
+      return visitor(a1, a2, a3, a4, a5, a6);
+    }
+    else if constexpr (Count == 7) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7);
+    }
+    else if constexpr (Count == 8) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8);
+    }
+    else if constexpr (Count == 9) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    }
+    else if constexpr (Count == 10) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    }
+    else if constexpr (Count == 11) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11);
+    }
+    else if constexpr (Count == 12) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+    }
+    else if constexpr (Count == 13) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
+    }
+    else if constexpr (Count == 14) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14] =
+          object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14);
+    }
+    else if constexpr (Count == 15) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
+              a15] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15);
+    }
+    else if constexpr (Count == 16) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16);
+    }
+    else if constexpr (Count == 17) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17);
+    }
+    else if constexpr (Count == 18) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18);
+    }
+    else if constexpr (Count == 19) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19);
+    }
+    else if constexpr (Count == 20) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20);
+    }
+    else if constexpr (Count == 21) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21);
+    }
+    else if constexpr (Count == 22) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22);
+    }
+    else if constexpr (Count == 23) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23);
+    }
+    else if constexpr (Count == 24) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24);
+    }
+    else if constexpr (Count == 25) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24,
+                     a25);
+    }
+    else if constexpr (Count == 26) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26);
+    }
+    else if constexpr (Count == 27) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27] =
+          object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27);
+    }
+    else if constexpr (Count == 28) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28] =
+          object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28);
+    }
+    else if constexpr (Count == 29) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29);
+    }
+    else if constexpr (Count == 30) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30);
+    }
+    else if constexpr (Count == 31) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31);
+    }
+    else if constexpr (Count == 32) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32);
+    }
+    else if constexpr (Count == 33) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33);
+    }
+    else if constexpr (Count == 34) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34);
+    }
+    else if constexpr (Count == 35) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35);
+    }
+    else if constexpr (Count == 36) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36);
+    }
+    else if constexpr (Count == 37) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36,
+                     a37);
+    }
+    else if constexpr (Count == 38) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38);
+    }
+    else if constexpr (Count == 39) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39);
+    }
+    else if constexpr (Count == 40) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40] =
+          object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40);
+    }
+    else if constexpr (Count == 41) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41] =
+          object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41);
+    }
+    else if constexpr (Count == 42) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42);
+    }
+    else if constexpr (Count == 43) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43);
+    }
+    else if constexpr (Count == 44) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44);
+    }
+    else if constexpr (Count == 45) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45);
+    }
+    else if constexpr (Count == 46) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46);
+    }
+    else if constexpr (Count == 47) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47);
+    }
+    else if constexpr (Count == 48) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48);
+    }
+    else if constexpr (Count == 49) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48,
+                     a49);
+    }
+    else if constexpr (Count == 50) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50);
+    }
+    else if constexpr (Count == 51) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51);
+    }
+    else if constexpr (Count == 52) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52);
+    }
+    else if constexpr (Count == 53) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53] =
+          object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53);
+    }
+    else if constexpr (Count == 54) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54] =
+          object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54);
+    }
+    else if constexpr (Count == 55) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55);
+    }
+    else if constexpr (Count == 56) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56);
+    }
+    else if constexpr (Count == 57) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56, a57] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56, a57);
+    }
+    else if constexpr (Count == 58) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56, a57, a58] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56, a57, a58);
+    }
+    else if constexpr (Count == 59) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56, a57, a58, a59] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56, a57, a58, a59);
+    }
+    else if constexpr (Count == 60) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56, a57, a58, a59, a60] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60);
+    }
+    else if constexpr (Count == 61) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56, a57, a58, a59, a60, a61] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60,
+                     a61);
+    }
+    else if constexpr (Count == 62) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56, a57, a58, a59, a60, a61, a62] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61,
+                     a62);
+    }
+    else if constexpr (Count == 63) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56, a57, a58, a59, a60, a61, a62, a63] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61,
+                     a62, a63);
+    }
+    else if constexpr (Count == 64) {
+      auto &&[a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,
+              a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28,
+              a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+              a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54,
+              a55, a56, a57, a58, a59, a60, a61, a62, a63, a64] = object;
+      return visitor(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+                     a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+                     a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37,
+                     a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49,
+                     a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61,
+                     a62, a63, a64);
+    }
   }
-}
+
+  template <template <size_t index, typename...> typename Func,
+            typename... Args>
+  constexpr decltype(auto) STRUCT_PACK_INLINE template_switch(std::size_t index,
+                                                              auto &...args) {
+    switch (index) {
+      case 0:
+        return Func<0, Args...>::run(args...);
+      case 1:
+        return Func<1, Args...>::run(args...);
+      case 2:
+        return Func<2, Args...>::run(args...);
+      case 3:
+        return Func<3, Args...>::run(args...);
+      case 4:
+        return Func<4, Args...>::run(args...);
+      case 5:
+        return Func<5, Args...>::run(args...);
+      case 6:
+        return Func<6, Args...>::run(args...);
+      case 7:
+        return Func<7, Args...>::run(args...);
+      case 8:
+        return Func<8, Args...>::run(args...);
+      case 9:
+        return Func<9, Args...>::run(args...);
+      case 10:
+        return Func<10, Args...>::run(args...);
+      case 11:
+        return Func<11, Args...>::run(args...);
+      case 12:
+        return Func<12, Args...>::run(args...);
+      case 13:
+        return Func<13, Args...>::run(args...);
+      case 14:
+        return Func<14, Args...>::run(args...);
+      case 15:
+        return Func<15, Args...>::run(args...);
+      case 16:
+        return Func<16, Args...>::run(args...);
+      case 17:
+        return Func<17, Args...>::run(args...);
+      case 18:
+        return Func<18, Args...>::run(args...);
+      case 19:
+        return Func<19, Args...>::run(args...);
+      case 20:
+        return Func<20, Args...>::run(args...);
+      case 21:
+        return Func<21, Args...>::run(args...);
+      case 22:
+        return Func<22, Args...>::run(args...);
+      case 23:
+        return Func<23, Args...>::run(args...);
+      case 24:
+        return Func<24, Args...>::run(args...);
+      case 25:
+        return Func<25, Args...>::run(args...);
+      case 26:
+        return Func<26, Args...>::run(args...);
+      case 27:
+        return Func<27, Args...>::run(args...);
+      case 28:
+        return Func<28, Args...>::run(args...);
+      case 29:
+        return Func<29, Args...>::run(args...);
+      case 30:
+        return Func<30, Args...>::run(args...);
+      case 31:
+        return Func<31, Args...>::run(args...);
+      case 32:
+        return Func<32, Args...>::run(args...);
+      case 33:
+        return Func<33, Args...>::run(args...);
+      case 34:
+        return Func<34, Args...>::run(args...);
+      case 35:
+        return Func<35, Args...>::run(args...);
+      case 36:
+        return Func<36, Args...>::run(args...);
+      case 37:
+        return Func<37, Args...>::run(args...);
+      case 38:
+        return Func<38, Args...>::run(args...);
+      case 39:
+        return Func<39, Args...>::run(args...);
+      case 40:
+        return Func<40, Args...>::run(args...);
+      case 41:
+        return Func<41, Args...>::run(args...);
+      case 42:
+        return Func<42, Args...>::run(args...);
+      case 43:
+        return Func<43, Args...>::run(args...);
+      case 44:
+        return Func<44, Args...>::run(args...);
+      case 45:
+        return Func<45, Args...>::run(args...);
+      case 46:
+        return Func<46, Args...>::run(args...);
+      case 47:
+        return Func<47, Args...>::run(args...);
+      case 48:
+        return Func<48, Args...>::run(args...);
+      case 49:
+        return Func<49, Args...>::run(args...);
+      case 50:
+        return Func<50, Args...>::run(args...);
+      case 51:
+        return Func<51, Args...>::run(args...);
+      case 52:
+        return Func<52, Args...>::run(args...);
+      case 53:
+        return Func<53, Args...>::run(args...);
+      case 54:
+        return Func<54, Args...>::run(args...);
+      case 55:
+        return Func<55, Args...>::run(args...);
+      case 56:
+        return Func<56, Args...>::run(args...);
+      case 57:
+        return Func<57, Args...>::run(args...);
+      case 58:
+        return Func<58, Args...>::run(args...);
+      case 59:
+        return Func<59, Args...>::run(args...);
+      case 60:
+        return Func<60, Args...>::run(args...);
+      case 61:
+        return Func<61, Args...>::run(args...);
+      case 62:
+        return Func<62, Args...>::run(args...);
+      case 63:
+        return Func<63, Args...>::run(args...);
+      case 64:
+        return Func<64, Args...>::run(args...);
+      case 65:
+        return Func<65, Args...>::run(args...);
+      case 66:
+        return Func<66, Args...>::run(args...);
+      case 67:
+        return Func<67, Args...>::run(args...);
+      case 68:
+        return Func<68, Args...>::run(args...);
+      case 69:
+        return Func<69, Args...>::run(args...);
+      case 70:
+        return Func<70, Args...>::run(args...);
+      case 71:
+        return Func<71, Args...>::run(args...);
+      case 72:
+        return Func<72, Args...>::run(args...);
+      case 73:
+        return Func<73, Args...>::run(args...);
+      case 74:
+        return Func<74, Args...>::run(args...);
+      case 75:
+        return Func<75, Args...>::run(args...);
+      case 76:
+        return Func<76, Args...>::run(args...);
+      case 77:
+        return Func<77, Args...>::run(args...);
+      case 78:
+        return Func<78, Args...>::run(args...);
+      case 79:
+        return Func<79, Args...>::run(args...);
+      case 80:
+        return Func<80, Args...>::run(args...);
+      case 81:
+        return Func<81, Args...>::run(args...);
+      case 82:
+        return Func<82, Args...>::run(args...);
+      case 83:
+        return Func<83, Args...>::run(args...);
+      case 84:
+        return Func<84, Args...>::run(args...);
+      case 85:
+        return Func<85, Args...>::run(args...);
+      case 86:
+        return Func<86, Args...>::run(args...);
+      case 87:
+        return Func<87, Args...>::run(args...);
+      case 88:
+        return Func<88, Args...>::run(args...);
+      case 89:
+        return Func<89, Args...>::run(args...);
+      case 90:
+        return Func<90, Args...>::run(args...);
+      case 91:
+        return Func<91, Args...>::run(args...);
+      case 92:
+        return Func<92, Args...>::run(args...);
+      case 93:
+        return Func<93, Args...>::run(args...);
+      case 94:
+        return Func<94, Args...>::run(args...);
+      case 95:
+        return Func<95, Args...>::run(args...);
+      case 96:
+        return Func<96, Args...>::run(args...);
+      case 97:
+        return Func<97, Args...>::run(args...);
+      case 98:
+        return Func<98, Args...>::run(args...);
+      case 99:
+        return Func<99, Args...>::run(args...);
+      case 100:
+        return Func<100, Args...>::run(args...);
+      case 101:
+        return Func<101, Args...>::run(args...);
+      case 102:
+        return Func<102, Args...>::run(args...);
+      case 103:
+        return Func<103, Args...>::run(args...);
+      case 104:
+        return Func<104, Args...>::run(args...);
+      case 105:
+        return Func<105, Args...>::run(args...);
+      case 106:
+        return Func<106, Args...>::run(args...);
+      case 107:
+        return Func<107, Args...>::run(args...);
+      case 108:
+        return Func<108, Args...>::run(args...);
+      case 109:
+        return Func<109, Args...>::run(args...);
+      case 110:
+        return Func<110, Args...>::run(args...);
+      case 111:
+        return Func<111, Args...>::run(args...);
+      case 112:
+        return Func<112, Args...>::run(args...);
+      case 113:
+        return Func<113, Args...>::run(args...);
+      case 114:
+        return Func<114, Args...>::run(args...);
+      case 115:
+        return Func<115, Args...>::run(args...);
+      case 116:
+        return Func<116, Args...>::run(args...);
+      case 117:
+        return Func<117, Args...>::run(args...);
+      case 118:
+        return Func<118, Args...>::run(args...);
+      case 119:
+        return Func<119, Args...>::run(args...);
+      case 120:
+        return Func<120, Args...>::run(args...);
+      case 121:
+        return Func<121, Args...>::run(args...);
+      case 122:
+        return Func<122, Args...>::run(args...);
+      case 123:
+        return Func<123, Args...>::run(args...);
+      case 124:
+        return Func<124, Args...>::run(args...);
+      case 125:
+        return Func<125, Args...>::run(args...);
+      case 126:
+        return Func<126, Args...>::run(args...);
+      case 127:
+        return Func<127, Args...>::run(args...);
+      case 128:
+        return Func<128, Args...>::run(args...);
+      case 129:
+        return Func<129, Args...>::run(args...);
+      case 130:
+        return Func<130, Args...>::run(args...);
+      case 131:
+        return Func<131, Args...>::run(args...);
+      case 132:
+        return Func<132, Args...>::run(args...);
+      case 133:
+        return Func<133, Args...>::run(args...);
+      case 134:
+        return Func<134, Args...>::run(args...);
+      case 135:
+        return Func<135, Args...>::run(args...);
+      case 136:
+        return Func<136, Args...>::run(args...);
+      case 137:
+        return Func<137, Args...>::run(args...);
+      case 138:
+        return Func<138, Args...>::run(args...);
+      case 139:
+        return Func<139, Args...>::run(args...);
+      case 140:
+        return Func<140, Args...>::run(args...);
+      case 141:
+        return Func<141, Args...>::run(args...);
+      case 142:
+        return Func<142, Args...>::run(args...);
+      case 143:
+        return Func<143, Args...>::run(args...);
+      case 144:
+        return Func<144, Args...>::run(args...);
+      case 145:
+        return Func<145, Args...>::run(args...);
+      case 146:
+        return Func<146, Args...>::run(args...);
+      case 147:
+        return Func<147, Args...>::run(args...);
+      case 148:
+        return Func<148, Args...>::run(args...);
+      case 149:
+        return Func<149, Args...>::run(args...);
+      case 150:
+        return Func<150, Args...>::run(args...);
+      case 151:
+        return Func<151, Args...>::run(args...);
+      case 152:
+        return Func<152, Args...>::run(args...);
+      case 153:
+        return Func<153, Args...>::run(args...);
+      case 154:
+        return Func<154, Args...>::run(args...);
+      case 155:
+        return Func<155, Args...>::run(args...);
+      case 156:
+        return Func<156, Args...>::run(args...);
+      case 157:
+        return Func<157, Args...>::run(args...);
+      case 158:
+        return Func<158, Args...>::run(args...);
+      case 159:
+        return Func<159, Args...>::run(args...);
+      case 160:
+        return Func<160, Args...>::run(args...);
+      case 161:
+        return Func<161, Args...>::run(args...);
+      case 162:
+        return Func<162, Args...>::run(args...);
+      case 163:
+        return Func<163, Args...>::run(args...);
+      case 164:
+        return Func<164, Args...>::run(args...);
+      case 165:
+        return Func<165, Args...>::run(args...);
+      case 166:
+        return Func<166, Args...>::run(args...);
+      case 167:
+        return Func<167, Args...>::run(args...);
+      case 168:
+        return Func<168, Args...>::run(args...);
+      case 169:
+        return Func<169, Args...>::run(args...);
+      case 170:
+        return Func<170, Args...>::run(args...);
+      case 171:
+        return Func<171, Args...>::run(args...);
+      case 172:
+        return Func<172, Args...>::run(args...);
+      case 173:
+        return Func<173, Args...>::run(args...);
+      case 174:
+        return Func<174, Args...>::run(args...);
+      case 175:
+        return Func<175, Args...>::run(args...);
+      case 176:
+        return Func<176, Args...>::run(args...);
+      case 177:
+        return Func<177, Args...>::run(args...);
+      case 178:
+        return Func<178, Args...>::run(args...);
+      case 179:
+        return Func<179, Args...>::run(args...);
+      case 180:
+        return Func<180, Args...>::run(args...);
+      case 181:
+        return Func<181, Args...>::run(args...);
+      case 182:
+        return Func<182, Args...>::run(args...);
+      case 183:
+        return Func<183, Args...>::run(args...);
+      case 184:
+        return Func<184, Args...>::run(args...);
+      case 185:
+        return Func<185, Args...>::run(args...);
+      case 186:
+        return Func<186, Args...>::run(args...);
+      case 187:
+        return Func<187, Args...>::run(args...);
+      case 188:
+        return Func<188, Args...>::run(args...);
+      case 189:
+        return Func<189, Args...>::run(args...);
+      case 190:
+        return Func<190, Args...>::run(args...);
+      case 191:
+        return Func<191, Args...>::run(args...);
+      case 192:
+        return Func<192, Args...>::run(args...);
+      case 193:
+        return Func<193, Args...>::run(args...);
+      case 194:
+        return Func<194, Args...>::run(args...);
+      case 195:
+        return Func<195, Args...>::run(args...);
+      case 196:
+        return Func<196, Args...>::run(args...);
+      case 197:
+        return Func<197, Args...>::run(args...);
+      case 198:
+        return Func<198, Args...>::run(args...);
+      case 199:
+        return Func<199, Args...>::run(args...);
+      case 200:
+        return Func<200, Args...>::run(args...);
+      case 201:
+        return Func<201, Args...>::run(args...);
+      case 202:
+        return Func<202, Args...>::run(args...);
+      case 203:
+        return Func<203, Args...>::run(args...);
+      case 204:
+        return Func<204, Args...>::run(args...);
+      case 205:
+        return Func<205, Args...>::run(args...);
+      case 206:
+        return Func<206, Args...>::run(args...);
+      case 207:
+        return Func<207, Args...>::run(args...);
+      case 208:
+        return Func<208, Args...>::run(args...);
+      case 209:
+        return Func<209, Args...>::run(args...);
+      case 210:
+        return Func<210, Args...>::run(args...);
+      case 211:
+        return Func<211, Args...>::run(args...);
+      case 212:
+        return Func<212, Args...>::run(args...);
+      case 213:
+        return Func<213, Args...>::run(args...);
+      case 214:
+        return Func<214, Args...>::run(args...);
+      case 215:
+        return Func<215, Args...>::run(args...);
+      case 216:
+        return Func<216, Args...>::run(args...);
+      case 217:
+        return Func<217, Args...>::run(args...);
+      case 218:
+        return Func<218, Args...>::run(args...);
+      case 219:
+        return Func<219, Args...>::run(args...);
+      case 220:
+        return Func<220, Args...>::run(args...);
+      case 221:
+        return Func<221, Args...>::run(args...);
+      case 222:
+        return Func<222, Args...>::run(args...);
+      case 223:
+        return Func<223, Args...>::run(args...);
+      case 224:
+        return Func<224, Args...>::run(args...);
+      case 225:
+        return Func<225, Args...>::run(args...);
+      case 226:
+        return Func<226, Args...>::run(args...);
+      case 227:
+        return Func<227, Args...>::run(args...);
+      case 228:
+        return Func<228, Args...>::run(args...);
+      case 229:
+        return Func<229, Args...>::run(args...);
+      case 230:
+        return Func<230, Args...>::run(args...);
+      case 231:
+        return Func<231, Args...>::run(args...);
+      case 232:
+        return Func<232, Args...>::run(args...);
+      case 233:
+        return Func<233, Args...>::run(args...);
+      case 234:
+        return Func<234, Args...>::run(args...);
+      case 235:
+        return Func<235, Args...>::run(args...);
+      case 236:
+        return Func<236, Args...>::run(args...);
+      case 237:
+        return Func<237, Args...>::run(args...);
+      case 238:
+        return Func<238, Args...>::run(args...);
+      case 239:
+        return Func<239, Args...>::run(args...);
+      case 240:
+        return Func<240, Args...>::run(args...);
+      case 241:
+        return Func<241, Args...>::run(args...);
+      case 242:
+        return Func<242, Args...>::run(args...);
+      case 243:
+        return Func<243, Args...>::run(args...);
+      case 244:
+        return Func<244, Args...>::run(args...);
+      case 245:
+        return Func<245, Args...>::run(args...);
+      case 246:
+        return Func<246, Args...>::run(args...);
+      case 247:
+        return Func<247, Args...>::run(args...);
+      case 248:
+        return Func<248, Args...>::run(args...);
+      case 249:
+        return Func<249, Args...>::run(args...);
+      case 250:
+        return Func<250, Args...>::run(args...);
+      case 251:
+        return Func<251, Args...>::run(args...);
+      case 252:
+        return Func<252, Args...>::run(args...);
+      case 253:
+        return Func<253, Args...>::run(args...);
+      case 254:
+        return Func<254, Args...>::run(args...);
+      case 255:
+        return Func<255, Args...>::run(args...);
+      default:
+        return Func<256, Args...>::run(args...);
+        // index shouldn't bigger than 256
+    }
+  }  // namespace detail
 }  // namespace detail
 }  // namespace struct_pack

--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -67,7 +67,7 @@ concept seek_reader_t = reader_t<T> && requires(T t) {
   t.seekg(std::size_t{});
 };
 
-//clang-format off
+// clang-format off
 namespace detail {
   template <typename Type>
   concept deserialize_view = requires(Type container) {

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -35,10 +35,10 @@
 #include <variant>
 #include <vector>
 
-#include "md5_constexpr.hpp"
 #include "error_code.h"
-#include "varint.hpp"
+#include "md5_constexpr.hpp"
 #include "tuple.hpp"
+#include "varint.hpp"
 
 static_assert(std::endian::native == std::endian::little,
               "only support little endian now");

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -35,9 +35,9 @@
 #include <variant>
 #include <vector>
 
-#include "error_code.h"
 #include "md5_constexpr.hpp"
-#include "struct_pack/struct_pack/varint.hpp"
+#include "error_code.h"
+#include "varint.hpp"
 #include "tuple.hpp"
 
 static_assert(std::endian::native == std::endian::little,
@@ -109,6 +109,11 @@ struct compatible : public std::optional<T> {
   constexpr compatible &operator=(compatible &&other) = default;
   using base = std::optional<T>;
   using base::base;
+  friend bool operator==(const compatible<T> &self,
+                         const compatible<T> &other) {
+    return static_cast<bool>(self) == static_cast<bool>(other) &&
+           (!self || *self == *other);
+  }
 };
 
 using var_int32_t = detail::sint<int32_t>;
@@ -128,6 +133,28 @@ constexpr inline type_info_config enable_type_info =
 
 template <typename... Args>
 STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal();
+
+struct serialize_runtime_info;
+
+namespace detail {
+template <serialize_config conf, typename... Args>
+STRUCT_PACK_INLINE constexpr serialize_runtime_info get_serialize_runtime_info(
+    const Args &...args);
+}
+
+struct serialize_runtime_info {
+ private:
+  std::size_t len_ = 4;
+  unsigned char metainfo_ = 0;
+
+ public:
+  constexpr std::size_t size() const { return len_; }
+  constexpr unsigned char metainfo() const { return metainfo_; }
+
+  template <serialize_config conf, typename... Args>
+  friend STRUCT_PACK_INLINE constexpr serialize_runtime_info
+  struct_pack::detail::get_serialize_runtime_info(const Args &...args);
+};
 
 namespace detail {
 
@@ -986,8 +1013,9 @@ consteval uint32_t get_types_code() {
 
 template <typename T>
 consteval int check_if_compatible_element_exist() {
-  return detail::check_if_compatible_element_exist<T>(
-      std::make_index_sequence<std::tuple_size_v<T>>{});
+  using U = std::remove_cvref_t<T>;
+  return detail::check_if_compatible_element_exist<U>(
+      std::make_index_sequence<std::tuple_size_v<U>>{});
 }
 
 template <typename T>
@@ -1008,11 +1036,6 @@ struct serialize_static_config {
 #else
   static constexpr bool has_type_literal = true;
 #endif
-};
-
-struct serialize_runtime_info {
-  std::size_t len;
-  unsigned char metainfo;
 };
 
 template <typename... Args>
@@ -1041,63 +1064,62 @@ get_serialize_runtime_info(const Args &...args) {
   using Type = get_args_type<Args...>;
   constexpr bool has_compatible = serialize_static_config<Type>::has_compatible;
   constexpr bool has_type_literal = check_if_add_type_literal<conf, Type>();
-  serialize_runtime_info ret{.len = sizeof(uint32_t)};
+  serialize_runtime_info ret;
   auto sz_info = calculate_payload_size(args...);
 
   if (sz_info.max_size < (1ull << 8)) [[likely]] {
-    ret.len += sz_info.total + sz_info.size_cnt;
-    ret.metainfo = 0b00000;
+    ret.len_ += sz_info.total + sz_info.size_cnt;
+    ret.metainfo_ = 0b00000;
     constexpr bool has_compile_time_determined_meta_info =
         has_compatible || has_type_literal;
     if constexpr (has_compile_time_determined_meta_info) {
-      ret.len += sizeof(unsigned char);
+      ret.len_ += sizeof(unsigned char);
     }
   }
   else {
     if (sz_info.max_size < (1ull << 16)) {
-      ret.len += sz_info.total + sz_info.size_cnt * 2;
-      ret.metainfo = 0b01000;
+      ret.len_ += sz_info.total + sz_info.size_cnt * 2;
+      ret.metainfo_ = 0b01000;
     }
     else if (sz_info.max_size < (1ull << 32)) {
-      ret.len += sz_info.total + sz_info.size_cnt * 4;
-      ret.metainfo = 0b10000;
+      ret.len_ += sz_info.total + sz_info.size_cnt * 4;
+      ret.metainfo_ = 0b10000;
     }
     else {
-      ret.len += sz_info.total + sz_info.size_cnt * 8;
-      ret.metainfo = 0b11000;
+      ret.len_ += sz_info.total + sz_info.size_cnt * 8;
+      ret.metainfo_ = 0b11000;
     }
     // size_type >= 1 , has metainfo
-    ret.len += sizeof(unsigned char);
+    ret.len_ += sizeof(unsigned char);
   }
   if constexpr (has_type_literal) {
     constexpr auto type_literal = struct_pack::get_type_literal<Args...>();
     // struct_pack::get_type_literal<Args...>().size() crash in clang13. Bug?
-    ret.len += type_literal.size() + 1;
-    ret.metainfo |= 0b100;
+    ret.len_ += type_literal.size() + 1;
+    ret.metainfo_ |= 0b100;
   }
-  if constexpr (has_compatible) {  // calculate bytes count of serialize
-                                   // length
-    if (ret.len + 2 < (1ull << 16)) [[likely]] {
-      ret.len += 2;
-      ret.metainfo |= 0b01;
+  if constexpr (has_compatible) {  // calculate bytes count of serialize length
+    if (ret.len_ + 2 < (1ull << 16)) [[likely]] {
+      ret.len_ += 2;
+      ret.metainfo_ |= 0b01;
     }
-    else if (ret.len + 4 < (1ull << 32)) {
-      ret.len += 4;
-      ret.metainfo |= 0b10;
+    else if (ret.len_ + 4 < (1ull << 32)) {
+      ret.len_ += 4;
+      ret.metainfo_ |= 0b10;
     }
     else {
-      ret.len += 8;
-      ret.metainfo |= 0b11;
+      ret.len_ += 8;
+      ret.metainfo_ |= 0b11;
     }
   }
   return ret;
 }
 
-template <struct_pack_byte Byte, typename serialize_type>
+template <writer_t writer, typename serialize_type>
 class packer {
  public:
-  packer(Byte *data, const serialize_runtime_info &info)
-      : data_(data), pos_(0), info(info) {}
+  packer(writer &writer_, const serialize_runtime_info &info)
+      : writer_(writer_), info(info) {}
   packer(const packer &) = delete;
   packer &operator=(const packer &) = delete;
 
@@ -1107,10 +1129,6 @@ class packer {
     serialize_metainfo<conf, size_type == 1, T, Args...>();
     serialize_many<size_type>(t, args...);
   }
-
-  STRUCT_PACK_INLINE const Byte *data() { return data_; }
-
-  STRUCT_PACK_INLINE size_t size() { return pos_; }
 
  private:
   template <typename T, typename... Args>
@@ -1142,22 +1160,20 @@ class packer {
   constexpr void STRUCT_PACK_INLINE serialize_metainfo() {
     constexpr auto hash_head = calculate_hash_head<conf, T, Args...>() |
                                (is_default_size_type ? 0 : 1);
-    std::memcpy(data_ + pos_, &hash_head, sizeof(uint32_t));
-    pos_ += sizeof(uint32_t);
+    writer_.write((char *)&hash_head, sizeof(uint32_t));
     if constexpr (hash_head % 2) {  // has more metainfo
-      std::memcpy(data_ + pos_, &info.metainfo, sizeof(char));
-      pos_ += sizeof(char);
+      auto metainfo = info.metainfo();
+      writer_.write((char *)&metainfo, sizeof(char));
       if constexpr (serialize_static_config<serialize_type>::has_compatible) {
         constexpr std::size_t sz[] = {0, 2, 4, 8};
-        auto len_size = sz[info.metainfo & 0b11];
-        std::memcpy(data_ + pos_, &info.len, len_size);
-        pos_ += len_size;
+        auto len_size = sz[metainfo & 0b11];
+        auto len = info.size();
+        writer_.write((char *)&len, len_size);
       }
       if constexpr (check_if_add_type_literal<conf, serialize_type>()) {
         constexpr auto type_literal =
             struct_pack::get_type_literal<T, Args...>();
-        std::memcpy(data_ + pos_, type_literal.data(), type_literal.size() + 1);
-        pos_ += type_literal.size() + 1;
+        writer_.write(type_literal.data(), type_literal.size() + 1);
       }
     }
   }
@@ -1179,16 +1195,14 @@ class packer {
     if constexpr (std::is_same_v<type, std::monostate>) {
     }
     else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
-      std::memcpy(data_ + pos_, &item, sizeof(type));
-      pos_ += sizeof(type);
+      writer_.write((char *)&item, sizeof(type));
     }
     else if constexpr (detail::varint_t<type>) {
-      detail::serialize_varint(data_, pos_, item);
+      detail::serialize_varint(writer_, item);
     }
     else if constexpr (c_array<type> || array<type>) {
       if constexpr (is_trivial_serializable<type>::value) {
-        std::memcpy(data_ + pos_, &item, sizeof(type));
-        pos_ += sizeof(type);
+        writer_.write((char *)&item, sizeof(type));
       }
       else {
         for (const auto &i : item) {
@@ -1199,26 +1213,21 @@ class packer {
     else if constexpr (map_container<type> || container<type>) {
       uint64_t size = item.size();
 #ifdef STRUCT_PACK_OPTIMIZE
-      std::memcpy(data_ + pos_, &size, size_type);
-      pos_ += size_type;
+      writer_.write((char *)&size, size_type);
 #else
       if constexpr (size_type == 1) {
-        std::memcpy(data_ + pos_, &size, size_type);
-        pos_ += size_type;
+        writer_.write((char *)&size, size_type);
       }
       else {
-        switch ((info.metainfo & 0b11000) >> 3) {
+        switch ((info.metainfo() & 0b11000) >> 3) {
           case 1:
-            std::memcpy(data_ + pos_, &size, 2);
-            pos_ += 2;
+            writer_.write((char *)&size, 2);
             break;
           case 2:
-            std::memcpy(data_ + pos_, &size, 4);
-            pos_ += 4;
+            writer_.write((char *)&size, 4);
             break;
           case 3:
-            std::memcpy(data_ + pos_, &size, 8);
-            pos_ += 8;
+            writer_.write((char *)&size, 8);
             break;
           default:
             unreachable();
@@ -1230,9 +1239,9 @@ class packer {
         auto container_size = 1ull * size * sizeof(value_type);
         if (container_size >= PTRDIFF_MAX) [[unlikely]]
           unreachable();
-        else
-          std::memcpy(data_ + pos_, item.data(), container_size);
-        pos_ += container_size;
+        else {
+          writer_.write((char *)item.data(), container_size);
+        }
         return;
       }
       else {
@@ -1254,8 +1263,7 @@ class packer {
     }
     else if constexpr (optional<type>) {
       bool has_value = item.has_value();
-      std::memcpy(data_ + pos_, &has_value, sizeof(char));
-      pos_ += sizeof(char);
+      writer_.write((char *)&has_value, sizeof(bool));
       if (has_value) {
         serialize_one<size_type>(*item);
       }
@@ -1264,8 +1272,7 @@ class packer {
       static_assert(std::variant_size_v<type> < 256,
                     "variant's size is too large");
       uint8_t index = item.index();
-      std::memcpy(data_ + pos_, &index, sizeof(index));
-      pos_ += sizeof(index);
+      writer_.write((char *)&index, sizeof(index));
       std::visit(
           [this](auto &&e) {
             this->serialize_one<size_type>(e);
@@ -1274,8 +1281,7 @@ class packer {
     }
     else if constexpr (expected<type>) {
       bool has_value = item.has_value();
-      std::memcpy(data_ + pos_, &has_value, sizeof(has_value));
-      pos_ += sizeof(has_value);
+      writer_.write((char *)&has_value, sizeof(has_value));
       if (has_value) {
         if constexpr (!std::is_same_v<typename type::value_type, void>)
           serialize_one<size_type>(item.value());
@@ -1288,8 +1294,7 @@ class packer {
       if constexpr (!pair<type> && !is_trivial_tuple<type>)
         static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
       if constexpr (is_trivial_serializable<type>::value) {
-        std::memcpy(data_ + pos_, &item, sizeof(type));
-        pos_ += sizeof(type);
+        writer_.write((char *)&item, sizeof(type));
       }
       else {
         visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
@@ -1306,8 +1311,7 @@ class packer {
   template <std::size_t size_type, unique_ptr T>
   constexpr void inline serialize_one(const T &item) {
     bool has_value = (item != nullptr);
-    std::memcpy(data_ + pos_, &has_value, sizeof(char));
-    pos_ += sizeof(char);
+    writer_.write((char *)&has_value, sizeof(char));
     if (has_value) {
       serialize_one<size_type>(*item);
     }
@@ -1315,27 +1319,104 @@ class packer {
 
   template <typename T>
   friend constexpr size_t get_needed_size(const T &t);
-  Byte *data_;
-  std::size_t pos_;
+  writer &writer_;
   const serialize_runtime_info &info;
 };
 
-template <struct_pack_byte Byte>
+template <serialize_config conf = serialize_config{},
+          struct_pack::writer_t Writer, typename... Args>
+STRUCT_PACK_INLINE void serialize_to(Writer &writer,
+                                     const serialize_runtime_info &info,
+                                     const Args &...args) {
+  static_assert(sizeof...(args) > 0);
+  detail::packer<Writer, detail::get_args_type<Args...>> o(writer, info);
+  switch ((info.metainfo() & 0b11000) >> 3) {
+    case 0:
+      o.template serialize<conf, 1>(args...);
+      break;
+#ifdef STRUCT_PACK_OPTIMIZE
+    case 1:
+      o.template serialize<conf, 2>(args...);
+      break;
+    case 2:
+      o.template serialize<conf, 4>(args...);
+      break;
+    case 3:
+      o.template serialize<conf, 8>(args...);
+      break;
+#else
+    case 1:
+    case 2:
+    case 3:
+      o.template serialize<conf, 2>(args...);
+      break;
+#endif
+    default:
+      detail::unreachable();
+      break;
+  };
+}
+
+struct memory_reader {
+  const char *now;
+  const char *end;
+  constexpr memory_reader(const char *beg, const char *end) noexcept
+      : now(beg), end(end) {}
+  bool read(char *target, size_t len) {
+    if (now + len > end) [[unlikely]] {
+      return false;
+    }
+    memcpy(target, now, len);
+    now += len;
+    return true;
+  }
+  const char *read_view(size_t len) {
+    if (now + len > end) [[unlikely]] {
+      return nullptr;
+    }
+    auto ret = now;
+    now += len;
+    return ret;
+  }
+  bool ignore(size_t len) {
+    if (now + len > end) [[unlikely]] {
+      return false;
+    }
+    now += len;
+    return true;
+  }
+  std::size_t tellg() { return (std::size_t)now; }
+  bool seekg(std::size_t pos) {
+    auto tmp = (const char *)pos;
+    if (tmp > end)
+      return false;
+    else {
+      now = tmp;
+      return true;
+    }
+  }
+};
+
+template <reader_t Reader>
 class unpacker {
  public:
   unpacker() = delete;
   unpacker(const unpacker &) = delete;
   unpacker &operator=(const unpacker &) = delete;
 
-  STRUCT_PACK_INLINE unpacker(const Byte *data, std::size_t size)
-      : data_{data}, size_(size) {}
+  STRUCT_PACK_INLINE unpacker(Reader &reader) : reader_(reader) {}
 
   template <typename T, typename... Args>
   STRUCT_PACK_INLINE struct_pack::errc deserialize(T &t, Args &...args) {
-    auto &&[err_code, data_len] =
+    struct_pack::errc err_code;
+    std::tie(err_code, data_len) =
         deserialize_metainfo<get_args_type<T, Args...>>();
     if (err_code != struct_pack::errc{}) [[unlikely]] {
       return err_code;
+    }
+    if constexpr (check_if_compatible_element_exist<decltype(get_types(
+                      get_args_type<T, Args...>{}))>()) {
+      data_len += reader_.tellg();
     }
     switch (size_type_) {
       case 0:
@@ -1359,40 +1440,39 @@ class unpacker {
   }
 
   template <typename T, typename... Args>
-  STRUCT_PACK_INLINE struct_pack::errc deserialize(std::size_t &len, T &t,
-                                                   Args &...args) {
-    auto &&[err_code, data_len] =
+  STRUCT_PACK_INLINE struct_pack::errc deserialize_with_len(std::size_t &len,
+                                                            T &t,
+                                                            Args &...args) {
+    struct_pack::errc err_code;
+    std::tie(err_code, data_len) =
         deserialize_metainfo<get_args_type<T, Args...>>();
+    len = data_len;
     if (err_code != struct_pack::errc{}) [[unlikely]] {
       return err_code;
     }
-    struct_pack::errc ret;
+    if constexpr (check_if_compatible_element_exist<decltype(get_types(
+                      get_args_type<T, Args...>{}))>()) {
+      data_len += reader_.tellg();
+    }
     switch (size_type_) {
       case 0:
-        ret = deserialize_many<1>(t, args...);
-        break;
+        return deserialize_many<1>(t, args...);
 #ifdef STRUCT_PACK_OPTIMIZE
       case 1:
-        ret = deserialize_many<2>(t, args...);
-        break;
+        return deserialize_many<2>(t, args...);
       case 2:
-        ret = deserialize_many<4>(t, args...);
-        break;
+        return deserialize_many<4>(t, args...);
       case 3:
-        ret = deserialize_many<8>(t, args...);
-        break;
+        return deserialize_many<8>(t, args...);
 #else
       case 1:
       case 2:
       case 3:
-        ret = deserialize_many<2>(t, args...);
-        break;
+        return deserialize_many<2>(t, args...);
 #endif
       default:
         unreachable();
     }
-    len = (ret == struct_pack::errc{} ? std::max(pos_, data_len) : 0);
-    return ret;
   }
 
   template <typename U, size_t I>
@@ -1401,10 +1481,14 @@ class unpacker {
           I, decltype(get_types(std::declval<std::remove_cvref_t<U>>()))>
           &field) {
     using T = std::remove_cvref_t<U>;
-
-    if (auto [code, _] = deserialize_metainfo<T>(); code != struct_pack::errc{})
-        [[unlikely]] {
-      return code;
+    struct_pack::errc err_code;
+    std::tie(err_code, data_len) = deserialize_metainfo<T>();
+    if (err_code != struct_pack::errc{}) [[unlikely]] {
+      return err_code;
+    }
+    if constexpr (check_if_compatible_element_exist<decltype(get_types(
+                      get_args_type<T>{}))>()) {
+      data_len += reader_.tellg();
     }
     switch (size_type_) {
       case 0:
@@ -1454,7 +1538,6 @@ class unpacker {
     else {
       static_assert(!sizeof(T), "illegal type");
     }
-    pos_ = 0;
     return err_code;
   }
 
@@ -1480,51 +1563,59 @@ class unpacker {
     constexpr std::size_t sz[] = {0, 2, 4, 8};
     auto len_sz = sz[compatible_sz_len];
     uint64_t data_len = 0;
-    if (size_ < sizeof(uint32_t) + sizeof(unsigned char) + len_sz)
-        [[unlikely]] {
+    if (!reader_.read((char *)&data_len, len_sz)) [[unlikely]] {
       return {errc::no_buffer_space, 0};
     }
-    std::memcpy(&data_len, data_ + pos_, len_sz);
-    pos_ += len_sz;
     return {errc{}, data_len};
   }
 
   template <typename T>
   STRUCT_PACK_INLINE struct_pack::errc deserialize_type_literal() {
     constexpr auto literal = struct_pack::get_type_literal<T>();
-    if (std::string_view{(char *)(data_ + pos_), literal.size() + 1} !=
-        std::string_view{literal.data(), literal.size() + 1}) [[unlikely]] {
-      return errc::hash_conflict;
+    if constexpr (view_reader_t<Reader>) {
+      const char *buffer = reader_.read_view(literal.size() + 1);
+      if (!buffer) [[unlikely]] {
+        return errc::no_buffer_space;
+      }
+      if (memcmp(buffer, literal.data(), literal.size() + 1)) [[unlikely]] {
+        return errc::hash_conflict;
+      }
     }
-    pos_ += literal.size() + 1;
+    else {
+      char buffer[literal.size() + 1];
+      if (!reader_.read(buffer, literal.size() + 1)) [[unlikely]] {
+        return errc::no_buffer_space;
+      }
+      if (memcmp(buffer, literal.data(), literal.size() + 1)) [[unlikely]] {
+        return errc::hash_conflict;
+      }
+    }
+
     return errc{};
   }
 
   template <class T>
   STRUCT_PACK_INLINE std::pair<struct_pack::errc, std::size_t>
   deserialize_metainfo() {
-    if (size_ < sizeof(uint32_t)) [[unlikely]] {
+    uint32_t current_types_code;
+    if (!reader_.read((char *)&current_types_code, sizeof(uint32_t)))
+        [[unlikely]] {
       return {struct_pack::errc::no_buffer_space, 0};
     }
     constexpr uint32_t types_code =
         get_types_code<T, decltype(get_types(std::declval<T>()))>();
-    uint32_t current_types_code;
-    std::memcpy(&current_types_code, data_ + pos_, sizeof(uint32_t));
     if ((current_types_code / 2) != (types_code / 2)) [[unlikely]] {
-      return {struct_pack::errc::invalid_argument, 0};
+      return {struct_pack::errc::invalid_buffer, 0};
     }
-    pos_ += sizeof(uint32_t);
     if (current_types_code % 2 == 0) [[likely]]  // unexist extended metainfo
     {
       size_type_ = 0;
       return {};
     }
-    if (size_ < sizeof(unsigned char) + sizeof(uint32_t)) [[unlikely]] {
+    unsigned char metainfo;
+    if (!reader_.read((char *)&metainfo, sizeof(unsigned char))) [[unlikely]] {
       return {struct_pack::errc::no_buffer_space, 0};
     }
-    unsigned char metainfo;
-    std::memcpy(&metainfo, data_ + pos_, sizeof(unsigned char));
-    pos_ += sizeof(unsigned char);
     std::pair<errc, std::size_t> ret;
     auto compatible_sz_len = metainfo & 0b11;
     if (compatible_sz_len) {
@@ -1547,10 +1638,14 @@ class unpacker {
   constexpr struct_pack::errc STRUCT_PACK_INLINE deserialize_many() {
     return {};
   }
-
   template <size_t size_type, bool NotSkip = true>
   constexpr struct_pack::errc STRUCT_PACK_INLINE
   deserialize_many(auto &&first_item, auto &&...items) {
+    if constexpr (get_type_id<std::remove_cvref_t<decltype(first_item)>>() ==
+                  type_id::compatible_t) {
+      if (reader_.tellg() >= data_len)
+        return struct_pack::errc{};
+    }
     auto code = deserialize_one<size_type, NotSkip>(first_item);
     if (code != struct_pack::errc{}) [[unlikely]] {
       return code;
@@ -1566,23 +1661,28 @@ class unpacker {
     if constexpr (std::is_same_v<type, std::monostate>) {
     }
     else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
-      if (pos_ + sizeof(type) > size_) [[unlikely]] {
-        return struct_pack::errc::no_buffer_space;
-      }
       if constexpr (NotSkip) {
-        std::memcpy(&item, data_ + pos_, sizeof(type));
+        if (!reader_.read((char *)&item, sizeof(type))) [[unlikely]] {
+          return struct_pack::errc::no_buffer_space;
+        }
       }
-      pos_ += sizeof(type);
+      else {
+        return reader_.ignore(sizeof(type)) ? errc{} : errc::no_buffer_space;
+      }
     }
     else if constexpr (detail::varint_t<type>) {
-      code = detail::deserialize_varint(data_, pos_, size_, item);
+      code = detail::deserialize_varint<NotSkip>(reader_, item);
     }
     else if constexpr (array<type> || c_array<type>) {
       if constexpr (is_trivial_serializable<type>::value) {
         if constexpr (NotSkip) {
-          std::memcpy(&item, data_ + pos_, sizeof(type));
+          if (!reader_.read((char *)&item, sizeof(type))) [[unlikely]] {
+            return struct_pack::errc::no_buffer_space;
+          }
         }
-        pos_ += sizeof(type);
+        else {
+          return reader_.ignore(sizeof(type)) ? errc{} : errc::no_buffer_space;
+        }
       }
       else {
         for (auto &i : item) {
@@ -1596,41 +1696,31 @@ class unpacker {
     else if constexpr (container<type>) {
       size_t size = 0;
 #ifdef STRUCT_PACK_OPTIMIZE
-      if (pos_ + size_type > size_) [[unlikely]] {
+      if (!reader_.read((char *)&size, size_type)) [[unlikely]] {
         return struct_pack::errc::no_buffer_space;
       }
-      std::memcpy(&size, data_ + pos_, size_type);
-      pos_ += size_type;
 #else
       if constexpr (size_type == 1) {
-        if (pos_ + size_type > size_) [[unlikely]] {
+        if (!reader_.read((char *)&size, size_type)) [[unlikely]] {
           return struct_pack::errc::no_buffer_space;
         }
-        std::memcpy(&size, data_ + pos_, size_type);
-        pos_ += size_type;
       }
       else {
         switch (size_type_) {
           case 1:
-            if (pos_ + 2 > size_) [[unlikely]] {
+            if (!reader_.read((char *)&size, 2)) [[unlikely]] {
               return struct_pack::errc::no_buffer_space;
             }
-            std::memcpy(&size, data_ + pos_, 2);
-            pos_ += 2;
             break;
           case 2:
-            if (pos_ + 4 > size_) [[unlikely]] {
+            if (!reader_.read((char *)&size, 4)) [[unlikely]] {
               return struct_pack::errc::no_buffer_space;
             }
-            std::memcpy(&size, data_ + pos_, 4);
-            pos_ += 4;
             break;
           case 3:
-            if (pos_ + 8 > size_) [[unlikely]] {
+            if (!reader_.read((char *)&size, 8)) [[unlikely]] {
               return struct_pack::errc::no_buffer_space;
             }
-            std::memcpy(&size, data_ + pos_, 8);
-            pos_ += 8;
             break;
           default:
             unreachable();
@@ -1652,13 +1742,20 @@ class unpacker {
             return typename T::value_type{};
           }
         }(item)) value;
-        for (size_t i = 0; i < size; ++i) {
-          code = deserialize_one<size_type, NotSkip>(value);
-          if (code != struct_pack::errc{}) [[unlikely]] {
-            return code;
-          }
-          if constexpr (NotSkip) {
-            item.emplace(std::move(value));
+        if constexpr (is_trivial_serializable<decltype(value)>::value &&
+                      !NotSkip) {
+          return reader_.ignore(size * sizeof(value)) ? errc{}
+                                                      : errc::no_buffer_space;
+        }
+        else {
+          for (size_t i = 0; i < size; ++i) {
+            code = deserialize_one<size_type, NotSkip>(value);
+            if (code != struct_pack::errc{}) [[unlikely]] {
+              return code;
+            }
+            if constexpr (NotSkip) {
+              item.emplace(std::move(value));
+            }
           }
         }
       }
@@ -1667,21 +1764,30 @@ class unpacker {
         if constexpr (trivially_copyable_container<type>) {
           size_t mem_sz = size * sizeof(value_type);
           if constexpr (NotSkip) {
-            if (pos_ + mem_sz > size_) [[unlikely]] {
-              return struct_pack::errc::no_buffer_space;
-            }
             if constexpr (string_view<type>) {
-              item = {(value_type *)(data_ + pos_), size};
+              static_assert(view_reader_t<Reader>,
+                            "The Reader isn't a view_reader, can't deserialize "
+                            "a string_view");
+              const char *view = reader_.read_view(mem_sz);
+              if (view == nullptr) [[unlikely]] {
+                return struct_pack::errc::no_buffer_space;
+              }
+              item = {(value_type *)view, size};
             }
             else {
-              item.resize(size);
               if (mem_sz >= PTRDIFF_MAX) [[unlikely]]
                 unreachable();
-              else
-                std::memcpy(item.data(), data_ + pos_, mem_sz);
+              else {
+                item.resize(size);
+                if (!reader_.read((char *)item.data(), mem_sz)) [[unlikely]] {
+                  return struct_pack::errc::no_buffer_space;
+                }
+              }
             }
           }
-          pos_ += mem_sz;
+          else {
+            return reader_.ignore(mem_sz) ? errc{} : errc::no_buffer_space;
+          }
         }
         else {
           if constexpr (NotSkip) {
@@ -1716,28 +1822,41 @@ class unpacker {
           },
           item);
     }
-    else if constexpr (optional<type>) {
-      if (pos_ + sizeof(bool) > size_) [[unlikely]] {
+    else if constexpr (optional<type> || expected<type>) {
+      bool has_value;
+      if (!reader_.read((char *)&has_value, sizeof(bool))) [[unlikely]] {
         return struct_pack::errc::no_buffer_space;
       }
-      bool has_value{};
-      std::memcpy(&has_value, data_ + pos_, sizeof(bool));
-      pos_ += sizeof(bool);
       if (!has_value) [[unlikely]] {
-        return {};
+        if constexpr (expected<type>) {
+          typename type::error_type value;
+          deserialize_one<size_type, NotSkip>(value);
+          if constexpr (NotSkip) {
+            item = typename type::unexpected_type{std::move(value)};
+          }
+        }
+        else {
+          return {};
+        }
       }
-      item = type{std::in_place_t{}};
-      deserialize_one<size_type, NotSkip>(*item);
+      else {
+        if constexpr (expected<type>) {
+          if constexpr (!std::is_same_v<typename type::value_type, void>)
+            deserialize_one<size_type, NotSkip>(item.value());
+        }
+        else {
+          item = type{std::in_place_t{}};
+          deserialize_one<size_type, NotSkip>(*item);
+        }
+      }
     }
     else if constexpr (variant<type>) {
-      if (pos_ + sizeof(uint8_t) > size_) [[unlikely]] {
+      uint8_t index;
+      if (!reader_.read((char *)&index, sizeof(index))) [[unlikely]] {
         return struct_pack::errc::no_buffer_space;
       }
-      uint8_t index;
-      std::memcpy(&index, data_ + pos_, sizeof(index));
-      pos_ += sizeof(index);
       if (index >= std::variant_size_v<type>) [[unlikely]] {
-        return struct_pack::errc::invalid_argument;
+        return struct_pack::errc::invalid_buffer;
       }
       else {
         template_switch<variant_construct_helper,
@@ -1746,37 +1865,18 @@ class unpacker {
                                                                item);
       }
     }
-    else if constexpr (expected<type>) {
-      if (pos_ + sizeof(bool) > size_) [[unlikely]] {
-        return struct_pack::errc::no_buffer_space;
-      }
-      bool has_value{};
-      std::memcpy(&has_value, data_ + pos_, sizeof(bool));
-      pos_ += sizeof(bool);
-      if (has_value) {
-        if constexpr (!std::is_same_v<typename type::value_type, void>)
-          deserialize_one<size_type, NotSkip>(item.value());
-      }
-      else {
-        typename type::error_type value;
-        deserialize_one<size_type, NotSkip>(value);
-        if constexpr (NotSkip) {
-          item = typename type::unexpected_type{std::move(value)};
-        }
-      }
-    }
     else if constexpr (std::is_class_v<type>) {
       if constexpr (!pair<type> && !is_trivial_tuple<type>)
         static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
       if constexpr (is_trivial_serializable<type>::value) {
-        if (pos_ + sizeof(type) > size_) [[unlikely]] {
-          return struct_pack::errc::no_buffer_space;
-        }
         if constexpr (NotSkip) {
-          std::memcpy(&item, data_ + pos_, sizeof(type));
+          if (!reader_.read((char *)&item, sizeof(type))) [[unlikely]] {
+            return struct_pack::errc::no_buffer_space;
+          }
         }
-
-        pos_ += sizeof(type);
+        else {
+          return reader_.ignore(sizeof(type)) ? errc{} : errc::no_buffer_space;
+        }
       }
       else {
         visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
@@ -1792,12 +1892,10 @@ class unpacker {
 
   template <size_t size_type, bool NotSkip, unique_ptr T>
   constexpr struct_pack::errc inline deserialize_one(T &item) {
-    if (pos_ + sizeof(bool) > size_) [[unlikely]] {
+    bool has_value;
+    if (!reader_.read((char *)&has_value, sizeof(bool))) [[unlikely]] {
       return struct_pack::errc::no_buffer_space;
     }
-    bool has_value{};
-    std::memcpy(&has_value, data_ + pos_, sizeof(bool));
-    pos_ += sizeof(bool);
     if (!has_value) [[unlikely]] {
       return {};
     }
@@ -1826,24 +1924,39 @@ class unpacker {
     return std::get<I>(std::forward_as_tuple(ts...));
   }
 
+  template <typename T>
+  STRUCT_PACK_INLINE constexpr bool
+  check_if_continue_deserialize_compatible_field() {
+    if constexpr (get_type_id<std::remove_cvref_t<T>>() !=
+                  type_id::compatible_t) {
+      return true;
+    }
+    else {
+      return reader_.tellg() < data_len;
+    }
+  }
+
   template <size_t size_type, size_t FieldIndex, typename FieldType,
             typename... Args>
   STRUCT_PACK_INLINE constexpr decltype(auto) for_each(FieldType &field,
                                                        Args &&...items) {
-    bool stop = false;
     struct_pack::errc code{};
     [&]<std::size_t... I>(std::index_sequence<I...>) CONSTEXPR_INLINE_LAMBDA {
-      ((!stop && (stop = set_value<size_type, I, FieldIndex>(
-                      code, field, get_nth<I>(items...)))),
+      ((check_if_continue_deserialize_compatible_field<decltype(get_nth<I>(
+            items...))>() &&
+        !set_value<size_type, I, FieldIndex>(code, field,
+                                             get_nth<I>(items...))) &&
        ...);
     }
     (std::make_index_sequence<sizeof...(Args)>{});
     return code;
   }
 
-  const Byte *data_;
-  std::size_t size_;
-  std::size_t pos_{};
+ public:
+  std::size_t data_len;
+
+ private:
+  Reader &reader_;
   unsigned char size_type_;
 };
 

--- a/include/struct_pack/struct_pack/varint.hpp
+++ b/include/struct_pack/struct_pack/varint.hpp
@@ -4,8 +4,8 @@
 #include <system_error>
 #include <type_traits>
 
-#include "reflection.h"
 #include "error_code.h"
+#include "reflection.h"
 namespace struct_pack {
 
 namespace detail {

--- a/include/struct_pack/struct_pack/varint.hpp
+++ b/include/struct_pack/struct_pack/varint.hpp
@@ -5,7 +5,7 @@
 #include <type_traits>
 
 #include "reflection.h"
-#include "struct_pack/struct_pack/error_code.h"
+#include "error_code.h"
 namespace struct_pack {
 
 namespace detail {
@@ -157,8 +157,8 @@ template <typename T>
   }
 }
 
-template <typename charT, typename T>
-STRUCT_PACK_INLINE void serialize_varint(charT* data, size_t& pos, const T& t) {
+template <writer_t writer, typename T>
+STRUCT_PACK_INLINE void serialize_varint(writer& writer_, const T& t) {
   uint64_t v;
   if constexpr (sintable_t<T>) {
     v = encode_zigzag(t.get());
@@ -167,67 +167,44 @@ STRUCT_PACK_INLINE void serialize_varint(charT* data, size_t& pos, const T& t) {
     v = t;
   }
   while (v >= 0x80) {
-    data[pos++] = static_cast<uint8_t>(v | 0x80u);
+    uint8_t temp = v | 0x80u;
+    writer_.write((char*)&temp, sizeof(temp));
     v >>= 7;
   }
-  data[pos++] = static_cast<uint8_t>(v);
+  writer_.write((char*)&v, sizeof(char));
 }
-template <typename charT>
+template <reader_t Reader>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_varint_impl(
-    charT* data, size_t& pos, size_t size, uint64_t& v) {
-  if ((static_cast<uint64_t>(data[pos]) & 0x80U) == 0) {
-    v = static_cast<uint64_t>(data[pos]);
-    pos++;
-    return {};
-  }
+    Reader& reader, uint64_t& v) {
+  uint8_t now;
   constexpr const int8_t max_varint_length = sizeof(uint64_t) * 8 / 7 + 1;
-  uint64_t val = 0;
-  if (size - pos >= max_varint_length) [[likely]] {
-    do {
-      // clang-format off
-        int64_t b = data[pos++];
-                           val  = ((uint64_t(b) & 0x7fU)       ); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x7fU) <<  7U); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x7fU) << 14U); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x7fU) << 21U); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x7fU) << 28U); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x7fU) << 35U); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x7fU) << 42U); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x7fU) << 49U); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x7fU) << 56U); if (b >= 0) { break; }
-        b = data[pos++]; val |= ((uint64_t(b) & 0x01U) << 63U); if (b >= 0) { break; }
-      // clang-format on
-      return struct_pack::errc::invalid_argument;
-    } while (false);
-  }
-  else {
-    unsigned int shift = 0;
-    while (pos != size && int64_t(data[pos]) < 0) {
-      val |= (uint64_t(data[pos++]) & 0x7fU) << shift;
-      shift += 7;
-    }
-    if (pos == size) {
+  for (int8_t i = 0; i < max_varint_length; ++i) {
+    if (!reader.read((char*)&now, sizeof(char))) [[unlikely]] {
       return struct_pack::errc::no_buffer_space;
     }
-    val |= uint64_t(data[pos++]) << shift;
+    v |= (1ull * (now & 0x7fu)) << (i * 7);
+    if ((now & 0x80U) == 0) {
+      return {};
+    }
   }
-  v = val;
-  return struct_pack::errc{};
+  return struct_pack::errc::invalid_buffer;
 }
-template <typename charT, typename T>
+template <bool NotSkip = true, reader_t Reader, typename T>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_varint(
-    charT* data, size_t& pos, size_t size, T& t) {
-  uint64_t v;
-  auto ec = deserialize_varint_impl(data, pos, size, v);
-  if (ec == struct_pack::errc{}) [[likely]] {
-    if constexpr (sintable_t<T>) {
-      t = decode_zigzag<int64_t>(v);
-    }
-    else if constexpr (std::is_enum_v<T>) {
-      t = static_cast<T>(v);
-    }
-    else {
-      t = v;
+    Reader& reader, T& t) {
+  uint64_t v = 0;
+  auto ec = deserialize_varint_impl(reader, v);
+  if constexpr (NotSkip) {
+    if (ec == struct_pack::errc{}) [[likely]] {
+      if constexpr (sintable_t<T>) {
+        t = decode_zigzag<int64_t>(v);
+      }
+      else if constexpr (std::is_enum_v<T>) {
+        t = static_cast<T>(v);
+      }
+      else {
+        t = v;
+      }
     }
   }
   return ec;

--- a/src/coro_rpc/tests/test_async_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_async_rpc_server.cpp
@@ -19,10 +19,12 @@
 #include <variant>
 
 #include "ServerTester.hpp"
+#include "coro_rpc/coro_rpc/rpc_protocol.h"
 #include "doctest.h"
 #include "rpc_api.hpp"
+#include "struct_pack/struct_pack.hpp"
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -240,8 +242,9 @@ TEST_CASE("test server write queue") {
   header.seq_num = g_client_id++;
   easylog::info("client_id {} begin to connect {}", header.seq_num, 8820);
   header.length = buffer.size() - RPC_HEAD_LEN;
-  auto sz = struct_pack::serialize_to(buffer.data(), RPC_HEAD_LEN, header);
-  CHECK(sz == RPC_HEAD_LEN);
+  constexpr auto info = struct_pack::get_serialize_info(header);
+  static_assert(info.size() == RPC_HEAD_LEN);
+  struct_pack::serialize_to((char*)buffer.data(), info, header);
   asio::io_context io_context;
   std::thread thd([&io_context]() {
     asio::io_context::work work(io_context);
@@ -266,8 +269,8 @@ TEST_CASE("test server write queue") {
     asio_util::read(socket, asio::buffer(resp_len_buf, RESPONSE_HEADER_LEN));
 
     rpc_header header{};
-    [[maybe_unused]] auto errc =
-        struct_pack::deserialize_to(header, resp_len_buf, RESPONSE_HEADER_LEN);
+    [[maybe_unused]] auto errc = struct_pack::deserialize_to(
+        header, (const char*)resp_len_buf, RESPONSE_HEADER_LEN);
     uint32_t body_len = header.length;
 
     CHECK(body_len == buf.size());

--- a/src/coro_rpc/tests/test_async_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_async_rpc_server.cpp
@@ -242,9 +242,7 @@ TEST_CASE("test server write queue") {
   header.seq_num = g_client_id++;
   easylog::info("client_id {} begin to connect {}", header.seq_num, 8820);
   header.length = buffer.size() - RPC_HEAD_LEN;
-  constexpr auto info = struct_pack::get_serialize_info(header);
-  static_assert(info.size() == RPC_HEAD_LEN);
-  struct_pack::serialize_to((char*)buffer.data(), info, header);
+  struct_pack::serialize_to((char*)buffer.data(), RPC_HEAD_LEN, header);
   asio::io_context io_context;
   std::thread thd([&io_context]() {
     asio::io_context::work work(io_context);

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -289,8 +289,8 @@ TEST_CASE("test server write queue") {
   header.seq_num = g_client_id++;
   easylog::info("client_id {} begin to connect {}", header.seq_num, 8820);
   header.length = buffer.size() - RPC_HEAD_LEN;
-  constexpr auto info = struct_pack::get_serialize_info(header);
-  struct_pack::serialize_to((char *)buffer.data(), info, header);
+  constexpr auto size = struct_pack::get_needed_size(header);
+  struct_pack::serialize_to((char *)buffer.data(), size, header);
   asio::io_context io_context;
   std::thread thd([&io_context]() {
     asio::io_context::work work(io_context);

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -26,6 +26,7 @@
 #include "coro_rpc/coro_rpc/remote.hpp"
 #include "doctest.h"
 #include "rpc_api.hpp"
+#include "struct_pack/struct_pack.hpp"
 
 async_simple::coro::Lazy<int> get_coro_value(int val) { co_return val; }
 
@@ -288,8 +289,8 @@ TEST_CASE("test server write queue") {
   header.seq_num = g_client_id++;
   easylog::info("client_id {} begin to connect {}", header.seq_num, 8820);
   header.length = buffer.size() - RPC_HEAD_LEN;
-  auto sz = struct_pack::serialize_to(buffer.data(), RPC_HEAD_LEN, header);
-  CHECK(sz == RPC_HEAD_LEN);
+  constexpr auto info = struct_pack::get_serialize_info(header);
+  struct_pack::serialize_to((char *)buffer.data(), info, header);
   asio::io_context io_context;
   std::thread thd([&io_context]() {
     asio::io_context::work work(io_context);
@@ -314,8 +315,8 @@ TEST_CASE("test server write queue") {
     read(socket, asio::buffer(resp_len_buf, RESPONSE_HEADER_LEN));
 
     rpc_header header{};
-    [[maybe_unused]] auto errc =
-        struct_pack::deserialize_to(header, resp_len_buf, RESPONSE_HEADER_LEN);
+    [[maybe_unused]] auto errc = struct_pack::deserialize_to(
+        header, (const char *)resp_len_buf, RESPONSE_HEADER_LEN);
     uint32_t body_len = header.length;
     CHECK(body_len == buf.size());
     read(socket, asio::buffer(buffer_read, body_len));

--- a/src/coro_rpc/tests/test_register_handler.cpp
+++ b/src/coro_rpc/tests/test_register_handler.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/src/struct_pack/doc/Introduction_EN.md
+++ b/src/struct_pack/doc/Introduction_EN.md
@@ -8,13 +8,20 @@
     - [Append the result at the end of existing data container](#append-the-result-at-the-end-of-existing-data-container)
     - [Save the results to memory location indicated by pointer](#save-the-results-to-memory-location-indicated-by-pointer)
     - [Multi-parameter serialization](#multi-parameter-serialization)
+    - [Save the results to output stream](#save-the-results-to-output-stream)
   - [Deserialization](#deserialization)
     - [Basic Usage](#basic-usage-1)
     - [deserialize from pointers](#deserialize-from-pointers)
     - [deserialize to an existing object](#deserialize-to-an-existing-object)
     - [Multi-parameter deserialization](#multi-parameter-deserialization)
+    - [deserialize to input stream](#deserialize-to-input-stream)
     - [Partial deserialization](#partial-deserialization)
   - [support std containers, std::optional and custom containers](#support-std-containers-stdoptional-and-custom-containers)
+  - [custom support](#custom-support)
+    - [custom type](#custom-type)
+    - [custom output stream](#custom-output-stream)
+    - [custom input stream](#custom-input-stream)
+  - [varint support](#varint-support)
   - [benchmark](#benchmark)
     - [Test case](#test-case)
     - [Test objects](#test-objects)
@@ -23,6 +30,8 @@
   - [Forward/backward compatibility](#forwardbackward-compatibility)
   - [Why is struct\_pack faster?](#why-is-struct_pack-faster)
   - [Appendix](#appendix)
+    - [struct\_pack type system](#struct_pack-type-system)
+    - [struct\_pack layout](#struct_pack-layout)
     - [Test code](#test-code)
 
 struct_pack is a serialization library featuring zero-cost abstraction as well as usability. In struct_pack, the serialization or deserialization of one complex structure could easily be done in a single line of code, without any DSL, macro, or template to be defined. struct_pack supports the serialization of C++ structures through compile-time reflection and its performance is significantly better than protobuf and msgpack (see the benchmark section for details).
@@ -82,6 +91,14 @@ auto result=struct_pack::serialize(person1.id, person1.name, person1.age, person
 //serialize as std::tuple<int64_t, std::string, int, double>
 ```
 
+### Save the results to output stream
+
+```cpp
+std::ofstream writer("struct_pack_demo.data",
+                      std::ofstream::out | std::ofstream::binary);
+struct_pack::serialize_to(writer, person1);
+```
+
 ## Deserialization
 
 In below we demonstrate serval ways of deserialize one object with struct_pack APIs.
@@ -124,6 +141,15 @@ assert(person1.id==id);
 assert(person1.name==name);
 assert(person1.age==age);
 assert(person1.salary==salary);
+```
+
+### deserialize to input stream
+
+```cpp
+std::ifstream ifs("struct_pack_demo.data",
+                  std::ofstream::in | std::ofstream::binary);
+auto person2 = struct_pack::deserialize<person>(ifs);
+assert(person2 == person1);
 ```
 
 
@@ -179,6 +205,10 @@ assert(nested2)
 assert(nested2==nested1);
 ```
 
+## custom support
+
+### custom type
+
 In addition, struct_pack supports serialization and deserialization on custom containers, as below:
 
 ```cpp
@@ -196,6 +226,65 @@ absl::flat_hash_map<int, std::string> map2 =
 auto buffer1 = serialize(map1);
 auto buffer2 = serialize(map2);
 ```
+
+For more detail, See [struct_pack type system](https://alibaba.github.io/yalantinglibs/guide/struct-pack-type-system.html)
+
+### custom output stream
+
+Except std::ostream/std::sstream struct_pack also support serialize to custom output stream.
+
+The custom stream should satisfy those conditions:
+
+```cpp
+template <typename T>
+concept writer_t = requires(T t) {
+  t.write((const char *)nullptr, std::size_t{}); // Output a piece of data. The return value can be implicit conversion to bool. Return false in any error. 
+};
+```
+
+For example:
+
+```cpp
+// A simple output stream for fwrite.
+struct fwrite_stream {
+  FILE* file;
+  bool write(const char* data, std::size_t sz) {
+    return fwrite(data, sz, 1, file) == 1;
+  }
+  fwrite_stream(const char* file_name) : file(fopen(file_name, "wb")) {}
+  ~fwrite_stream() { fclose(file); }
+};
+// ...
+fwrite_stream writer("struct_pack_demo.data");
+struct_pack::serialize_to(writer, person);
+```
+
+### custom input stream
+
+Except std::istream/std::sstream struct_pack also support serialize to custom input stream.
+
+The custom stream should satisfy those conditions:
+
+```cpp
+template <typename T>
+concept reader_t = requires(T t) {
+  t.read((char *)nullptr, std::size_t{}); // Input a piece of data. The return value can be implicit conversion to bool. Return false in any error. 
+  t.ignore(std::size_t{}); // Skip a piece of data. The return value can be implicit conversion to bool. Return false in any error. 
+  t.tellg(); // Return an unsigned integer as the absolute position of stream.
+};
+```
+
+In addition, if the stream support `read_view`, then we enable the support of zero-copy for string_view.
+
+```cpp
+template <typename T>
+concept view_reader_t = reader_t<T> && requires(T t) {
+  { t.read_view(std::size_t{}) } -> std::convertible_to<const char *>;
+  // Read a view from stream. The return value is the begin pointer to view. Return nullptr in any error.
+};
+```
+
+## varint support
 
 struct_pack also supports varint code for integer.
 
@@ -310,6 +399,15 @@ struct_pack ensures that the two classes can be safely converted to each other b
 6. Compile-time type calculation allows struct_pack to generate different codes according to different types. So we can do optimization upon types. For example, we could use `memcpy` on contiguous containers and zero-copy optimization could be used on `string_view`
 
 ## Appendix
+
+### struct_pack type system
+
+[struct_pack type system](https://alibaba.github.io/yalantinglibs/guide/struct-pack-type-system.html)
+
+### struct_pack layout
+
+[struct_pack layout](https://alibaba.github.io/yalantinglibs/guide/struct-pack-layout.html)
+
 
 ### Test code
 

--- a/src/struct_pack/doc/struct_pack_doc.hpp
+++ b/src/struct_pack/doc/struct_pack_doc.hpp
@@ -288,7 +288,7 @@ STRUCT_PACK_INLINE std::string error_message(struct_pack::errc err);
  * @return 序列化所需的buffer的长度。
  */
 template <typename... Args>
-[[nodiscard]] STRUCT_PACK_INLINE constexpr size_t get_needed_size(
+[[nodiscard]] STRUCT_PACK_INLINE constexpr auto get_needed_size(
     const Args &...args);
 
 /*!

--- a/src/struct_pack/examples/serialize/serialize.cpp
+++ b/src/struct_pack/examples/serialize/serialize.cpp
@@ -77,9 +77,9 @@ void basic_usage() {
   }
   // api 4. serialize to continuous buffer
   {
-    auto info = struct_pack::get_serialize_info(p);
-    auto array = std::make_unique<char[]>(info.size());
-    struct_pack::serialize_to(array.get(), info, p);
+    auto size = struct_pack::get_needed_size(p);
+    auto array = std::make_unique<char[]>(size);
+    struct_pack::serialize_to(array.get(), size, p);
   }
   // api 5. serialize with offset
   {

--- a/src/struct_pack/examples/serialize/serialize.cpp
+++ b/src/struct_pack/examples/serialize/serialize.cpp
@@ -13,33 +13,60 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <fcntl.h>
+
 #include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <ostream>
+#include <sstream>
 
 #include "struct_pack/struct_pack.hpp"
 #include "struct_pack/struct_pack/struct_pack_impl.hpp"
+
+struct fwrite_stream {
+  FILE* file;
+  bool write(const char* data, std::size_t sz) {
+    return fwrite(data, sz, 1, file) == 1;
+  }
+  fwrite_stream(const char* file_name) : file(fopen(file_name, "wb")) {}
+  ~fwrite_stream() { fclose(file); }
+};
+
+struct fread_stream {
+  FILE* file;
+  bool read(char* data, std::size_t sz) {
+    return fread(data, sz, 1, file) == 1;
+  }
+  bool ignore(std::size_t sz) { return fseek(file, sz, SEEK_CUR) == 0; }
+  std::size_t tellg() {
+    // if you worry about ftell performance, just use an variable to record it.
+    return ftell(file);
+  }
+  fread_stream(const char* file_name) : file(fopen(file_name, "rb")) {}
+  ~fread_stream() { fclose(file); }
+};
 
 struct person {
   int age;
   std::string name;
 
-  auto operator==(const person &rhs) const {
+  auto operator==(const person& rhs) const {
     return age == rhs.age && name == rhs.name;
   }
 };
 
+//clang-format off
 void basic_usage() {
   person p{20, "tom"};
 
   person p2{.age = 21, .name = "Betty"};
 
   // serialize api
-  // api 1. return default container
-
+  // api 1. serialize with default container
   { auto buffer = struct_pack::serialize(p); }
   // api 2. use specifier container
   { auto buffer = struct_pack::serialize<std::string>(p); }
@@ -56,7 +83,7 @@ void basic_usage() {
   }
   // api 5. serialize with offset
   {
-    auto buffer = struct_pack::serialize_with_offset(2, p);
+    auto buffer = struct_pack::serialize_with_offset(/* offset = */ 2, p);
     assert(buffer[0] == '\0' && buffer[1] == '\0');
   }
   // api 6. serialize varadic param
@@ -66,7 +93,9 @@ void basic_usage() {
   }
   // api 7. serialize to stream
   {
-    std::ofstream writer("test.out");
+    // std::ofstream writer("struct_pack_demo.data",
+    //                      std::ofstream::out | std::ofstream::binary);
+    fwrite_stream writer("struct_pack_demo.data");
     struct_pack::serialize_to(writer, p);
   }
 
@@ -96,7 +125,7 @@ void basic_usage() {
     auto buffer = struct_pack::serialize(p.age, p2.name);
     auto result = struct_pack::deserialize<int, std::string>(buffer);
     assert(result);  // no error
-    [[maybe_unused]] auto &&[age, name] = result.value();
+    [[maybe_unused]] auto&& [age, name] = result.value();
     assert(age == p.age);
     assert(name == p2.name);
   }
@@ -109,6 +138,14 @@ void basic_usage() {
     assert(result == struct_pack::errc{});
     assert(p3.age == p.age);
     assert(p3.name == p2.name);
+  }
+  // api 5. deserialize from stream
+  {
+    // std::ifstream ifs("struct_pack_demo.data",
+    //                   std::ofstream::in | std::ofstream::binary);
+    fread_stream ifs("struct_pack_demo.data");
+    auto p4 = struct_pack::deserialize<person>(ifs);
+    assert(p4 == p);
   }
 }
 

--- a/src/struct_pack/tests/CMakeLists.txt
+++ b/src/struct_pack/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(test_serialize
         test_pragma_pack.cpp
         test_pragma_pack_and_alignas_mix.cpp
         test_varint.cpp
+        test_stream.cpp
         main.cpp
         )
 add_test(NAME test_serialize COMMAND test_serialize)

--- a/src/struct_pack/tests/test_data_struct.cpp
+++ b/src/struct_pack/tests/test_data_struct.cpp
@@ -298,7 +298,7 @@ TEST_CASE("testing enum") {
     auto ec = deserialize<enum_i32>(ret.data(), ret.size());
     CHECK(!ec);
     if (!ec) {
-      CHECK(ec.error() == struct_pack::errc::invalid_argument);
+      CHECK(ec.error() == struct_pack::errc::invalid_buffer);
     }
   }
   {
@@ -468,7 +468,7 @@ TEST_CASE("test unique_ptr") {
         std::tuple<std::unique_ptr<int>>{std::make_unique<int>(24)});
     auto ret = deserialize<std::unique_ptr<float>>(buffer);
     REQUIRE(!ret);
-    CHECK(ret.error() == struct_pack::errc::invalid_argument);
+    CHECK(ret.error() == struct_pack::errc::invalid_buffer);
   }
   SUBCASE("test list") {
     my_list list_head, *now = &list_head;

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -25,6 +25,8 @@
 #include <utility>
 #include <variant>
 
+#include "struct_pack/struct_pack/error_code.h"
+
 #define private public
 #include "struct_pack/struct_pack.hpp"
 #undef private
@@ -101,18 +103,16 @@ TEST_CASE("testing api") {
     CHECK(p == p2.value());
   }
   SUBCASE("serialize to") {
-    auto need_size = get_needed_size(p);
+    auto info = get_serialize_info(p);
     std::vector<std::byte> my_buffer, my_buffer2;
-    my_buffer.resize(need_size);
-    my_buffer2.resize(need_size + offset);
-    auto ret1 = serialize_to(my_buffer.data(), need_size, p);
-    CHECK(ret1 == need_size);
-    auto ret2 = serialize_to(my_buffer2.data() + offset, need_size, p);
-    CHECK(ret2 == need_size);
+    my_buffer.resize(info.size());
+    my_buffer2.resize(info.size() + offset);
+    serialize_to((char *)my_buffer.data(), info, p);
+    serialize_to((char *)my_buffer2.data() + offset, info, p);
     person p1, p2;
-    auto ec1 = deserialize_to(p1, my_buffer.data(), my_buffer.size());
+    auto ec1 = deserialize_to(p1, my_buffer);
     CHECK(ec1 == struct_pack::errc{});
-    auto ec2 = deserialize_to(p2, my_buffer2.data() + offset,
+    auto ec2 = deserialize_to(p2, (const char *)my_buffer2.data() + offset,
                               my_buffer2.size() - offset);
     CHECK(ec2 == struct_pack::errc{});
     CHECK(p == p1);
@@ -123,16 +123,16 @@ TEST_CASE("testing api") {
     serialize_to(my_buffer, p);
     serialize_to_with_offset(my_buffer2, offset, p);
     CHECK(my_buffer.size() == my_buffer2.size() - offset);
-    auto ret1 = get_field<person, 0>(my_buffer.data(), my_buffer.size());
+    auto ret1 = get_field<person, 0>(my_buffer);
     CHECK(ret1);
-    auto ret2 = get_field<person, 0>(my_buffer2.data() + offset,
+    auto ret2 = get_field<person, 0>((const char *)my_buffer2.data() + offset,
                                      my_buffer2.size() - offset);
     CHECK(ret2);
     CHECK(ret1.value() == p.age);
     CHECK(ret2.value() == p.age);
-    auto ret3 = get_field<person, 1>(my_buffer.data(), my_buffer.size());
+    auto ret3 = get_field<person, 1>(my_buffer);
     CHECK(ret3);
-    auto ret4 = get_field<person, 1>(my_buffer2.data() + offset,
+    auto ret4 = get_field<person, 1>((const char *)my_buffer2.data() + offset,
                                      my_buffer2.size() - offset);
     CHECK(ret4);
     CHECK(ret3.value() == p.name);
@@ -162,24 +162,6 @@ TEST_CASE("testing pack object") {
   }
 }
 
-TEST_CASE("test buffer size") {
-  person p{20, "tom"};
-  auto size = get_needed_size(p);
-
-  SUBCASE("test great than need") {
-    auto buffer_size = size + 100;
-    auto buffer = std::make_unique<char[]>(buffer_size);
-    auto ret = serialize_to(buffer.get(), buffer_size, p);
-    CHECK(ret == size);
-  }
-
-  SUBCASE("test less than need") {
-    auto buffer_size = size - 1;
-    auto buffer = std::make_unique<char[]>(buffer_size);
-    auto ret = serialize_to(buffer.get(), buffer_size, p);
-    CHECK(ret == 0);
-  }
-}
 void test_container(auto &v) {
   auto ret = serialize(v);
 
@@ -199,48 +181,21 @@ void test_container(auto &v) {
 }
 
 TEST_CASE("testing exceptions") {
-  std::string buffer;
-  buffer.resize(2);
-  auto ret = serialize_to(buffer.data(), buffer.size(), std::string("hello"));
-  CHECK(ret == 0);
-
-  std::array<std::string, 2> arr{"hello", "struct_pack"};
-  auto size = get_needed_size(arr);
-  buffer.resize(size);
-  ret = serialize_to(buffer.data(), size - 1, arr);
-  CHECK(ret == 0);
-
-  std::pair<int, std::string> pair{2, "hello"};
-  size = get_needed_size(pair);
-  buffer.resize(size);
-  ret = serialize_to(buffer.data(), size - 1, pair);
-  CHECK(ret == 0);
-
-  std::map<int, std::string> map{{1, "hello"}};
-  size = get_needed_size(map);
-  buffer.resize(size);
-  ret = serialize_to(buffer.data(), size - 1, map);
-  CHECK(ret == 0);
-  ret = serialize_to(buffer.data(), size - 6, map);
-  CHECK(ret == 0);
-  ret = serialize_to(buffer.data(), size - 10, map);
-  CHECK(ret == 0);
-
   std::vector<int> data_list = {1, 2, 3};
   std::vector<std::byte> my_byte_buffer;
   serialize_to(my_byte_buffer, data_list);
   std::vector<int> data_list2;
-  auto ec = deserialize_to(data_list2, my_byte_buffer.data(), 0);
+  auto ec = deserialize_to(data_list2, (const char *)my_byte_buffer.data(), 0);
   CHECK(ec == struct_pack::errc::no_buffer_space);
-  ec = deserialize_to(data_list2, my_byte_buffer.data(),
+  ec = deserialize_to(data_list2, (const char *)my_byte_buffer.data(),
                       my_byte_buffer.size() - 1);
   CHECK(ec == struct_pack::errc::no_buffer_space);
 
   std::vector<std::byte> my_byte_buffer2;
   std::optional<bool> bool_opt;
   serialize_to(my_byte_buffer2, bool_opt);
-  auto ret3 = deserialize<std::optional<bool>>(my_byte_buffer2.data(),
-                                               my_byte_buffer2.size() - 1);
+  auto ret3 = deserialize<std::optional<bool>>(
+      (const char *)my_byte_buffer2.data(), my_byte_buffer2.size() - 1);
   CHECK(!ret3);
   if (!ret3) {
     CHECK(ret3.error() == struct_pack::errc::no_buffer_space);
@@ -557,17 +512,17 @@ TEST_CASE("testing deserialization with invalid data") {
 
   std::string str{};
   auto ret2 = deserialize_to(str, ret.data(), ret.size());
-  CHECK(ret2 == struct_pack::errc::invalid_argument);
+  CHECK(ret2 == struct_pack::errc::invalid_buffer);
 
   ret2 = deserialize_to(str, ret.data(), INT32_MAX);
-  CHECK(ret2 == struct_pack::errc::invalid_argument);
+  CHECK(ret2 == struct_pack::errc::invalid_buffer);
 
   SUBCASE("test invalid int") {
     ret = serialize(std::string("hello"));
 
     std::tuple<int, int> tp{};
     auto ret3 = deserialize_to(tp, ret.data(), ret.size());
-    CHECK(ret3 == struct_pack::errc::invalid_argument);
+    CHECK(ret3 == struct_pack::errc::invalid_buffer);
   }
 }
 
@@ -721,7 +676,7 @@ TEST_CASE("test type info config") {
   SUBCASE("test_person") {
 #ifdef NDEBUG
     {
-      auto size = get_needed_size(person{.age = 24, .name = "Betty"});
+      auto size = get_serialize_info(person{.age = 24, .name = "Betty"}).size();
       CHECK(size == 14);
       auto buffer = serialize(person{.age = 24, .name = "Betty"});
       CHECK(buffer.size() == size);
@@ -731,7 +686,7 @@ TEST_CASE("test type info config") {
     }
 #else
     {
-      auto size = get_needed_size(person{.age = 24, .name = "Betty"});
+      auto size = get_serialize_info(person{.age = 24, .name = "Betty"}).size();
       CHECK(size == 21);
       auto buffer = serialize(person{.age = 24, .name = "Betty"});
       CHECK(buffer.size() == size);
@@ -741,8 +696,10 @@ TEST_CASE("test type info config") {
     }
 #endif
     {
-      auto size = get_needed_size<serialize_config{type_info_config::disable}>(
-          person{.age = 24, .name = "Betty"});
+      auto size =
+          get_serialize_info<serialize_config{type_info_config::disable}>(
+              person{.age = 24, .name = "Betty"})
+              .size();
       CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
@@ -753,8 +710,10 @@ TEST_CASE("test type info config") {
               serialize_config{type_info_config::disable}, person>() == false);
     }
     {
-      auto size = get_needed_size<serialize_config{type_info_config::enable}>(
-          person{.age = 24, .name = "Betty"});
+      auto size =
+          get_serialize_info<serialize_config{type_info_config::enable}>(
+              person{.age = 24, .name = "Betty"})
+              .size();
       CHECK(size == 21);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
@@ -768,7 +727,8 @@ TEST_CASE("test type info config") {
   SUBCASE("test_person_with_type_info") {
     {
       auto size =
-          get_needed_size(person_with_type_info{.age = 24, .name = "Betty"});
+          get_serialize_info(person_with_type_info{.age = 24, .name = "Betty"})
+              .size();
       CHECK(size == 21);
       auto buffer =
           serialize(person_with_type_info{.age = 24, .name = "Betty"});
@@ -778,8 +738,10 @@ TEST_CASE("test type info config") {
                                             person_with_type_info>() == true);
     }
     {
-      auto size = get_needed_size<serialize_config{type_info_config::disable}>(
-          person_with_type_info{.age = 24, .name = "Betty"});
+      auto size =
+          get_serialize_info<serialize_config{type_info_config::disable}>(
+              person_with_type_info{.age = 24, .name = "Betty"})
+              .size();
       CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
@@ -790,8 +752,10 @@ TEST_CASE("test type info config") {
                         person_with_type_info>() == false);
     }
     {
-      auto size = get_needed_size<serialize_config{type_info_config::enable}>(
-          person_with_type_info{.age = 24, .name = "Betty"});
+      auto size =
+          get_serialize_info<serialize_config{type_info_config::enable}>(
+              person_with_type_info{.age = 24, .name = "Betty"})
+              .size();
       CHECK(size == 21);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
@@ -804,8 +768,9 @@ TEST_CASE("test type info config") {
   }
   SUBCASE("test_person_with_no_type_info") {
     {
-      auto size =
-          get_needed_size(person_with_no_type_info{.age = 24, .name = "Betty"});
+      auto size = get_serialize_info(
+                      person_with_no_type_info{.age = 24, .name = "Betty"})
+                      .size();
       CHECK(size == 14);
       auto buffer =
           serialize(person_with_no_type_info{.age = 24, .name = "Betty"});
@@ -816,8 +781,10 @@ TEST_CASE("test type info config") {
           false);
     }
     {
-      auto size = get_needed_size<serialize_config{type_info_config::disable}>(
-          person_with_no_type_info{.age = 24, .name = "Betty"});
+      auto size =
+          get_serialize_info<serialize_config{type_info_config::disable}>(
+              person_with_no_type_info{.age = 24, .name = "Betty"})
+              .size();
       CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
@@ -828,8 +795,10 @@ TEST_CASE("test type info config") {
                         person_with_no_type_info>() == false);
     }
     {
-      auto size = get_needed_size<serialize_config{type_info_config::enable}>(
-          person_with_no_type_info{.age = 24, .name = "Betty"});
+      auto size =
+          get_serialize_info<serialize_config{type_info_config::enable}>(
+              person_with_no_type_info{.age = 24, .name = "Betty"})
+              .size();
       CHECK(size == 21);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
@@ -872,7 +841,7 @@ TEST_CASE("test get field exceptions") {
   auto pair = get_field<std::pair<int, int>, 0>(ret.data(), ret.size());
   CHECK(!pair);
   if (!pair) {
-    CHECK(pair.error() == struct_pack::errc::invalid_argument);
+    CHECK(pair.error() == struct_pack::errc::invalid_buffer);
   }
 
   auto pair1 = get_field<person, 0>(ret.data(), 3);
@@ -885,7 +854,8 @@ TEST_CASE("test get field exceptions") {
 TEST_CASE("test set_value") {
   person p{20, "tom"};
   auto ret = serialize(p);
-  detail::unpacker in(ret.data(), ret.size());
+  detail::memory_reader reader(ret.data(), ret.data() + ret.size());
+  detail::unpacker in(reader);
   person p2;
   struct_pack::errc ec;
   std::string s;
@@ -931,13 +901,13 @@ TEST_CASE("test free functions") {
 }
 
 TEST_CASE("test compatible") {
-  SUBCASE("serialize person") {
+  SUBCASE("serialize person1 2 person") {
     person1 p1{20, "tom", 1, false};
     std::vector<char> buffer;
-    buffer.resize(get_needed_size(p1));
+    auto info = get_serialize_info(p1);
+    buffer.resize(info.size());
 
-    auto ret = serialize_to(buffer.data(), buffer.size(), p1);
-    CHECK(ret != 0);
+    serialize_to(buffer.data(), info, p1);
 
     person p;
     auto res = deserialize_to(p, buffer.data(), buffer.size());
@@ -945,18 +915,31 @@ TEST_CASE("test compatible") {
     CHECK(p.name == p1.name);
     CHECK(p.age == p1.age);
 
+    auto info2 = get_serialize_info(p);
     // short data
-    for (int i = 0, lim = get_needed_size(p); i < lim; ++i)
+    for (int i = 0, lim = info2.size(); i < lim; ++i)
       CHECK(deserialize_to(p, buffer.data(), i) ==
             struct_pack::errc::no_buffer_space);
 
-    ret = serialize_to(buffer.data(), buffer.size(), p);
-    CHECK(ret != 0);
+    serialize_to(buffer.data(), info2, p);
 
     person1 p2;
     CHECK(deserialize_to(p2, buffer.data(), buffer.size()) ==
           struct_pack::errc{});
     CHECK((p2.age == p.age && p2.name == p.name));
+  }
+  SUBCASE("serialize person 2 person1") {
+    std::vector<char> buffer;
+    person p{20, "tom"};
+    struct_pack::serialize_to(buffer, p);
+    struct_pack::serialize_to(buffer, p);
+    struct_pack::serialize_to(buffer, p);
+
+    person1 p1, p0 = {.age = 20, .name = "tom"};
+    auto ec = struct_pack::deserialize_to(p1, buffer);
+    CHECK(ec == struct_pack::errc{});
+    bool i=p1.id.has_value();
+    CHECK(p1 == p0);
   }
   SUBCASE("big compatible metainfo") {
     {
@@ -967,7 +950,7 @@ TEST_CASE("test compatible") {
 #endif
       std::tuple<compatible<std::array<char, array_sz>>> big =
           std::array<char, array_sz>{'A', 'E', 'I', 'O', 'U'};
-      auto sz = get_needed_size(big);
+      auto sz = get_serialize_info(big).size();
       CHECK(sz == 255);
       auto buffer = serialize(big);
       CHECK(sz == buffer.size());
@@ -990,7 +973,7 @@ TEST_CASE("test compatible") {
 #endif
       std::tuple<compatible<std::array<char, array_sz>>> big =
           std::array<char, array_sz>{'A', 'E', 'I', 'O', 'U'};
-      auto sz = get_needed_size(big);
+      auto sz = get_serialize_info(big).size();
       CHECK(sz == 256);
       auto buffer = serialize(big);
       CHECK(sz == buffer.size());
@@ -1013,7 +996,7 @@ TEST_CASE("test compatible") {
 #endif
       std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
       std::get<0>(big).value().resize(array_sz);
-      auto sz = get_needed_size(big);
+      auto sz = get_serialize_info(big).size();
       CHECK(sz == 65535);
       auto buffer = serialize(big);
       CHECK(sz == buffer.size());
@@ -1034,7 +1017,7 @@ TEST_CASE("test compatible") {
 #endif
       std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
       std::get<0>(big).value().resize(array_sz);
-      auto sz = get_needed_size(big);
+      auto sz = get_serialize_info(big).size();
       CHECK(sz == 65538);
       auto buffer = serialize(big);
       CHECK(sz == buffer.size());
@@ -1133,12 +1116,12 @@ TEST_CASE("test serialize offset") {
 
   person p{20, "tom"};
   std::vector<char> buffer;
-  auto need_size = get_needed_size(p);
-  buffer.resize(need_size + offset);
-  auto ret = serialize_to(buffer.data() + offset, buffer.size(), p);
-  CHECK(ret != 0);
+  auto info = get_serialize_info(p);
+  buffer.resize(info.size() + offset);
+  serialize_to(buffer.data() + offset, info, p);
   person p2;
-  CHECK(deserialize_to(p2, buffer.data() + offset, ret) == struct_pack::errc{});
+  CHECK(deserialize_to(p2, buffer.data() + offset, info.size()) ==
+        struct_pack::errc{});
   CHECK(p2 == p);
 
   std::vector<char> buffer2;
@@ -1146,9 +1129,9 @@ TEST_CASE("test serialize offset") {
   auto original_size = buffer2.size();
   auto data_offset = original_size + offset;
   serialize_to_with_offset(buffer2, offset, p);
-  CHECK(data_offset + need_size == buffer2.size());
+  CHECK(data_offset + info.size() == buffer2.size());
   person p3;
-  CHECK(deserialize_to(p3, buffer2.data() + data_offset, need_size) ==
+  CHECK(deserialize_to(p3, buffer2.data() + data_offset, info.size()) ==
         struct_pack::errc{});
   CHECK(p3 == p);
 }

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -103,12 +103,12 @@ TEST_CASE("testing api") {
     CHECK(p == p2.value());
   }
   SUBCASE("serialize to") {
-    auto info = get_serialize_info(p);
+    auto size = get_needed_size(p);
     std::vector<std::byte> my_buffer, my_buffer2;
-    my_buffer.resize(info.size());
-    my_buffer2.resize(info.size() + offset);
-    serialize_to((char *)my_buffer.data(), info, p);
-    serialize_to((char *)my_buffer2.data() + offset, info, p);
+    my_buffer.resize(size);
+    my_buffer2.resize(size + offset);
+    serialize_to((char *)my_buffer.data(), size, p);
+    serialize_to((char *)my_buffer2.data() + offset, size, p);
     person p1, p2;
     auto ec1 = deserialize_to(p1, my_buffer);
     CHECK(ec1 == struct_pack::errc{});
@@ -676,7 +676,7 @@ TEST_CASE("test type info config") {
   SUBCASE("test_person") {
 #ifdef NDEBUG
     {
-      auto size = get_serialize_info(person{.age = 24, .name = "Betty"}).size();
+      auto size = get_needed_size(person{.age = 24, .name = "Betty"});
       CHECK(size == 14);
       auto buffer = serialize(person{.age = 24, .name = "Betty"});
       CHECK(buffer.size() == size);
@@ -686,7 +686,7 @@ TEST_CASE("test type info config") {
     }
 #else
     {
-      auto size = get_serialize_info(person{.age = 24, .name = "Betty"}).size();
+      auto size = get_needed_size(person{.age = 24, .name = "Betty"});
       CHECK(size == 21);
       auto buffer = serialize(person{.age = 24, .name = "Betty"});
       CHECK(buffer.size() == size);
@@ -696,10 +696,8 @@ TEST_CASE("test type info config") {
     }
 #endif
     {
-      auto size =
-          get_serialize_info<serialize_config{type_info_config::disable}>(
-              person{.age = 24, .name = "Betty"})
-              .size();
+      auto size = get_needed_size<serialize_config{type_info_config::disable}>(
+          person{.age = 24, .name = "Betty"});
       CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
@@ -710,10 +708,8 @@ TEST_CASE("test type info config") {
               serialize_config{type_info_config::disable}, person>() == false);
     }
     {
-      auto size =
-          get_serialize_info<serialize_config{type_info_config::enable}>(
-              person{.age = 24, .name = "Betty"})
-              .size();
+      auto size = get_needed_size<serialize_config{type_info_config::enable}>(
+          person{.age = 24, .name = "Betty"});
       CHECK(size == 21);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
@@ -727,8 +723,7 @@ TEST_CASE("test type info config") {
   SUBCASE("test_person_with_type_info") {
     {
       auto size =
-          get_serialize_info(person_with_type_info{.age = 24, .name = "Betty"})
-              .size();
+          get_needed_size(person_with_type_info{.age = 24, .name = "Betty"});
       CHECK(size == 21);
       auto buffer =
           serialize(person_with_type_info{.age = 24, .name = "Betty"});
@@ -738,10 +733,8 @@ TEST_CASE("test type info config") {
                                             person_with_type_info>() == true);
     }
     {
-      auto size =
-          get_serialize_info<serialize_config{type_info_config::disable}>(
-              person_with_type_info{.age = 24, .name = "Betty"})
-              .size();
+      auto size = get_needed_size<serialize_config{type_info_config::disable}>(
+          person_with_type_info{.age = 24, .name = "Betty"});
       CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
@@ -752,10 +745,8 @@ TEST_CASE("test type info config") {
                         person_with_type_info>() == false);
     }
     {
-      auto size =
-          get_serialize_info<serialize_config{type_info_config::enable}>(
-              person_with_type_info{.age = 24, .name = "Betty"})
-              .size();
+      auto size = get_needed_size<serialize_config{type_info_config::enable}>(
+          person_with_type_info{.age = 24, .name = "Betty"});
       CHECK(size == 21);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
@@ -768,9 +759,8 @@ TEST_CASE("test type info config") {
   }
   SUBCASE("test_person_with_no_type_info") {
     {
-      auto size = get_serialize_info(
-                      person_with_no_type_info{.age = 24, .name = "Betty"})
-                      .size();
+      auto size =
+          get_needed_size(person_with_no_type_info{.age = 24, .name = "Betty"});
       CHECK(size == 14);
       auto buffer =
           serialize(person_with_no_type_info{.age = 24, .name = "Betty"});
@@ -781,10 +771,8 @@ TEST_CASE("test type info config") {
           false);
     }
     {
-      auto size =
-          get_serialize_info<serialize_config{type_info_config::disable}>(
-              person_with_no_type_info{.age = 24, .name = "Betty"})
-              .size();
+      auto size = get_needed_size<serialize_config{type_info_config::disable}>(
+          person_with_no_type_info{.age = 24, .name = "Betty"});
       CHECK(size == 14);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::disable}>(
@@ -795,10 +783,8 @@ TEST_CASE("test type info config") {
                         person_with_no_type_info>() == false);
     }
     {
-      auto size =
-          get_serialize_info<serialize_config{type_info_config::enable}>(
-              person_with_no_type_info{.age = 24, .name = "Betty"})
-              .size();
+      auto size = get_needed_size<serialize_config{type_info_config::enable}>(
+          person_with_no_type_info{.age = 24, .name = "Betty"});
       CHECK(size == 21);
       auto buffer = serialize<std::vector<char>,
                               serialize_config{type_info_config::enable}>(
@@ -904,10 +890,9 @@ TEST_CASE("test compatible") {
   SUBCASE("serialize person1 2 person") {
     person1 p1{20, "tom", 1, false};
     std::vector<char> buffer;
-    auto info = get_serialize_info(p1);
-    buffer.resize(info.size());
-
-    serialize_to(buffer.data(), info, p1);
+    auto size = get_needed_size(p1);
+    buffer.resize(size);
+    serialize_to(buffer.data(), size, p1);
 
     person p;
     auto res = deserialize_to(p, buffer.data(), buffer.size());
@@ -915,13 +900,13 @@ TEST_CASE("test compatible") {
     CHECK(p.name == p1.name);
     CHECK(p.age == p1.age);
 
-    auto info2 = get_serialize_info(p);
+    auto size2 = get_needed_size(p);
     // short data
-    for (int i = 0, lim = info2.size(); i < lim; ++i)
+    for (int i = 0, lim = size2; i < lim; ++i)
       CHECK(deserialize_to(p, buffer.data(), i) ==
             struct_pack::errc::no_buffer_space);
 
-    serialize_to(buffer.data(), info2, p);
+    serialize_to(buffer.data(), size2, p);
 
     person1 p2;
     CHECK(deserialize_to(p2, buffer.data(), buffer.size()) ==
@@ -950,7 +935,7 @@ TEST_CASE("test compatible") {
 #endif
       std::tuple<compatible<std::array<char, array_sz>>> big =
           std::array<char, array_sz>{'A', 'E', 'I', 'O', 'U'};
-      auto sz = get_serialize_info(big).size();
+      auto sz = get_needed_size(big);
       CHECK(sz == 255);
       auto buffer = serialize(big);
       CHECK(sz == buffer.size());
@@ -973,7 +958,7 @@ TEST_CASE("test compatible") {
 #endif
       std::tuple<compatible<std::array<char, array_sz>>> big =
           std::array<char, array_sz>{'A', 'E', 'I', 'O', 'U'};
-      auto sz = get_serialize_info(big).size();
+      auto sz = get_needed_size(big);
       CHECK(sz == 256);
       auto buffer = serialize(big);
       CHECK(sz == buffer.size());
@@ -996,7 +981,7 @@ TEST_CASE("test compatible") {
 #endif
       std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
       std::get<0>(big).value().resize(array_sz);
-      auto sz = get_serialize_info(big).size();
+      auto sz = get_needed_size(big);
       CHECK(sz == 65535);
       auto buffer = serialize(big);
       CHECK(sz == buffer.size());
@@ -1017,7 +1002,7 @@ TEST_CASE("test compatible") {
 #endif
       std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
       std::get<0>(big).value().resize(array_sz);
-      auto sz = get_serialize_info(big).size();
+      auto sz = get_needed_size(big);
       CHECK(sz == 65538);
       auto buffer = serialize(big);
       CHECK(sz == buffer.size());
@@ -1116,7 +1101,7 @@ TEST_CASE("test serialize offset") {
 
   person p{20, "tom"};
   std::vector<char> buffer;
-  auto info = get_serialize_info(p);
+  auto info = get_needed_size(p);
   buffer.resize(info.size() + offset);
   serialize_to(buffer.data() + offset, info, p);
   person p2;

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -938,7 +938,7 @@ TEST_CASE("test compatible") {
     person1 p1, p0 = {.age = 20, .name = "tom"};
     auto ec = struct_pack::deserialize_to(p1, buffer);
     CHECK(ec == struct_pack::errc{});
-    bool i=p1.id.has_value();
+    bool i = p1.id.has_value();
     CHECK(p1 == p0);
   }
   SUBCASE("big compatible metainfo") {

--- a/src/struct_pack/tests/test_stream.cpp
+++ b/src/struct_pack/tests/test_stream.cpp
@@ -1,0 +1,205 @@
+#include <fstream>
+#include <ios>
+#include <iostream>
+
+#include "doctest.h"
+#include "struct_pack/struct_pack.hpp"
+#include "struct_pack/struct_pack/error_code.h"
+#include "test_struct.hpp"
+
+TEST_CASE("test serialize_to/deserialize file") {
+  person p1{.age = 24, .name = "Betty"}, p2{.age = 45, .name = "Tom"};
+  complicated_object v{
+      .color = Color::red,
+      .a = 42,
+      .b = "hello",
+      .c = {{20, "tom"}, {22, "jerry"}},
+      .d = {"hello", "world"},
+      .e = {1, 2},
+      .f = {{1, {20, "tom"}}},
+      .g = {{1, {20, "tom"}}, {1, {22, "jerry"}}},
+      .h = {"aa", "bb"},
+      .i = {1, 2},
+      .j = {{1, {20, "tom"}}, {1, {22, "jerry"}}},
+      .k = {{1, 2}, {1, 3}},
+      .m = {person{20, "tom"}, {22, "jerry"}},
+      .n = {person{20, "tom"}, {22, "jerry"}},
+      .o = std::make_pair("aa", person{20, "tom"}),
+  };
+  nested_object nested{.id = 2, .name = "tom", .p = {20, "tom"}, .o = v};
+  SUBCASE("serialize_to empty file") {
+    // serialize to file
+    std::ofstream ofs("1.save", std::ofstream::binary | std::ofstream::out);
+    for (int i = 0; i < 100; ++i) {
+      struct_pack::serialize_to(ofs, p1);
+      struct_pack::serialize_to(ofs, nested);
+    }
+    auto total_size = (struct_pack::get_serialize_info(p1).size() +
+                       struct_pack::get_serialize_info(nested).size()) *
+                      100;
+    CHECK(ofs.tellp() == total_size);
+  }
+  SUBCASE("serialize_to non-empty file") {
+    // serialize to file
+    std::ofstream ofs("1.save", std::ofstream::binary | std::ofstream::out |
+                                    std::ostream::app);
+    for (int i = 0; i < 100; ++i) {
+      struct_pack::serialize_to(ofs, p2);
+      struct_pack::serialize_to(ofs, nested);
+    }
+  }
+  SUBCASE("test deserialize") {
+    std::ifstream ifs("1.save", std::ofstream::binary | std::ofstream::in);
+    for (int i = 0; i < 100; ++i) {
+      auto person1 = struct_pack::deserialize<person>(ifs);
+      CHECK(person1 == p1);
+      auto nested1 = struct_pack::deserialize<nested_object>(ifs);
+      CHECK(nested1 == nested);
+    }
+    for (int i = 0; i < 100; ++i) {
+      auto person2 = struct_pack::deserialize<person>(ifs);
+      CHECK(person2 == p2);
+      auto nested1 = struct_pack::deserialize<nested_object>(ifs);
+      CHECK(nested1 == nested);
+    }
+  }
+  SUBCASE("test deserialize_to") {
+    std::ifstream ifs("1.save", std::ofstream::binary | std::ofstream::in);
+    for (int i = 0; i < 100; ++i) {
+      person person1;
+      auto ec = struct_pack::deserialize_to(person1, ifs);
+      CHECK(ec == struct_pack::errc{});
+      CHECK(person1 == p1);
+      nested_object nested1;
+      ec = struct_pack::deserialize_to(nested1, ifs);
+      CHECK(ec == struct_pack::errc{});
+      CHECK(nested1 == nested);
+    }
+    for (int i = 0; i < 100; ++i) {
+      person person2;
+      auto ec = struct_pack::deserialize_to(person2, ifs);
+      CHECK(ec == struct_pack::errc{});
+      CHECK(person2 == p2);
+      nested_object nested1;
+      ec = struct_pack::deserialize_to(nested1, ifs);
+      CHECK(ec == struct_pack::errc{});
+      CHECK(nested1 == nested);
+    }
+  }
+}
+
+TEST_CASE("test get_field file") {
+  std::array<person, 2> p{person{.age = 24, .name = "Betty"},
+                          person{.age = 45, .name = "Tom"}};
+  std::ofstream ofs("2.save", std::ofstream::binary | std::ofstream::out);
+  for (int i = 0; i < 100; ++i) {
+    for (auto &p1 : p) {
+      auto pos = ofs.tellp();
+      CHECK(ofs.seekp(4, std::ios_base::cur));
+      struct_pack::serialize_to(ofs, p1);
+      auto npos = ofs.tellp();
+      CHECK(ofs.seekp(pos));
+      uint32_t sz = npos - pos;
+      CHECK(ofs.write((char *)&sz, 4));
+      CHECK(ofs.seekp(npos));
+    }
+  }
+  auto total_size = (struct_pack::get_serialize_info(p[0]).size() +
+                     struct_pack::get_serialize_info(p[1]).size() + 8) *
+                    100;
+  CHECK(ofs.tellp() == total_size);
+
+  SUBCASE("test get_field") {
+    std::ifstream ifs("2.save", std::ofstream::binary | std::ofstream::in);
+    for (int i = 0; i < 100; ++i) {
+      for (auto &p1 : p) {
+        std::size_t pos = ifs.tellg();
+        std::uint32_t sz;
+        CHECK(ifs.read((char *)&sz, 4));
+        auto name = struct_pack::get_field<person, 1>(ifs);
+        CHECK(name == p1.name);
+        CHECK(ifs.seekg(pos + sz));
+      }
+    }
+  }
+  SUBCASE("test get_field") {
+    std::ifstream ifs("2.save", std::ofstream::binary | std::ofstream::in);
+    for (int i = 0; i < 100; ++i) {
+      for (auto &p1 : p) {
+        std::size_t pos = ifs.tellg();
+        std::uint32_t sz;
+        CHECK(ifs.read((char *)&sz, 4));
+        std::string name;
+        auto ec = struct_pack::get_field_to<person, 1>(name, ifs);
+        CHECK(ec == struct_pack::errc{});
+        CHECK(name == p1.name);
+        CHECK(ifs.seekg(pos + sz));
+      }
+    }
+  }
+}
+
+TEST_CASE("test compatible obj") {
+  person p{.age = 24, .name = "Betty"};
+  person1 p1{.age = 24, .name = "Betty"};
+  person1 p2{.age = 24, .name = "Betty", .id = 114514};
+  person1 p3{.age = 24, .name = "Betty", .id = 114514, .maybe = true};
+  SUBCASE("forward") {
+    {
+      std::ofstream ofs("3.save", std::ofstream::binary | std::ofstream::out);
+      for (int i = 0; i < 100; ++i) {
+        struct_pack::serialize_to(ofs, p1);
+        struct_pack::serialize_to(ofs, p2);
+        struct_pack::serialize_to(ofs, p3);
+      }
+      auto total_size = (struct_pack::get_serialize_info(p1).size() +
+                         struct_pack::get_serialize_info(p2).size() +
+                         struct_pack::get_serialize_info(p3).size()) *
+                        100;
+      CHECK(ofs.tellp() == total_size);
+    }
+    {
+      std::ifstream ifs("3.save", std::ofstream::binary | std::ofstream::in);
+      for (int i = 0; i < 100; ++i) {
+        auto person1 = struct_pack::deserialize<person>(ifs);
+        CHECK(person1 == p);
+        auto person2 = struct_pack::deserialize<person>(ifs);
+        CHECK(person2 == p);
+        auto person3 = struct_pack::deserialize<person>(ifs);
+        CHECK(person3 == p);
+      }
+    }
+  }
+  SUBCASE("backward") {
+    {
+      std::ofstream ofs("4.save", std::ofstream::binary | std::ofstream::out);
+      for (int i = 0; i < 100; ++i) {
+        struct_pack::serialize_to(ofs, p);
+        struct_pack::serialize_to(ofs, p1);
+        struct_pack::serialize_to(ofs, p2);
+      }
+      auto total_size = (struct_pack::get_serialize_info(p).size() +
+                         struct_pack::get_serialize_info(p1).size() +
+                         struct_pack::get_serialize_info(p2).size()) *
+                        100;
+      CHECK(ofs.tellp() == total_size);
+    }
+    {
+      std::ifstream ifs("4.save", std::ofstream::binary | std::ofstream::in);
+      for (int i = 0; i < 100; ++i) {
+        auto res1 = struct_pack::deserialize<person1>(ifs);
+        CHECK(res1 == p1);
+        auto res2 = struct_pack::deserialize<person1>(ifs);
+        CHECK(res2 == p1);
+        auto res3 = struct_pack::deserialize<person1>(ifs);
+        CHECK(res3 == p2);
+      }
+    }
+    {
+      std::ifstream ifs("4.save", std::ofstream::binary | std::ofstream::in);
+      auto res = struct_pack::get_field<person1, 2>(ifs);
+      CHECK(res.has_value() == true);
+      CHECK(*res == std::nullopt);
+    }
+  }
+}

--- a/src/struct_pack/tests/test_stream.cpp
+++ b/src/struct_pack/tests/test_stream.cpp
@@ -34,8 +34,8 @@ TEST_CASE("test serialize_to/deserialize file") {
       struct_pack::serialize_to(ofs, p1);
       struct_pack::serialize_to(ofs, nested);
     }
-    auto total_size = (struct_pack::get_serialize_info(p1).size() +
-                       struct_pack::get_serialize_info(nested).size()) *
+    auto total_size = (struct_pack::get_needed_size(p1) +
+                       struct_pack::get_needed_size(nested)) *
                       100;
     CHECK(ofs.tellp() == total_size);
   }
@@ -104,8 +104,8 @@ TEST_CASE("test get_field file") {
       CHECK(ofs.seekp(npos));
     }
   }
-  auto total_size = (struct_pack::get_serialize_info(p[0]).size() +
-                     struct_pack::get_serialize_info(p[1]).size() + 8) *
+  auto total_size = (struct_pack::get_needed_size(p[0]) +
+                     struct_pack::get_needed_size(p[1]) + 8) *
                     100;
   CHECK(ofs.tellp() == total_size);
 
@@ -152,10 +152,10 @@ TEST_CASE("test compatible obj") {
         struct_pack::serialize_to(ofs, p2);
         struct_pack::serialize_to(ofs, p3);
       }
-      auto total_size = (struct_pack::get_serialize_info(p1).size() +
-                         struct_pack::get_serialize_info(p2).size() +
-                         struct_pack::get_serialize_info(p3).size()) *
-                        100;
+      auto total_size =
+          (struct_pack::get_needed_size(p1) + struct_pack::get_needed_size(p2) +
+           struct_pack::get_needed_size(p3)) *
+          100;
       CHECK(ofs.tellp() == total_size);
     }
     {
@@ -178,10 +178,10 @@ TEST_CASE("test compatible obj") {
         struct_pack::serialize_to(ofs, p1);
         struct_pack::serialize_to(ofs, p2);
       }
-      auto total_size = (struct_pack::get_serialize_info(p).size() +
-                         struct_pack::get_serialize_info(p1).size() +
-                         struct_pack::get_serialize_info(p2).size()) *
-                        100;
+      auto total_size =
+          (struct_pack::get_needed_size(p) + struct_pack::get_needed_size(p1) +
+           struct_pack::get_needed_size(p2)) *
+          100;
       CHECK(ofs.tellp() == total_size);
     }
     {

--- a/src/struct_pack/tests/test_struct.hpp
+++ b/src/struct_pack/tests/test_struct.hpp
@@ -29,6 +29,9 @@ struct person1 {
   std::string name;
   struct_pack::compatible<int32_t> id;
   struct_pack::compatible<bool> maybe;
+  auto operator==(const person1 &rhs) const {
+    return age == rhs.age && name == rhs.name && id == rhs.id && maybe == rhs.maybe;
+  }
 };
 
 struct empty {};

--- a/src/struct_pack/tests/test_struct.hpp
+++ b/src/struct_pack/tests/test_struct.hpp
@@ -30,7 +30,8 @@ struct person1 {
   struct_pack::compatible<int32_t> id;
   struct_pack::compatible<bool> maybe;
   auto operator==(const person1 &rhs) const {
-    return age == rhs.age && name == rhs.name && id == rhs.id && maybe == rhs.maybe;
+    return age == rhs.age && name == rhs.name && id == rhs.id &&
+           maybe == rhs.maybe;
   }
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

struct_pack should support serialize to stream(like file,socket,pipeline...)

Fix the #143 too.

## What is changing

Refactor the struct_pack. Now it can serialize/deserialize to stream.

struct_pack::writer_t is a concept: 

```cpp
template <typename T>
concept writer_t = requires(T t) {
  t.write((const char *){}, std::size_t{});
};
```

istream/sstream is a writer, and it's easy for user to write an wrapper code for socket,pipe……

struct_pack::reader_t is a concept: 

```cpp
template <typename T>
concept reader_t = requires(T t) {
  t.read((char *)nullptr, std::size_t{}); 
  t.ignore(std::size_t{});
  t.tellg();
};
```

ostream/sstream is a reader, and it's easy for user to write an wrapper code for socket,pipe……


struct_pack::get_needed_size now return a class struct_pack::serialize_buffer_size. This class is read-only and can be convert to std::size_t. Now we can sure the size of buffer in parameter is correct, so we don't need to check it when serialize.

## Example 1

```cpp
struct person {
  int age;
  std::string name;
};
person p{.age=24, .name="Betty"};

//write to file
std::ofstream writer("test.dat",std::ofstream::binary|std::ofstream::out);
struct_pack::serialize_to(writer, p);

//read from file
std::ifstream reader("test.dat",std::ifstream::binary|std::ifstream::in);
auto p2 = struct_pack::deserialize<person>(reader);

assert(p == p2);
```

## Example 2

```cpp
auto size = struct_pack::get_needed_size(person{});
auto buffer = struct_pack::make_unique<char[]>(size);
struct_pack::serialize_to(buffer.get(),size,p);
```
