### PR TITLE
[struct_pack] Improve compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ html
 CMakeUserPresets.json
 .DS_Store
 node_modules
-
+/CMakeSettings.json

--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -67,6 +67,9 @@ concept seek_reader_t = reader_t<T> && requires(T t) {
   t.seekg(std::size_t{});
 };
 
+template <typename T, uint64_t version = 0>
+struct compatible;
+
 // clang-format off
 namespace detail {
   template <typename Type>
@@ -223,6 +226,13 @@ namespace detail {
     optional.operator*();
     typename std::remove_cvref_t<Type>::value_type;
   };
+
+
+  template <typename Type>
+  constexpr inline bool is_compatible = false;
+
+  template <typename Type, uint64_t version>
+  constexpr inline bool is_compatible<compatible<Type,version>> = true;
 
   template <typename Type>
   constexpr inline bool is_variant_v = false;

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -1724,46 +1724,55 @@ class unpacker {
       T &t, Args &...args, std::index_sequence<I...>) {
     using Type = get_args_type<T, Args...>;
     struct_pack::errc err_code;
-    [[maybe_unused]] bool val =
-        ((
-             [&] {
-               switch (size_type_) {
-                 case 0:
-                   err_code =
-                       deserialize_many<1, compatible_version_number<Type>[I]>(
-                           t, args...);
-                   break;
-#ifdef STRUCT_PACK_OPTIMIZE
-                 case 1:
-                   err_code =
-                       deserialize_many<2, compatible_version_number<Type>[I]>(
-                           t, args...);
-                   break;
-                 case 2:
-                   err_code =
-                       deserialize_many<4, compatible_version_number<Type>[I]>(
-                           t, args...);
-                   break;
-                 case 3:
-                   err_code =
-                       deserialize_many<8, compatible_version_number<Type>[I]>(
-                           t, args...);
-                   break;
-#else
-                 case 1:
-                 case 2:
-                 case 3:
-                   err_code =
-                       deserialize_many<2, compatible_version_number<Type>[I]>(
-                           t, args...);
-                   break;
-#endif
-                 default:
-                   unreachable();
-               }
-             }(),
-             err_code == errc::ok) &&
+    switch (size_type_) {
+      case 0:
+        ([&] {
+          err_code = deserialize_many<1, compatible_version_number<Type>[I]>(
+              t, args...);
+          return err_code == errc::ok;
+        }() &&
          ...);
+        break;
+#ifdef STRUCT_PACK_OPTIMIZE
+      case 1:
+        ([&] {
+          err_code = deserialize_many<2, compatible_version_number<Type>[I]>(
+              t, args...);
+          return err_code == errc::ok;
+        }() &&
+         ...);
+        break;
+      case 2:
+        ([&] {
+          err_code = deserialize_many<4, compatible_version_number<Type>[I]>(
+              t, args...);
+          return err_code == errc::ok;
+        }() &&
+         ...);
+        break;
+      case 3:
+        ([&] {
+          err_code = deserialize_many<8, compatible_version_number<Type>[I]>(
+              t, args...);
+          return err_code == errc::ok;
+        }() &&
+         ...);
+        break;
+#else
+      case 1:
+      case 2:
+      case 3:
+        ([&] {
+          err_code = deserialize_many<2, compatible_version_number<Type>[I]>(
+              t, args...);
+          return err_code == errc::ok;
+        }() &&
+         ...);
+        break;
+#endif
+      default:
+        unreachable();
+    }
     if (size_type_ ==
         UCHAR_MAX) {  // reuse size_type_ as a tag that the buffer miss some
                       // compatible field, whic is legal.
@@ -1781,46 +1790,60 @@ class unpacker {
     using T = std::remove_cvref_t<U>;
     using Type = get_args_type<T>;
     struct_pack::errc err_code;
-    [[maybe_unused]] bool val =
-        ((
-             [&] {
-               switch (size_type_) {
-                 case 0:
-                   err_code =
-                       get_field_impl<1, compatible_version_number<Type>[Is], U,
-                                      I>(field);
-                   break;
-#ifdef STRUCT_PACK_OPTIMIZE
-                 case 1:
-                   err_code =
-                       get_field_impl<2, compatible_version_number<Type>[Is], U,
-                                      I>(field);
-                   break;
-                 case 2:
-                   err_code =
-                       get_field_impl<4, compatible_version_number<Type>[Is], U,
-                                      I>(field);
-                   break;
-                 case 3:
-                   err_code =
-                       get_field_impl<8, compatible_version_number<Type>[Is], U,
-                                      I>(field);
-                   break;
-#else
-                 case 1:
-                 case 2:
-                 case 3:
-                   err_code =
-                       get_field_impl<2, compatible_version_number<Type>[Is], U,
-                                      I>(field);
-                   break;
-#endif
-                 default:
-                   unreachable();
-               }
-             }(),
-             err_code == errc::ok) &&
+    switch (size_type_) {
+      case 0:
+        ([&] {
+          err_code =
+              get_field_impl<1, compatible_version_number<Type>[Is], U, I>(
+                  field);
+          return err_code == errc::ok;
+        }() &&
          ...);
+        break;
+#ifdef STRUCT_PACK_OPTIMIZE
+      case 1:
+        ([&] {
+          err_code =
+              get_field_impl<2, compatible_version_number<Type>[Is], U, I>(
+                  field);
+          return err_code == errc::ok;
+        }() &&
+         ...);
+        break;
+      case 2:
+        ([&] {
+          err_code =
+              get_field_impl<4, compatible_version_number<Type>[Is], U, I>(
+                  field);
+          return err_code == errc::ok;
+        }() &&
+         ...);
+        break;
+      case 3:
+        ([&] {
+          err_code =
+              get_field_impl<8, compatible_version_number<Type>[Is], U, I>(
+                  field);
+          return err_code == errc::ok;
+        }() &&
+         ...);
+        break;
+#else
+      case 1:
+      case 2:
+      case 3:
+        ([&] {
+          err_code =
+              get_field_impl<2, compatible_version_number<Type>[Is], U, I>(
+                  field);
+          return err_code == errc::ok;
+        }() &&
+         ...);
+        break;
+#endif
+      default:
+        unreachable();
+    }
     if (size_type_ ==
         UCHAR_MAX) {  // reuse size_type_ as a tag that the buffer miss some
                       // compatible field, whic is legal.

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -37,6 +37,7 @@
 
 #include "error_code.h"
 #include "md5_constexpr.hpp"
+#include "struct_pack/struct_pack.hpp"
 #include "tuple.hpp"
 #include "varint.hpp"
 
@@ -96,7 +97,8 @@ namespace struct_pack {
  *
  * @tparam T field type
  */
-template <typename T>
+
+template <typename T, uint64_t version>
 struct compatible : public std::optional<T> {
   constexpr compatible() = default;
   constexpr compatible(const compatible &other) = default;
@@ -109,11 +111,12 @@ struct compatible : public std::optional<T> {
   constexpr compatible &operator=(compatible &&other) = default;
   using base = std::optional<T>;
   using base::base;
-  friend bool operator==(const compatible<T> &self,
-                         const compatible<T> &other) {
+  friend bool operator==(const compatible<T, version> &self,
+                         const compatible<T, version> &other) {
     return static_cast<bool>(self) == static_cast<bool>(other) &&
            (!self || *self == *other);
   }
+  static constexpr uint64_t version_number = version;
 };
 
 using var_int32_t = detail::sint<int32_t>;
@@ -482,10 +485,7 @@ template <typename T>
 consteval type_id get_type_id() {
   static_assert(CHAR_BIT == 8);
   // compatible member, which should be ignored in MD5 calculated.
-  if constexpr (optional<T> && requires {
-                  requires std::is_same_v<
-                      struct_pack::compatible<typename T::value_type>, T>;
-                }) {
+  if constexpr (optional<T> && is_compatible<T>) {
     return type_id::compatible_t;
   }
   else if constexpr (std::is_enum_v<T>) {
@@ -798,80 +798,95 @@ consteval decltype(auto) get_types_literal(std::index_sequence<I...>) {
       T, std::remove_cvref_t<std::tuple_element_t<I, Tuple>>...>();
 }
 
-// the compatible<T> should in the end of the struct, and it shouldn't in the
-// nested struct.
-template <size_t depth, typename... Args>
-consteval int check_if_compatible_element_exist();
+template <uint64_t version, typename Args, typename... ParentArgs>
+constexpr bool check_if_compatible_element_exist_impl_helper();
 
 // This help function is just to improve unit test coverage. :)
 // Same as `get_type_literal_help_coverage`
-template <std::size_t depth, typename Args, std::size_t... I>
-consteval decltype(auto) check_if_compatible_element_exist_help_coverage(
+template <uint64_t version, typename Args, typename... ParentArgs,
+          std::size_t... I>
+constexpr bool check_if_compatible_element_exist_impl(
     std::index_sequence<I...>) {
-  return check_if_compatible_element_exist<
-      depth + 1, std::remove_cvref_t<std::tuple_element_t<I, Args>>...>();
+  return (check_if_compatible_element_exist_impl_helper<
+              version, std::remove_cvref_t<std::tuple_element_t<I, Args>>,
+              ParentArgs...>() ||
+          ...);
 }
 
-template <size_t depth, typename Arg>
-constexpr int check_if_compatible_element_exist_helper(bool &flag) {
-  constexpr auto id = get_type_id<Arg>();
+template <uint64_t version, typename Arg, typename... ParentArgs,
+          std::size_t... I>
+constexpr bool check_if_compatible_element_exist_impl_variant(
+    std::index_sequence<I...>) {
+  return (check_if_compatible_element_exist_impl_helper<
+              version, std::remove_cvref_t<std::variant_alternative_t<I, Arg>>,
+              ParentArgs...>() ||
+          ...);
+}
+
+template <uint64_t version, typename Arg, typename... ParentArgs>
+constexpr bool check_if_compatible_element_exist_impl_helper() {
+  using T = std::remove_cvref_t<Arg>;
+  constexpr auto id = get_type_id<T>();
   if constexpr (id == type_id::compatible_t) {
-    flag = false;
-    if (depth)
-      return -1;
-    return 1;
+    return T::version_number == version;
   }
   else {
-    if (!flag)
-      return -1;
     if constexpr (id == type_id::non_trivial_class_t ||
                   id == type_id::trivial_class_t) {
-      using subArgs = decltype(get_types(Arg{}));
-      return check_if_compatible_element_exist_help_coverage<depth, subArgs>(
+      using subArgs = decltype(get_types(T{}));
+      return check_if_compatible_element_exist_impl<version, subArgs, T,
+                                                    ParentArgs...>(
           std::make_index_sequence<std::tuple_size_v<subArgs>>());
     }
+    else if constexpr (id == type_id::optional_t) {
+      if constexpr (unique_ptr<T>) {
+        if constexpr (check_cycle<typename T::element_type, ParentArgs...>())
+          return false;
+        else
+          return check_if_compatible_element_exist_impl_helper<
+              version, typename T::element_type, T, ParentArgs...>();
+      }
+      else {
+        return check_if_compatible_element_exist_impl_helper<
+            version, typename T::value_type, T, ParentArgs...>();
+      }
+    }
+    else if constexpr (id == type_id::array_t) {
+      return check_if_compatible_element_exist_impl_helper<
+          version, std::remove_cvref_t<decltype(T{}[0])>, T, ParentArgs...>();
+    }
+    else if constexpr (id == type_id::map_container_t) {
+      return check_if_compatible_element_exist_impl_helper<
+                 version, typename T::key_type, T, ParentArgs...>() ||
+             check_if_compatible_element_exist_impl_helper<
+                 version, typename T::mapped_type, T, ParentArgs...>();
+    }
+    else if constexpr (id == type_id::set_container_t ||
+                       id == type_id::container_t) {
+      return check_if_compatible_element_exist_impl_helper<
+          version, typename T::value_type, T, ParentArgs...>();
+    }
+    else if constexpr (id == type_id::expected_t) {
+      return check_if_compatible_element_exist_impl_helper<
+                 version, typename T::value_type, T, ParentArgs...>() ||
+             check_if_compatible_element_exist_impl_helper<
+                 version, typename T::error_type, T, ParentArgs...>();
+    }
+    else if constexpr (id == type_id::variant_t) {
+      return check_if_compatible_element_exist_impl_variant<version, T, T,
+                                                            ParentArgs...>(
+          std::make_index_sequence<std::variant_size_v<T>>{});
+    }
     else {
-      return 0;
+      return false;
     }
   }
-}
-
-template <size_t depth, typename... Args>
-consteval int check_if_compatible_element_exist() {
-  bool flag = true;
-  int ret = 0;
-  (
-      [&]() {
-        auto tmp = check_if_compatible_element_exist_helper<depth, Args>(flag);
-        if (tmp == -1) {
-          ret = -1;
-        }
-        else if (tmp == 1 && ret != -1) {
-          ret = 1;
-        }
-        return ret;
-      }(),
-      ...);
-  return ret;
 }
 
 template <typename T, typename... Args>
 consteval uint32_t get_types_code_impl() {
   constexpr auto str = get_types_literal<T, std::remove_cvref_t<Args>...>();
   return MD5::MD5Hash32Constexpr(str.data(), str.size());
-}
-
-template <typename T, size_t... I>
-consteval int check_if_compatible_element_exist(std::index_sequence<I...>) {
-  constexpr auto ret =
-      check_if_compatible_element_exist<0, std::tuple_element_t<I, T>...>();
-  // ret == 0 -> unexist_compatible_element
-  // ret == 1 -> legal_compatible_element
-  // ret == -1 -> illegal_compatible_element
-  static_assert(
-      ret == 0 || ret == 1,
-      "The relative position of compatible<T> in struct is not allowed!");
-  return ret;
 }
 
 template <typename T, typename Tuple, size_t... I>
@@ -1013,22 +1028,237 @@ consteval uint32_t get_types_code() {
       std::make_index_sequence<std::tuple_size_v<Tuple>>{});
 }
 
-template <typename T>
-consteval int check_if_compatible_element_exist() {
+template <typename T, uint64_t version = 0>
+consteval bool check_if_compatible_element_exist() {
   using U = std::remove_cvref_t<T>;
-  return detail::check_if_compatible_element_exist<U>(
+  return detail::check_if_compatible_element_exist_impl<version, U>(
       std::make_index_sequence<std::tuple_size_v<U>>{});
 }
 
-template <typename T>
+template <typename T, uint64_t version = 0>
 concept exist_compatible_member = check_if_compatible_element_exist<
-    decltype(get_types(std::remove_cvref_t<T>{}))>()
-== 1;
+    decltype(get_types(std::remove_cvref_t<T>{})), version>();
+
+template <typename T, uint64_t version = 0>
+concept unexist_compatible_member =
+    !exist_compatible_member<decltype(get_types(std::remove_cvref_t<T>{})),
+                             version>;
+
+template <typename Args, typename... ParentArgs>
+constexpr std::size_t calculate_compatible_version_size();
+
+template <typename Args, typename... ParentArgs, std::size_t... I>
+constexpr std::size_t calculate_compatible_version_size(
+    std::index_sequence<I...>) {
+  return (
+      calculate_compatible_version_size<
+          std::remove_cvref_t<std::tuple_element_t<I, Args>>, ParentArgs...>() +
+      ...);
+}
+
+template <typename Arg, typename... ParentArgs, std::size_t... I>
+constexpr std::size_t calculate_variant_compatible_version_size(
+    std::index_sequence<I...>) {
+  return (calculate_compatible_version_size<
+              std::remove_cvref_t<std::variant_alternative_t<I, Arg>>,
+              ParentArgs...>() +
+          ...);
+}
+
+template <typename Arg, typename... ParentArgs>
+constexpr std::size_t calculate_compatible_version_size() {
+  using T = std::remove_cvref_t<Arg>;
+  constexpr auto id = get_type_id<T>();
+  std::size_t sz = 0;
+  if constexpr (id == type_id::compatible_t) {
+    sz = 1;
+  }
+  else {
+    if constexpr (id == type_id::non_trivial_class_t ||
+                  id == type_id::trivial_class_t) {
+      using subArgs = decltype(get_types(T{}));
+      return calculate_compatible_version_size<subArgs, T, ParentArgs...>(
+          std::make_index_sequence<std::tuple_size_v<subArgs>>());
+    }
+    else if constexpr (id == type_id::optional_t) {
+      if constexpr (unique_ptr<T>) {
+        if constexpr (check_cycle<typename T::element_type, ParentArgs...>())
+          sz = 0;
+        else
+          sz = calculate_compatible_version_size<typename T::element_type, T,
+                                                 ParentArgs...>();
+      }
+      else {
+        sz = calculate_compatible_version_size<typename T::value_type, T,
+                                               ParentArgs...>();
+      }
+    }
+    else if constexpr (id == type_id::array_t) {
+      return calculate_compatible_version_size<
+          std::remove_cvref_t<decltype(T{}[0])>, T, ParentArgs...>();
+    }
+    else if constexpr (id == type_id::map_container_t) {
+      return calculate_compatible_version_size<typename T::key_type, T,
+                                               ParentArgs...>() +
+             calculate_compatible_version_size<typename T::mapped_type, T,
+                                               ParentArgs...>();
+    }
+    else if constexpr (id == type_id::set_container_t ||
+                       id == type_id::container_t) {
+      return calculate_compatible_version_size<typename T::value_type, T,
+                                               ParentArgs...>();
+    }
+    else if constexpr (id == type_id::expected_t) {
+      return calculate_compatible_version_size<typename T::value_type, T,
+                                               ParentArgs...>() +
+             calculate_compatible_version_size<typename T::error_type, T,
+                                               ParentArgs...>();
+    }
+    else if constexpr (id == type_id::variant_t) {
+      return calculate_variant_compatible_version_size<T, T, ParentArgs...>(
+          std::make_index_sequence<std::variant_size_v<T>>{});
+    }
+  }
+  return sz;
+}
+
+template <typename Args, typename... ParentArgs>
+constexpr void get_compatible_version_numbers(auto &buffer, std::size_t &sz);
+
+template <typename Args, typename... ParentArgs, std::size_t... I>
+constexpr void get_compatible_version_numbers(auto &buffer, std::size_t &sz,
+                                              std::index_sequence<I...>) {
+  return (
+      get_compatible_version_numbers<
+          std::remove_cvref_t<std::tuple_element_t<I, Args>>, ParentArgs...>(
+          buffer, sz),
+      ...);
+}
+
+template <typename Arg, typename... ParentArgs, std::size_t... I>
+constexpr void get_variant_compatible_version_numbers(
+    auto &buffer, std::size_t &sz, std::index_sequence<I...>) {
+  return (get_compatible_version_numbers<
+              std::remove_cvref_t<std::variant_alternative_t<I, Arg>>,
+              ParentArgs...>(buffer, sz),
+          ...);
+}
+
+template <typename Arg, typename... ParentArgs>
+constexpr void get_compatible_version_numbers(auto &buffer, std::size_t &sz) {
+  using T = std::remove_cvref_t<Arg>;
+  constexpr auto id = get_type_id<T>();
+  if constexpr (id == type_id::compatible_t) {
+    buffer[sz++] = T::version_number;
+  }
+  else {
+    if constexpr (id == type_id::non_trivial_class_t ||
+                  id == type_id::trivial_class_t) {
+      using subArgs = decltype(get_types(T{}));
+      get_compatible_version_numbers<subArgs, T, ParentArgs...>(
+          buffer, sz, std::make_index_sequence<std::tuple_size_v<subArgs>>());
+    }
+    else if constexpr (id == type_id::optional_t) {
+      if constexpr (unique_ptr<T>) {
+        if constexpr (!check_cycle<typename T::element_type, ParentArgs...>())
+          get_compatible_version_numbers<typename T::element_type, T,
+                                         ParentArgs...>(buffer, sz);
+      }
+      else {
+        get_compatible_version_numbers<typename T::value_type, T,
+                                       ParentArgs...>(buffer, sz);
+      }
+    }
+    else if constexpr (id == type_id::array_t) {
+      get_compatible_version_numbers<std::remove_cvref_t<decltype(T{}[0])>, T,
+                                     ParentArgs...>(buffer, sz);
+    }
+    else if constexpr (id == type_id::map_container_t) {
+      get_compatible_version_numbers<typename T::key_type, T, ParentArgs...>(
+          buffer, sz);
+      get_compatible_version_numbers<typename T::mapped_type, T, ParentArgs...>(
+          buffer, sz);
+    }
+    else if constexpr (id == type_id::set_container_t ||
+                       id == type_id::container_t) {
+      get_compatible_version_numbers<typename T::value_type, T, ParentArgs...>(
+          buffer, sz);
+    }
+    else if constexpr (id == type_id::expected_t) {
+      get_compatible_version_numbers<typename T::value_type, T, ParentArgs...>(
+          buffer, sz);
+      get_compatible_version_numbers<typename T::error_type, T, ParentArgs...>(
+          buffer, sz);
+    }
+    else if constexpr (id == type_id::variant_t) {
+      get_variant_compatible_version_numbers<T, T, ParentArgs...>(
+          buffer, sz, std::make_index_sequence<std::variant_size_v<T>>{});
+    }
+  }
+}
+
+template <std::size_t sz>
+constexpr void STRUCT_PACK_INLINE
+compile_time_sort(std::array<uint64_t, sz> &array) {
+  // FIXME: use faster compile-time sort
+  for (std::size_t i = 0; i < array.size(); ++i) {
+    for (std::size_t j = i + 1; j < array.size(); ++j) {
+      if (array[i] > array[j]) {
+        auto tmp = array[i];
+        array[i] = array[j];
+        array[j] = tmp;
+      }
+    }
+  }
+  return;
+}
+
+template <std::size_t sz>
+constexpr std::size_t STRUCT_PACK_INLINE
+calculate_uniqued_size(const std::array<uint64_t, sz> &input) {
+  std::size_t unique_cnt = sz;
+  for (std::size_t i = 1; i < input.size(); ++i) {
+    if (input[i] == input[i - 1]) {
+      --unique_cnt;
+    }
+  }
+  return unique_cnt;
+}
+
+template <std::size_t sz1, std::size_t sz2>
+constexpr void STRUCT_PACK_INLINE compile_time_unique(
+    const std::array<uint64_t, sz1> &input, std::array<uint64_t, sz2> &output) {
+  std::size_t j = 0;
+  static_assert(sz1 != 0, "not allow empty input!");
+  output[0] = input[0];
+  for (std::size_t i = 1; i < input.size(); ++i) {
+    if (input[i] != input[i - 1]) {
+      output[++j] = input[i];
+    }
+  }
+}
 
 template <typename T>
-concept unexist_compatible_member = check_if_compatible_element_exist<
-    decltype(get_types(std::remove_cvref_t<T>{}))>()
-== 0;
+constexpr auto STRUCT_PACK_INLINE get_sorted_compatible_version_numbers() {
+  std::array<uint64_t, calculate_compatible_version_size<T>()> buffer;
+  std::size_t sz = 0;
+  get_compatible_version_numbers<T>(buffer, sz);
+  compile_time_sort(buffer);
+  return buffer;
+}
+
+template <typename T>
+constexpr auto STRUCT_PACK_INLINE
+get_sorted_and_uniqued_compatible_version_numbers() {
+  constexpr auto buffer = get_sorted_compatible_version_numbers<T>();
+  std::array<uint64_t, calculate_uniqued_size(buffer)> uniqued_buffer{};
+  compile_time_unique(buffer, uniqued_buffer);
+  return uniqued_buffer;
+}
+
+template <typename T>
+constexpr auto compatible_version_number =
+    get_sorted_and_uniqued_compatible_version_numbers<T>();
 
 template <typename T>
 struct serialize_static_config {
@@ -1100,7 +1330,8 @@ get_serialize_runtime_info(const Args &...args) {
     ret.len_ += type_literal.size() + 1;
     ret.metainfo_ |= 0b100;
   }
-  if constexpr (has_compatible) {  // calculate bytes count of serialize length
+  if constexpr (has_compatible) {  // calculate bytes count of serialize
+                                   // length
     if (ret.len_ + 2 < (1ull << 16)) [[likely]] {
       ret.len_ += 2;
       ret.metainfo_ |= 0b01;
@@ -1129,7 +1360,17 @@ class packer {
             typename... Args>
   STRUCT_PACK_INLINE void serialize(const T &t, const Args &...args) {
     serialize_metainfo<conf, size_type == 1, T, Args...>();
-    serialize_many<size_type>(t, args...);
+    serialize_many<size_type, SIZE_MAX>(t, args...);
+    using Type = get_args_type<T, Args...>;
+    if constexpr (serialize_static_config<Type>::has_compatible) {
+      constexpr std::size_t sz = compatible_version_number<Type>.size();
+      [&]<std::size_t... I>(std::index_sequence<I...>) {
+        (serialize_many<size_type, compatible_version_number<Type>[I]>(t,
+                                                                       args...),
+         ...);
+      }
+      (std::make_index_sequence<sz>{});
+    }
   }
 
  private:
@@ -1181,141 +1422,211 @@ class packer {
   }
 
  private:
-  template <std::size_t size_type>
+  template <std::size_t size_type, uint64_t version>
   constexpr void STRUCT_PACK_INLINE serialize_many(const auto &first_item,
                                                    const auto &...items) {
-    serialize_one<size_type>(first_item);
+    serialize_one<size_type, version>(first_item);
     if constexpr (sizeof...(items) > 0) {
-      serialize_many<size_type>(items...);
+      serialize_many<size_type, version>(items...);
     }
   }
 
-  template <std::size_t size_type>
+  template <std::size_t size_type, uint64_t version>
   constexpr void STRUCT_PACK_INLINE serialize_one(const auto &item) {
     using type = std::remove_cvref_t<decltype(item)>;
     static_assert(!std::is_pointer_v<type>);
-    if constexpr (std::is_same_v<type, std::monostate>) {
-    }
-    else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
-      writer_.write((char *)&item, sizeof(type));
-    }
-    else if constexpr (detail::varint_t<type>) {
-      detail::serialize_varint(writer_, item);
-    }
-    else if constexpr (c_array<type> || array<type>) {
-      if constexpr (is_trivial_serializable<type>::value) {
+    constexpr auto id = get_type_id<type>();
+    if constexpr (version == UINT64_MAX) {
+      if constexpr (id == type_id::compatible_t) {
+        // do nothing
+      }
+      else if constexpr (std::is_same_v<type, std::monostate>) {
+        // do nothing
+      }
+      else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
         writer_.write((char *)&item, sizeof(type));
       }
-      else {
-        for (const auto &i : item) {
-          serialize_one<size_type>(i);
+      else if constexpr (detail::varint_t<type>) {
+        detail::serialize_varint(writer_, item);
+      }
+      else if constexpr (c_array<type> || array<type>) {
+        if constexpr (is_trivial_serializable<type>::value) {
+          writer_.write((char *)&item, sizeof(type));
         }
-      }
-    }
-    else if constexpr (map_container<type> || container<type>) {
-      uint64_t size = item.size();
-#ifdef STRUCT_PACK_OPTIMIZE
-      writer_.write((char *)&size, size_type);
-#else
-      if constexpr (size_type == 1) {
-        writer_.write((char *)&size, size_type);
-      }
-      else {
-        switch ((info.metainfo() & 0b11000) >> 3) {
-          case 1:
-            writer_.write((char *)&size, 2);
-            break;
-          case 2:
-            writer_.write((char *)&size, 4);
-            break;
-          case 3:
-            writer_.write((char *)&size, 8);
-            break;
-          default:
-            unreachable();
-        }
-      }
-#endif
-      if constexpr (trivially_copyable_container<type>) {
-        using value_type = typename type::value_type;
-        auto container_size = 1ull * size * sizeof(value_type);
-        if (container_size >= PTRDIFF_MAX) [[unlikely]]
-          unreachable();
         else {
-          writer_.write((char *)item.data(), container_size);
+          for (const auto &i : item) {
+            serialize_one<size_type, version>(i);
+          }
         }
-        return;
+      }
+      else if constexpr (map_container<type> || container<type>) {
+        uint64_t size = item.size();
+#ifdef STRUCT_PACK_OPTIMIZE
+        writer_.write((char *)&size, size_type);
+#else
+        if constexpr (size_type == 1) {
+          writer_.write((char *)&size, size_type);
+        }
+        else {
+          switch ((info.metainfo() & 0b11000) >> 3) {
+            case 1:
+              writer_.write((char *)&size, 2);
+              break;
+            case 2:
+              writer_.write((char *)&size, 4);
+              break;
+            case 3:
+              writer_.write((char *)&size, 8);
+              break;
+            default:
+              unreachable();
+          }
+        }
+#endif
+        if constexpr (trivially_copyable_container<type>) {
+          using value_type = typename type::value_type;
+          auto container_size = 1ull * size * sizeof(value_type);
+          if (container_size >= PTRDIFF_MAX) [[unlikely]]
+            unreachable();
+          else {
+            writer_.write((char *)item.data(), container_size);
+          }
+          return;
+        }
+        else {
+          for (const auto &i : item) {
+            serialize_one<size_type, version>(i);
+          }
+        }
+      }
+      else if constexpr (container_adapter<type>) {
+        static_assert(!sizeof(type),
+                      "the container adapter type is not supported");
+      }
+      else if constexpr (!pair<type> && tuple<type> &&
+                         !is_trivial_tuple<type>) {
+        std::apply(
+            [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+              serialize_many<size_type, version>(items...);
+            },
+            item);
+      }
+      else if constexpr (optional<type>) {
+        bool has_value = item.has_value();
+        writer_.write((char *)&has_value, sizeof(bool));
+        if (has_value) {
+          serialize_one<size_type, version>(*item);
+        }
+      }
+      else if constexpr (variant<type>) {
+        static_assert(std::variant_size_v<type> < 256,
+                      "variant's size is too large");
+        uint8_t index = item.index();
+        writer_.write((char *)&index, sizeof(index));
+        std::visit(
+            [this](auto &&e) {
+              this->serialize_one<size_type, version>(e);
+            },
+            item);
+      }
+      else if constexpr (expected<type>) {
+        bool has_value = item.has_value();
+        writer_.write((char *)&has_value, sizeof(has_value));
+        if (has_value) {
+          if constexpr (!std::is_same_v<typename type::value_type, void>)
+            serialize_one<size_type, version>(item.value());
+        }
+        else {
+          serialize_one<size_type, version>(item.error());
+        }
+      }
+      else if constexpr (std::is_class_v<type>) {
+        if constexpr (!pair<type> && !is_trivial_tuple<type>)
+          static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
+        if constexpr (is_trivial_serializable<type>::value) {
+          writer_.write((char *)&item, sizeof(type));
+        }
+        else {
+          visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+            serialize_many<size_type, version>(items...);
+          });
+        }
       }
       else {
+        static_assert(!sizeof(type), "the type is not supported yet");
+      }
+    }
+    else if constexpr (exist_compatible_member<type, version>) {
+      if constexpr (id == type_id::compatible_t) {
+        if constexpr (version == type::version_number) {
+          bool has_value = item.has_value();
+          writer_.write((char *)&has_value, sizeof(bool));
+          if (has_value) {
+            serialize_one<size_type, UINT64_MAX>(*item);
+          }
+        }
+      }
+      else if constexpr (c_array<type> || array<type>) {
         for (const auto &i : item) {
-          serialize_one<size_type>(i);
+          serialize_one<size_type, version>(i);
         }
       }
-    }
-    else if constexpr (container_adapter<type>) {
-      static_assert(!sizeof(type),
-                    "the container adapter type is not supported");
-    }
-    else if constexpr (!pair<type> && tuple<type> && !is_trivial_tuple<type>) {
-      std::apply(
-          [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-            serialize_many<size_type>(items...);
-          },
-          item);
-    }
-    else if constexpr (optional<type>) {
-      bool has_value = item.has_value();
-      writer_.write((char *)&has_value, sizeof(bool));
-      if (has_value) {
-        serialize_one<size_type>(*item);
+      else if constexpr (map_container<type> || container<type>) {
+        for (const auto &i : item) {
+          serialize_one<size_type, version>(i);
+        }
       }
-    }
-    else if constexpr (variant<type>) {
-      static_assert(std::variant_size_v<type> < 256,
-                    "variant's size is too large");
-      uint8_t index = item.index();
-      writer_.write((char *)&index, sizeof(index));
-      std::visit(
-          [this](auto &&e) {
-            this->serialize_one<size_type>(e);
-          },
-          item);
-    }
-    else if constexpr (expected<type>) {
-      bool has_value = item.has_value();
-      writer_.write((char *)&has_value, sizeof(has_value));
-      if (has_value) {
-        if constexpr (!std::is_same_v<typename type::value_type, void>)
-          serialize_one<size_type>(item.value());
+      else if constexpr (!pair<type> && tuple<type> &&
+                         !is_trivial_tuple<type>) {
+        std::apply(
+            [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+              serialize_many<size_type, version>(items...);
+            },
+            item);
       }
-      else {
-        serialize_one<size_type>(item.error());
+      else if constexpr (optional<type>) {
+        if (item.has_value()) {
+          serialize_one<size_type, version>(*item);
+        }
       }
-    }
-    else if constexpr (std::is_class_v<type>) {
-      if constexpr (!pair<type> && !is_trivial_tuple<type>)
-        static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
-      if constexpr (is_trivial_serializable<type>::value) {
-        writer_.write((char *)&item, sizeof(type));
+      else if constexpr (variant<type>) {
+        std::visit(
+            [this](const auto &e) {
+              this->serialize_one<size_type, version>(e);
+            },
+            item);
       }
-      else {
+      else if constexpr (expected<type>) {
+        if (item.has_value()) {
+          if constexpr (!std::is_same_v<typename type::value_type, void>)
+            serialize_one<size_type, version>(item.value());
+        }
+        else {
+          serialize_one<size_type, version>(item.error());
+        }
+      }
+      else if constexpr (std::is_class_v<type>) {
         visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-          serialize_many<size_type>(items...);
+          serialize_many<size_type, version>(items...);
         });
       }
-    }
-    else {
-      static_assert(!sizeof(type), "the type is not supported yet");
     }
     return;
   }
 
-  template <std::size_t size_type, unique_ptr T>
+  template <std::size_t size_type, uint64_t version, unique_ptr T>
   constexpr void inline serialize_one(const T &item) {
-    bool has_value = (item != nullptr);
-    writer_.write((char *)&has_value, sizeof(char));
-    if (has_value) {
-      serialize_one<size_type>(*item);
+    if constexpr (version == UINT64_MAX) {
+      bool has_value = (item != nullptr);
+      writer_.write((char *)&has_value, sizeof(char));
+      if (has_value) {
+        serialize_one<size_type, version>(*item);
+      }
+    }
+    else if constexpr (exist_compatible_member<T, version>) {
+      if (item != nullptr) {
+        serialize_one<size_type, version>(*item);
+      }
     }
   }
 
@@ -1408,73 +1719,217 @@ class unpacker {
 
   STRUCT_PACK_INLINE unpacker(Reader &reader) : reader_(reader) {}
 
+  template <typename T, typename... Args, size_t... I>
+  STRUCT_PACK_INLINE struct_pack::errc deserialize_compatibles(
+      T &t, Args &...args, std::index_sequence<I...>) {
+    using Type = get_args_type<T, Args...>;
+    struct_pack::errc err_code;
+    [[maybe_unused]] bool val =
+        ((
+             [&] {
+               switch (size_type_) {
+                 case 0:
+                   err_code =
+                       deserialize_many<1, compatible_version_number<Type>[I]>(
+                           t, args...);
+                   break;
+#ifdef STRUCT_PACK_OPTIMIZE
+                 case 1:
+                   err_code =
+                       deserialize_many<2, compatible_version_number<Type>[I]>(
+                           t, args...);
+                   break;
+                 case 2:
+                   err_code =
+                       deserialize_many<4, compatible_version_number<Type>[I]>(
+                           t, args...);
+                   break;
+                 case 3:
+                   err_code =
+                       deserialize_many<8, compatible_version_number<Type>[I]>(
+                           t, args...);
+                   break;
+#else
+                 case 1:
+                 case 2:
+                 case 3:
+                   err_code =
+                       deserialize_many<2, compatible_version_number<Type>[I]>(
+                           t, args...);
+                   break;
+#endif
+                 default:
+                   unreachable();
+               }
+             }(),
+             err_code == errc::ok) &&
+         ...);
+    if (size_type_ ==
+        UCHAR_MAX) {  // reuse size_type_ as a tag that the buffer miss some
+                      // compatible field, whic is legal.
+      err_code = {};
+    }
+    return err_code;
+  }
+
+  template <typename U, size_t I, size_t... Is>
+  STRUCT_PACK_INLINE struct_pack::errc deserialize_compatible_fields(
+      std::tuple_element_t<
+          I, decltype(get_types(std::declval<std::remove_cvref_t<U>>()))>
+          &field,
+      std::index_sequence<Is...>) {
+    using T = std::remove_cvref_t<U>;
+    using Type = get_args_type<T>;
+    struct_pack::errc err_code;
+    [[maybe_unused]] bool val =
+        ((
+             [&] {
+               switch (size_type_) {
+                 case 0:
+                   err_code =
+                       get_field_impl<1, compatible_version_number<Type>[Is], U,
+                                      I>(field);
+                   break;
+#ifdef STRUCT_PACK_OPTIMIZE
+                 case 1:
+                   err_code =
+                       get_field_impl<2, compatible_version_number<Type>[Is], U,
+                                      I>(field);
+                   break;
+                 case 2:
+                   err_code =
+                       get_field_impl<4, compatible_version_number<Type>[Is], U,
+                                      I>(field);
+                   break;
+                 case 3:
+                   err_code =
+                       get_field_impl<8, compatible_version_number<Type>[Is], U,
+                                      I>(field);
+                   break;
+#else
+                 case 1:
+                 case 2:
+                 case 3:
+                   err_code =
+                       get_field_impl<2, compatible_version_number<Type>[Is], U,
+                                      I>(field);
+                   break;
+#endif
+                 default:
+                   unreachable();
+               }
+             }(),
+             err_code == errc::ok) &&
+         ...);
+    if (size_type_ ==
+        UCHAR_MAX) {  // reuse size_type_ as a tag that the buffer miss some
+                      // compatible field, whic is legal.
+      err_code = {};
+    }
+    return err_code;
+  }
+
   template <typename T, typename... Args>
   STRUCT_PACK_INLINE struct_pack::errc deserialize(T &t, Args &...args) {
-    struct_pack::errc err_code;
-    std::tie(err_code, data_len) =
-        deserialize_metainfo<get_args_type<T, Args...>>();
+    using Type = get_args_type<T, Args...>;
+    constexpr bool has_compatible =
+        check_if_compatible_element_exist<decltype(get_types(Type{}))>();
+    if constexpr (has_compatible) {
+      data_len = reader_.tellg();
+    }
+    auto &&[err_code, buffer_len] = deserialize_metainfo<Type>();
     if (err_code != struct_pack::errc{}) [[unlikely]] {
       return err_code;
     }
-    if constexpr (check_if_compatible_element_exist<decltype(get_types(
-                      get_args_type<T, Args...>{}))>()) {
-      data_len += reader_.tellg();
+    if constexpr (has_compatible) {
+      data_len += buffer_len;
     }
     switch (size_type_) {
       case 0:
-        return deserialize_many<1>(t, args...);
+        err_code = deserialize_many<1, UINT64_MAX>(t, args...);
+        break;
 #ifdef STRUCT_PACK_OPTIMIZE
       case 1:
-        return deserialize_many<2>(t, args...);
+        err_code = deserialize_many<2, UINT64_MAX>(t, args...);
+        break;
       case 2:
-        return deserialize_many<4>(t, args...);
+        err_code = deserialize_many<4, UINT64_MAX>(t, args...);
+        break;
       case 3:
-        return deserialize_many<8>(t, args...);
+        err_code = deserialize_many<8, UINT64_MAX>(t, args...);
+        break;
 #else
       case 1:
       case 2:
       case 3:
-        return deserialize_many<2>(t, args...);
+        err_code = deserialize_many<2, UINT64_MAX>(t, args...);
+        break;
 #endif
       default:
         unreachable();
     }
+    if constexpr (has_compatible) {
+      if (err_code != errc::ok) [[unlikely]] {
+        return err_code;
+      }
+      constexpr std::size_t sz = compatible_version_number<Type>.size();
+      err_code = deserialize_compatibles<T, Args...>(
+          t, args..., std::make_index_sequence<sz>{});
+    }
+    return err_code;
   }
 
   template <typename T, typename... Args>
   STRUCT_PACK_INLINE struct_pack::errc deserialize_with_len(std::size_t &len,
                                                             T &t,
                                                             Args &...args) {
-    struct_pack::errc err_code;
-    std::tie(err_code, data_len) =
-        deserialize_metainfo<get_args_type<T, Args...>>();
-    len = data_len;
+    using Type = get_args_type<T, Args...>;
+    constexpr bool has_compatible =
+        check_if_compatible_element_exist<decltype(get_types(Type{}))>();
+    if constexpr (has_compatible) {
+      data_len = reader_.tellg();
+    }
+    auto &&[err_code, buffer_len] = deserialize_metainfo<Type>();
+    len = buffer_len;
     if (err_code != struct_pack::errc{}) [[unlikely]] {
       return err_code;
     }
-    if constexpr (check_if_compatible_element_exist<decltype(get_types(
-                      get_args_type<T, Args...>{}))>()) {
-      data_len += reader_.tellg();
+    if constexpr (has_compatible) {
+      data_len += buffer_len;
     }
     switch (size_type_) {
       case 0:
-        return deserialize_many<1>(t, args...);
+        err_code = deserialize_many<1, UINT64_MAX>(t, args...);
+        break;
 #ifdef STRUCT_PACK_OPTIMIZE
       case 1:
-        return deserialize_many<2>(t, args...);
+        err_code = deserialize_many<2, UINT64_MAX>(t, args...);
+        break;
       case 2:
-        return deserialize_many<4>(t, args...);
+        err_code = deserialize_many<4, UINT64_MAX>(t, args...);
+        break;
       case 3:
-        return deserialize_many<8>(t, args...);
+        err_code = deserialize_many<8, UINT64_MAX>(t, args...);
+        break;
 #else
       case 1:
       case 2:
       case 3:
-        return deserialize_many<2>(t, args...);
+        err_code = deserialize_many<2, UINT64_MAX>(t, args...);
+        break;
 #endif
       default:
         unreachable();
     }
+    if constexpr (has_compatible) {
+      if (err_code != errc::ok) [[unlikely]] {
+        return err_code;
+      }
+      constexpr std::size_t sz = compatible_version_number<Type>.size();
+      err_code = deserialize_compatibles<T, Args...>(
+          t, args..., std::make_index_sequence<sz>{});
+    }
+    return err_code;
   }
 
   template <typename U, size_t I>
@@ -1483,50 +1938,70 @@ class unpacker {
           I, decltype(get_types(std::declval<std::remove_cvref_t<U>>()))>
           &field) {
     using T = std::remove_cvref_t<U>;
-    struct_pack::errc err_code;
-    std::tie(err_code, data_len) = deserialize_metainfo<T>();
+    using Type = get_args_type<T>;
+
+    constexpr bool has_compatible =
+        check_if_compatible_element_exist<decltype(get_types(Type{}))>();
+    if constexpr (has_compatible) {
+      data_len = reader_.tellg();
+    }
+
+    auto &&[err_code, buffer_len] = deserialize_metainfo<T>();
     if (err_code != struct_pack::errc{}) [[unlikely]] {
       return err_code;
     }
-    if constexpr (check_if_compatible_element_exist<decltype(get_types(
-                      get_args_type<T>{}))>()) {
-      data_len += reader_.tellg();
+    if constexpr (has_compatible) {
+      data_len += buffer_len;
     }
     switch (size_type_) {
       case 0:
-        return get_field_impl<1, U, I>(field);
+        err_code = get_field_impl<1, UINT64_MAX, U, I>(field);
+        break;
 #ifdef STRUCT_PACK_OPTIMIZE
       case 1:
-        return get_field_impl<2, U, I>(field);
+        err_code = get_field_impl<2, UINT64_MAX, U, I>(field);
+        break;
       case 2:
-        return get_field_impl<4, U, I>(field);
+        err_code = get_field_impl<4, UINT64_MAX, U, I>(field);
+        break;
       case 3:
-        return get_field_impl<8, U, I>(field);
+        err_code = get_field_impl<8, UINT64_MAX, U, I>(field);
+        break;
 #else
       case 1:
       case 2:
       case 3:
-        return get_field_impl<2, U, I>(field);
+        err_code = get_field_impl<2, UINT64_MAX, U, I>(field);
+        break;
 #endif
       default:
         unreachable();
     }
+    if constexpr (has_compatible) {
+      if (err_code != errc::ok) [[unlikely]] {
+        return err_code;
+      }
+      constexpr std::size_t sz = compatible_version_number<Type>.size();
+      err_code = deserialize_compatible_fields<U, I>(
+          field, std::make_index_sequence<sz>{});
+    }
+    return err_code;
   }
 
-  template <std::size_t size_type, typename U, size_t I>
+  template <std::size_t size_type, uint64_t version, typename U, size_t I>
   STRUCT_PACK_INLINE struct_pack::errc get_field_impl(
       std::tuple_element_t<
           I, decltype(get_types(std::declval<std::remove_cvref_t<U>>()))>
           &field) {
     using T = std::remove_cvref_t<U>;
 
-    static T t;
+    T t;
     struct_pack::errc err_code;
     if constexpr (tuple<T>) {
       err_code = std::apply(
           [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
             static_assert(I < sizeof...(items), "out of range");
-            return for_each<size_type, I>(field, items...);
+            return for_each<size_type, version, I>(field, items...);
           },
           t);
     }
@@ -1534,7 +2009,7 @@ class unpacker {
       static_assert(std::is_aggregate_v<T>);
       err_code = visit_members(t, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
         static_assert(I < sizeof...(items), "out of range");
-        return for_each<size_type, I>(field, items...);
+        return for_each<size_type, version, I>(field, items...);
       });
     }
     else {
@@ -1544,7 +2019,8 @@ class unpacker {
   }
 
  private:
-  template <size_t index, typename size_type, typename NotSkip>
+  template <size_t index, typename size_type, typename version,
+            typename NotSkip>
   struct variant_construct_helper {
     template <typename unpack, typename variant_t>
     static STRUCT_PACK_INLINE constexpr void run(unpack &unpacker,
@@ -1554,8 +2030,8 @@ class unpacker {
       }
       else {
         v = variant_t{std::in_place_index_t<index>{}};
-        unpacker.template deserialize_one<size_type::value, NotSkip::value>(
-            std::get<index>(v));
+        unpacker.template deserialize_one<size_type::value, version::value,
+                                          NotSkip::value>(std::get<index>(v));
       }
     }
   };
@@ -1636,47 +2112,34 @@ class unpacker {
     return ret;
   }
 
-  template <size_t size_type, bool NotSkip = true>
+  template <size_t size_type, uint64_t version, bool NotSkip = true>
   constexpr struct_pack::errc STRUCT_PACK_INLINE deserialize_many() {
     return {};
   }
-  template <size_t size_type, bool NotSkip = true>
+  template <size_t size_type, uint64_t version, bool NotSkip = true>
   constexpr struct_pack::errc STRUCT_PACK_INLINE
   deserialize_many(auto &&first_item, auto &&...items) {
-    if constexpr (get_type_id<std::remove_cvref_t<decltype(first_item)>>() ==
-                  type_id::compatible_t) {
-      if (reader_.tellg() >= data_len)
-        return struct_pack::errc{};
-    }
-    auto code = deserialize_one<size_type, NotSkip>(first_item);
+    auto code = deserialize_one<size_type, version, NotSkip>(first_item);
     if (code != struct_pack::errc{}) [[unlikely]] {
       return code;
     }
-    return deserialize_many<size_type, NotSkip>(items...);
+    return deserialize_many<size_type, version, NotSkip>(items...);
   }
 
-  template <size_t size_type, bool NotSkip>
+  template <size_t size_type, uint64_t version, bool NotSkip>
   constexpr struct_pack::errc STRUCT_PACK_INLINE deserialize_one(auto &item) {
     struct_pack::errc code{};
     using type = std::remove_cvref_t<decltype(item)>;
     static_assert(!std::is_pointer_v<type>);
-    if constexpr (std::is_same_v<type, std::monostate>) {
-    }
-    else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
-      if constexpr (NotSkip) {
-        if (!reader_.read((char *)&item, sizeof(type))) [[unlikely]] {
-          return struct_pack::errc::no_buffer_space;
-        }
+    constexpr auto id = get_type_id<type>();
+    if constexpr (version == UINT64_MAX) {
+      if constexpr (id == type_id::compatible_t) {
+        // do nothing
       }
-      else {
-        return reader_.ignore(sizeof(type)) ? errc{} : errc::no_buffer_space;
+      else if constexpr (std::is_same_v<type, std::monostate>) {
+        // do nothing
       }
-    }
-    else if constexpr (detail::varint_t<type>) {
-      code = detail::deserialize_varint<NotSkip>(reader_, item);
-    }
-    else if constexpr (array<type> || c_array<type>) {
-      if constexpr (is_trivial_serializable<type>::value) {
+      else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
         if constexpr (NotSkip) {
           if (!reader_.read((char *)&item, sizeof(type))) [[unlikely]] {
             return struct_pack::errc::no_buffer_space;
@@ -1686,239 +2149,378 @@ class unpacker {
           return reader_.ignore(sizeof(type)) ? errc{} : errc::no_buffer_space;
         }
       }
+      else if constexpr (detail::varint_t<type>) {
+        code = detail::deserialize_varint<NotSkip>(reader_, item);
+      }
+      else if constexpr (array<type> || c_array<type>) {
+        if constexpr (is_trivial_serializable<type>::value) {
+          if constexpr (NotSkip) {
+            if (!reader_.read((char *)&item, sizeof(type))) [[unlikely]] {
+              return struct_pack::errc::no_buffer_space;
+            }
+          }
+          else {
+            return reader_.ignore(sizeof(type)) ? errc{}
+                                                : errc::no_buffer_space;
+          }
+        }
+        else {
+          for (auto &i : item) {
+            code = deserialize_one<size_type, version, NotSkip>(i);
+            if (code != struct_pack::errc{}) [[unlikely]] {
+              return code;
+            }
+          }
+        }
+      }
+      else if constexpr (container<type>) {
+        size_t size = 0;
+#ifdef STRUCT_PACK_OPTIMIZE
+        if (!reader_.read((char *)&size, size_type)) [[unlikely]] {
+          return struct_pack::errc::no_buffer_space;
+        }
+#else
+        if constexpr (size_type == 1) {
+          if (!reader_.read((char *)&size, size_type)) [[unlikely]] {
+            return struct_pack::errc::no_buffer_space;
+          }
+        }
+        else {
+          switch (size_type_) {
+            case 1:
+              if (!reader_.read((char *)&size, 2)) [[unlikely]] {
+                return struct_pack::errc::no_buffer_space;
+              }
+              break;
+            case 2:
+              if (!reader_.read((char *)&size, 4)) [[unlikely]] {
+                return struct_pack::errc::no_buffer_space;
+              }
+              break;
+            case 3:
+              if (!reader_.read((char *)&size, 8)) [[unlikely]] {
+                return struct_pack::errc::no_buffer_space;
+              }
+              break;
+            default:
+              unreachable();
+          }
+        }
+#endif
+        if (size == 0) [[unlikely]] {
+          return {};
+        }
+        if constexpr (map_container<type> || set_container<type>) {
+          // value is the element of map/set container.
+          // if the type is set, then value is set::value_type;
+          // if the type is map, then value is pair<key_type,mapped_type>
+          decltype([]<typename T>(const T &) {
+            if constexpr (map_container<T>) {
+              return std::pair<typename T::key_type, typename T::mapped_type>{};
+            }
+            else {
+              return typename T::value_type{};
+            }
+          }(item)) value;
+          if constexpr (is_trivial_serializable<decltype(value)>::value &&
+                        !NotSkip) {
+            return reader_.ignore(size * sizeof(value)) ? errc{}
+                                                        : errc::no_buffer_space;
+          }
+          else {
+            for (size_t i = 0; i < size; ++i) {
+              code = deserialize_one<size_type, version, NotSkip>(value);
+              if (code != struct_pack::errc{}) [[unlikely]] {
+                return code;
+              }
+              if constexpr (NotSkip) {
+                item.emplace(std::move(value));
+                // TODO: mapped_type can deserialize without be moved
+              }
+            }
+          }
+        }
+        else {
+          using value_type = typename type::value_type;
+          if constexpr (trivially_copyable_container<type>) {
+            size_t mem_sz = size * sizeof(value_type);
+            if constexpr (NotSkip) {
+              if constexpr (string_view<type>) {
+                static_assert(
+                    view_reader_t<Reader>,
+                    "The Reader isn't a view_reader, can't deserialize "
+                    "a string_view");
+                const char *view = reader_.read_view(mem_sz);
+                if (view == nullptr) [[unlikely]] {
+                  return struct_pack::errc::no_buffer_space;
+                }
+                item = {(value_type *)view, size};
+              }
+              else {
+                if (mem_sz >= PTRDIFF_MAX) [[unlikely]]
+                  unreachable();
+                else {
+                  item.resize(size);
+                  if (!reader_.read((char *)item.data(), mem_sz)) [[unlikely]] {
+                    return struct_pack::errc::no_buffer_space;
+                  }
+                }
+              }
+            }
+            else {
+              return reader_.ignore(mem_sz) ? errc{} : errc::no_buffer_space;
+            }
+          }
+          else {
+            if constexpr (NotSkip) {
+              item.resize(size);
+              for (auto &i : item) {
+                code = deserialize_one<size_type, version, NotSkip>(i);
+                if (code != struct_pack::errc{}) [[unlikely]] {
+                  return code;
+                }
+              }
+            }
+            else {
+              value_type useless;
+              for (size_t i = 0; i < size; ++i) {
+                code = deserialize_one<size_type, version, NotSkip>(useless);
+                if (code != struct_pack::errc{}) [[unlikely]] {
+                  return code;
+                }
+              }
+            }
+          }
+        }
+      }
+      else if constexpr (container_adapter<type>) {
+        static_assert(!sizeof(type),
+                      "the container adapter type is not supported");
+      }
+      else if constexpr (!pair<type> && tuple<type> &&
+                         !is_trivial_tuple<type>) {
+        std::apply(
+            [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+              code = deserialize_many<size_type, version, NotSkip>(items...);
+            },
+            item);
+      }
+      else if constexpr (optional<type> || expected<type>) {
+        bool has_value;
+        if (!reader_.read((char *)&has_value, sizeof(bool))) [[unlikely]] {
+          return struct_pack::errc::no_buffer_space;
+        }
+        if (!has_value) [[unlikely]] {
+          if constexpr (expected<type>) {
+            item = typename type::unexpected_type{typename type::error_type{}};
+            deserialize_one<size_type, version, NotSkip>(item.error());
+          }
+          else {
+            return {};
+          }
+        }
+        else {
+          if constexpr (expected<type>) {
+            if constexpr (!std::is_same_v<typename type::value_type, void>)
+              deserialize_one<size_type, version, NotSkip>(item.value());
+          }
+          else {
+            item = type{std::in_place_t{}};
+            deserialize_one<size_type, version, NotSkip>(*item);
+          }
+        }
+      }
+      else if constexpr (variant<type>) {
+        uint8_t index;
+        if (!reader_.read((char *)&index, sizeof(index))) [[unlikely]] {
+          return struct_pack::errc::no_buffer_space;
+        }
+        if (index >= std::variant_size_v<type>) [[unlikely]] {
+          return struct_pack::errc::invalid_buffer;
+        }
+        else {
+          template_switch<variant_construct_helper,
+                          std::integral_constant<std::size_t, size_type>,
+                          std::integral_constant<std::size_t, version>,
+                          std::integral_constant<bool, NotSkip>>(index, *this,
+                                                                 item);
+        }
+      }
+      else if constexpr (std::is_class_v<type>) {
+        if constexpr (!pair<type> && !is_trivial_tuple<type>)
+          static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
+        if constexpr (is_trivial_serializable<type>::value) {
+          if constexpr (NotSkip) {
+            if (!reader_.read((char *)&item, sizeof(type))) [[unlikely]] {
+              return struct_pack::errc::no_buffer_space;
+            }
+          }
+          else {
+            return reader_.ignore(sizeof(type)) ? errc{}
+                                                : errc::no_buffer_space;
+          }
+        }
+        else {
+          visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+            code = deserialize_many<size_type, version, NotSkip>(items...);
+          });
+        }
+      }
       else {
+        static_assert(!sizeof(type), "the type is not supported yet");
+      }
+    }
+    else if constexpr (exist_compatible_member<type, version>) {
+      if constexpr (id == type_id::compatible_t) {
+        if constexpr (version == type::version_number) {
+          if (reader_.tellg() >= data_len) {
+            size_type_ = UCHAR_MAX;  // Just notice that this is not a real
+                                     // error, this is a flag for exit.
+            return struct_pack::errc::no_buffer_space;
+          }
+          bool has_value;
+          if (!reader_.read((char *)&has_value, sizeof(bool))) [[unlikely]] {
+            return struct_pack::errc::no_buffer_space;
+          }
+          if (!has_value) {
+            return code;
+          }
+          else {
+            item = type{std::in_place_t{}};
+            deserialize_one<size_type, UINT64_MAX, NotSkip>(*item);
+          }
+        }
+      }
+      else if constexpr (array<type> || c_array<type>) {
         for (auto &i : item) {
-          code = deserialize_one<size_type, NotSkip>(i);
+          code = deserialize_one<size_type, version, NotSkip>(i);
           if (code != struct_pack::errc{}) [[unlikely]] {
             return code;
           }
         }
       }
-    }
-    else if constexpr (container<type>) {
-      size_t size = 0;
-#ifdef STRUCT_PACK_OPTIMIZE
-      if (!reader_.read((char *)&size, size_type)) [[unlikely]] {
-        return struct_pack::errc::no_buffer_space;
-      }
-#else
-      if constexpr (size_type == 1) {
-        if (!reader_.read((char *)&size, size_type)) [[unlikely]] {
-          return struct_pack::errc::no_buffer_space;
+      else if constexpr (container<type>) {
+        if constexpr (id == type_id::set_container_t) {
+          // TODO: support it.
+          static_assert(!sizeof(type),
+                        "we don't support compatible field in set now.");
         }
-      }
-      else {
-        switch (size_type_) {
-          case 1:
-            if (!reader_.read((char *)&size, 2)) [[unlikely]] {
-              return struct_pack::errc::no_buffer_space;
-            }
-            break;
-          case 2:
-            if (!reader_.read((char *)&size, 4)) [[unlikely]] {
-              return struct_pack::errc::no_buffer_space;
-            }
-            break;
-          case 3:
-            if (!reader_.read((char *)&size, 8)) [[unlikely]] {
-              return struct_pack::errc::no_buffer_space;
-            }
-            break;
-          default:
-            unreachable();
-        }
-      }
-#endif
-      if (size == 0) [[unlikely]] {
-        return {};
-      }
-      if constexpr (map_container<type> || set_container<type>) {
-        // value is the element of map/set container.
-        // if the type is set, then value is set::value_type;
-        // if the type is map, then value is pair<key_type,mapped_type>
-        decltype([]<typename T>(const T &) {
-          if constexpr (map_container<T>) {
-            return std::pair<typename T::key_type, typename T::mapped_type>{};
-          }
-          else {
-            return typename T::value_type{};
-          }
-        }(item)) value;
-        if constexpr (is_trivial_serializable<decltype(value)>::value &&
-                      !NotSkip) {
-          return reader_.ignore(size * sizeof(value)) ? errc{}
-                                                      : errc::no_buffer_space;
-        }
-        else {
-          for (size_t i = 0; i < size; ++i) {
-            code = deserialize_one<size_type, NotSkip>(value);
-            if (code != struct_pack::errc{}) [[unlikely]] {
-              return code;
-            }
-            if constexpr (NotSkip) {
-              item.emplace(std::move(value));
-            }
-          }
-        }
-      }
-      else {
-        using value_type = typename type::value_type;
-        if constexpr (trivially_copyable_container<type>) {
-          size_t mem_sz = size * sizeof(value_type);
+        else if constexpr (id == type_id::map_container_t) {
+          static_assert(
+              !exist_compatible_member<typename type::key_type>,
+              "we don't support compatible field in map's key_type now.");
           if constexpr (NotSkip) {
-            if constexpr (string_view<type>) {
-              static_assert(view_reader_t<Reader>,
-                            "The Reader isn't a view_reader, can't deserialize "
-                            "a string_view");
-              const char *view = reader_.read_view(mem_sz);
-              if (view == nullptr) [[unlikely]] {
-                return struct_pack::errc::no_buffer_space;
-              }
-              item = {(value_type *)view, size};
-            }
-            else {
-              if (mem_sz >= PTRDIFF_MAX) [[unlikely]]
-                unreachable();
-              else {
-                item.resize(size);
-                if (!reader_.read((char *)item.data(), mem_sz)) [[unlikely]] {
-                  return struct_pack::errc::no_buffer_space;
-                }
+            for (auto &e : item) {
+              code = deserialize_one<size_type, version, NotSkip>(e.second);
+              if (code != struct_pack::errc{}) [[unlikely]] {
+                return code;
               }
             }
           }
           else {
-            return reader_.ignore(mem_sz) ? errc{} : errc::no_buffer_space;
+            // TODO: support it.
+            static_assert(
+                !sizeof(type),
+                "we don't support skip compatible field in container now.");
           }
+          // how to deserialize it quickly?
         }
         else {
+          using value_type = typename type::value_type;
           if constexpr (NotSkip) {
-            item.resize(size);
             for (auto &i : item) {
-              code = deserialize_one<size_type, NotSkip>(i);
+              code = deserialize_one<size_type, version, NotSkip>(i);
               if (code != struct_pack::errc{}) [[unlikely]] {
                 return code;
               }
             }
           }
           else {
-            value_type useless;
-            for (size_t i = 0; i < size; ++i) {
-              code = deserialize_one<size_type, NotSkip>(useless);
-              if (code != struct_pack::errc{}) [[unlikely]] {
-                return code;
-              }
-            }
+            // TODO: support it.
+            static_assert(
+                !sizeof(type),
+                "we don't support skip compatible field in container now.");
           }
         }
       }
-    }
-    else if constexpr (container_adapter<type>) {
-      static_assert(!sizeof(type),
-                    "the container adapter type is not supported");
-    }
-    else if constexpr (!pair<type> && tuple<type> && !is_trivial_tuple<type>) {
-      std::apply(
-          [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-            code = deserialize_many<size_type>(items...);
-          },
-          item);
-    }
-    else if constexpr (optional<type> || expected<type>) {
-      bool has_value;
-      if (!reader_.read((char *)&has_value, sizeof(bool))) [[unlikely]] {
-        return struct_pack::errc::no_buffer_space;
+      else if constexpr (!pair<type> && tuple<type> &&
+                         !is_trivial_tuple<type>) {
+        std::apply(
+            [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+              code = deserialize_many<size_type, version, NotSkip>(items...);
+            },
+            item);
       }
-      if (!has_value) [[unlikely]] {
-        if constexpr (expected<type>) {
-          typename type::error_type value;
-          deserialize_one<size_type, NotSkip>(value);
-          if constexpr (NotSkip) {
-            item = typename type::unexpected_type{std::move(value)};
+      else if constexpr (optional<type> || expected<type>) {
+        bool has_value = item.has_value();
+        if (!has_value) {
+          if constexpr (expected<type>) {
+            deserialize_one<size_type, version, NotSkip>(item.error());
           }
         }
         else {
-          return {};
-        }
-      }
-      else {
-        if constexpr (expected<type>) {
-          if constexpr (!std::is_same_v<typename type::value_type, void>)
-            deserialize_one<size_type, NotSkip>(item.value());
-        }
-        else {
-          item = type{std::in_place_t{}};
-          deserialize_one<size_type, NotSkip>(*item);
-        }
-      }
-    }
-    else if constexpr (variant<type>) {
-      uint8_t index;
-      if (!reader_.read((char *)&index, sizeof(index))) [[unlikely]] {
-        return struct_pack::errc::no_buffer_space;
-      }
-      if (index >= std::variant_size_v<type>) [[unlikely]] {
-        return struct_pack::errc::invalid_buffer;
-      }
-      else {
-        template_switch<variant_construct_helper,
-                        std::integral_constant<std::size_t, size_type>,
-                        std::integral_constant<bool, NotSkip>>(index, *this,
-                                                               item);
-      }
-    }
-    else if constexpr (std::is_class_v<type>) {
-      if constexpr (!pair<type> && !is_trivial_tuple<type>)
-        static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
-      if constexpr (is_trivial_serializable<type>::value) {
-        if constexpr (NotSkip) {
-          if (!reader_.read((char *)&item, sizeof(type))) [[unlikely]] {
-            return struct_pack::errc::no_buffer_space;
+          if constexpr (expected<type>) {
+            if constexpr (!std::is_same_v<typename type::value_type, void>)
+              deserialize_one<size_type, version, NotSkip>(item.value());
+          }
+          else {
+            deserialize_one<size_type, version, NotSkip>(item.value());
           }
         }
-        else {
-          return reader_.ignore(sizeof(type)) ? errc{} : errc::no_buffer_space;
-        }
       }
-      else {
+      else if constexpr (variant<type>) {
+        std::visit(
+            [this](auto &item) {
+              deserialize_one<size_type, version, NotSkip>(item);
+            },
+            item);
+      }
+      else if constexpr (std::is_class_v<type>) {
         visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
-          code = deserialize_many<size_type>(items...);
+          code = deserialize_many<size_type, version, NotSkip>(items...);
         });
       }
-    }
-    else {
-      static_assert(!sizeof(type), "the type is not supported yet");
     }
     return code;
   }
 
-  template <size_t size_type, bool NotSkip, unique_ptr T>
+  template <size_t size_type, uint64_t version, bool NotSkip, unique_ptr T>
   constexpr struct_pack::errc inline deserialize_one(T &item) {
-    bool has_value;
-    if (!reader_.read((char *)&has_value, sizeof(bool))) [[unlikely]] {
-      return struct_pack::errc::no_buffer_space;
+    if constexpr (version == UINT64_MAX) {
+      bool has_value;
+      if (!reader_.read((char *)&has_value, sizeof(bool))) [[unlikely]] {
+        return struct_pack::errc::no_buffer_space;
+      }
+      if (!has_value) {
+        return {};
+      }
+      item = std::make_unique<typename T::element_type>();
+      deserialize_one<size_type, version, NotSkip>(*item);
     }
-    if (!has_value) [[unlikely]] {
-      return {};
+    else if constexpr (exist_compatible_member<T, version>) {
+      if (item == nullptr) {
+        return {};
+      }
+      deserialize_one<size_type, version, NotSkip>(*item);
     }
-    item = std::make_unique<typename T::element_type>();
-    deserialize_one<size_type, NotSkip>(*item);
     return struct_pack::errc{};
   }
 
   // partial deserialize_to
-  template <size_t size_type, size_t I, size_t FieldIndex, typename FiledType,
-            typename T>
-  STRUCT_PACK_INLINE bool set_value(struct_pack::errc &err_code,
-                                    FiledType &field, T &&t) {
+  template <size_t size_type, uint64_t version, size_t I, size_t FieldIndex,
+            typename FieldType, typename T>
+  STRUCT_PACK_INLINE constexpr bool set_value(struct_pack::errc &err_code,
+                                              FieldType &field, T &&t) {
     if constexpr (FieldIndex == I) {
-      static_assert(std::is_same_v<std::remove_cvref_t<FiledType>,
+      static_assert(std::is_same_v<std::remove_cvref_t<FieldType>,
                                    std::remove_cvref_t<T>>);
-      err_code = deserialize_one<size_type, true>(field);
+      err_code = deserialize_one<size_type, version, true>(field);
       return /*don't skip=*/true;
     }
-    err_code = deserialize_one<size_type, false>(t);
-    return /*don't skip=*/false;
+    else {
+      err_code = deserialize_one<size_type, version, false>(t);
+      return /*skip=*/false;
+    }
   }
 
   template <int I, class... Ts>
@@ -1926,29 +2528,16 @@ class unpacker {
     return std::get<I>(std::forward_as_tuple(ts...));
   }
 
-  template <typename T>
-  STRUCT_PACK_INLINE constexpr bool
-  check_if_continue_deserialize_compatible_field() {
-    if constexpr (get_type_id<std::remove_cvref_t<T>>() !=
-                  type_id::compatible_t) {
-      return true;
-    }
-    else {
-      return reader_.tellg() < data_len;
-    }
-  }
-
-  template <size_t size_type, size_t FieldIndex, typename FieldType,
-            typename... Args>
+  template <size_t size_type, uint64_t version, size_t FieldIndex,
+            typename FieldType, typename... Args>
   STRUCT_PACK_INLINE constexpr decltype(auto) for_each(FieldType &field,
                                                        Args &&...items) {
     struct_pack::errc code{};
     [&]<std::size_t... I>(std::index_sequence<I...>) CONSTEXPR_INLINE_LAMBDA {
-      ((check_if_continue_deserialize_compatible_field<decltype(get_nth<I>(
-            items...))>() &&
-        !set_value<size_type, I, FieldIndex>(code, field,
-                                             get_nth<I>(items...))) &&
-       ...);
+      [[maybe_unused]] auto result =
+          (!set_value<size_type, version, I, FieldIndex>(
+               code, field, get_nth<I>(items...)) &&
+           ...);
     }
     (std::make_index_sequence<sizeof...(Args)>{});
     return code;

--- a/src/struct_pack/tests/CMakeLists.txt
+++ b/src/struct_pack/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(test_serialize
         test_pragma_pack_and_alignas_mix.cpp
         test_varint.cpp
         test_stream.cpp
+        test_compatible.cpp
         main.cpp
         )
 add_test(NAME test_serialize COMMAND test_serialize)

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -50,17 +50,9 @@ struct compatible5 {
   std::string b;
 };
 
-struct compatible6 {
-  std::string a;
-  struct_pack::expected<int, compatible5> comp;
-  std::string b;
-  compatible6(){};
-  compatible6(compatible6& other){};
-};
-
 struct compatible7 {
   std::string a;
-  std::set<compatible6> j;
+  std::set<compatible5> j;
   std::string b;
 };
 
@@ -106,8 +98,6 @@ TEST_CASE("test compatible check") {
   static_assert(struct_pack::detail::exist_compatible_member<compatible4>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible5>,
-                "check compatible failed");
-  static_assert(struct_pack::detail::exist_compatible_member<compatible6>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible7>,
                 "check compatible failed");

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -429,14 +429,17 @@ struct compatible_nested5 {
 
 TEST_CASE("test nested compatible5") {
   compatible_nested5_old obj_old = {
-      "Hello", unexpected<compatible_nested5_old::nested>{{"Hi", "Hey"}},
+      "Hello",
+      struct_pack::unexpected<compatible_nested5_old::nested>{{"Hi", "Hey"}},
       "HooooooooooHo"};
   compatible_nested5 obj = {
-      "Hello", unexpected<compatible_nested5::nested>{{"Hi", "42", "Hey"}},
+      "Hello",
+      struct_pack::unexpected<compatible_nested5::nested>{{"Hi", "42", "Hey"}},
       "HooooooooooHo"};
   compatible_nested5 obj_empty = {
       "Hello",
-      unexpected<compatible_nested5::nested>{{"Hi", std::nullopt, "Hey"}},
+      struct_pack::unexpected<compatible_nested5::nested>{
+          {"Hi", std::nullopt, "Hey"}},
       "HooooooooooHo"};
   SUBCASE("test compatible_nested5 to compatible_nested5") {
     auto buffer = struct_pack::serialize(obj);

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -81,7 +81,6 @@ struct compatible12 {
 };
 
 TEST_CASE("test compatible check") {
-  compatible8 hi;
   static_assert(!struct_pack::detail::exist_compatible_member<nested_object>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible1>,

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -49,7 +49,7 @@ struct compatible4 {
 
 struct compatible7 {
   std::string a;
-  std::set<compatible4> j;
+  compatible4 j;
   std::string b;
   friend bool operator<(const compatible7&, const compatible7&) {
     return false;
@@ -87,6 +87,7 @@ struct compatible12 {
 };
 
 TEST_CASE("test compatible check") {
+  compatible8 hi;
   static_assert(!struct_pack::detail::exist_compatible_member<nested_object>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible1>,

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -42,18 +42,18 @@ struct compatible4 {
   std::string a;
   std::optional<compatible3> comp;
   std::string b;
-};
-
-struct compatible5 {
-  std::string a;
-  struct_pack::expected<compatible4, int> comp;
-  std::string b;
+  friend bool operator<(const compatible4&, const compatible4&) {
+    return false;
+  }
 };
 
 struct compatible7 {
   std::string a;
-  std::set<compatible5> j;
+  std::set<compatible4> j;
   std::string b;
+  friend bool operator<(const compatible7&, const compatible7&) {
+    return false;
+  }
 };
 
 struct compatible8 {
@@ -96,8 +96,6 @@ TEST_CASE("test compatible check") {
   static_assert(struct_pack::detail::exist_compatible_member<compatible3>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible4>,
-                "check compatible failed");
-  static_assert(struct_pack::detail::exist_compatible_member<compatible5>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible7>,
                 "check compatible failed");

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -54,6 +54,8 @@ struct compatible6 {
   std::string a;
   struct_pack::expected<int, compatible5> comp;
   std::string b;
+  compatible6(){};
+  compatible6(compatible6& other){};
 };
 
 struct compatible7 {

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -7,7 +7,6 @@ using namespace struct_pack;
 
 struct compatible12;
 struct compatible1 {
-  std::unique_ptr<compatible12> s;
   struct_pack::compatible<int> c;
   friend bool operator<(const compatible1& self, const compatible1& other) {
     if (self.c.has_value()) {

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -56,15 +56,9 @@ struct compatible7 {
   }
 };
 
-struct compatible8 {
-  std::string a;
-  std::map<compatible7, int> j;
-  std::string b;
-};
-
 struct compatible9 {
   std::string a;
-  std::map<int, compatible8> j;
+  std::map<int, compatible7> j;
   std::string b;
 };
 
@@ -99,8 +93,6 @@ TEST_CASE("test compatible check") {
   static_assert(struct_pack::detail::exist_compatible_member<compatible4>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible7>,
-                "check compatible failed");
-  static_assert(struct_pack::detail::exist_compatible_member<compatible8>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible9>,
                 "check compatible failed");

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -47,24 +47,9 @@ struct compatible4 {
   }
 };
 
-struct compatible7 {
-  std::string a;
-  compatible4 j;
-  std::string b;
-  friend bool operator<(const compatible7&, const compatible7&) {
-    return false;
-  }
-};
-
-struct compatible9 {
-  std::string a;
-  std::map<int, compatible7> j;
-  std::string b;
-};
-
 struct compatible10 {
   std::string a;
-  std::vector<compatible9> j;
+  std::vector<compatible4> j;
   std::string b;
 };
 
@@ -90,10 +75,6 @@ TEST_CASE("test compatible check") {
   static_assert(struct_pack::detail::exist_compatible_member<compatible3>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible4>,
-                "check compatible failed");
-  static_assert(struct_pack::detail::exist_compatible_member<compatible7>,
-                "check compatible failed");
-  static_assert(struct_pack::detail::exist_compatible_member<compatible9>,
                 "check compatible failed");
   static_assert(struct_pack::detail::exist_compatible_member<compatible10>,
                 "check compatible failed");

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -1,0 +1,854 @@
+#include "doctest.h"
+#include "struct_pack/struct_pack.hpp"
+#include "struct_pack/struct_pack/struct_pack_impl.hpp"
+#include "test_struct.hpp"
+
+using namespace struct_pack;
+
+struct compatible12;
+struct compatible1 {
+  std::unique_ptr<compatible12> s;
+  struct_pack::compatible<int> c;
+  friend bool operator<(const compatible1& self, const compatible1& other) {
+    if (self.c.has_value()) {
+      if (other.c.has_value()) {
+        return self.c.value() < other.c.value();
+      }
+      else {
+        return false;
+      }
+    }
+    else if (other.c.has_value()) {
+      return true;
+    }
+    else
+      return false;
+  }
+};
+
+struct compatible2 {
+  std::string a;
+  compatible1 comp;
+  std::string b;
+};
+
+struct compatible3 {
+  std::string a;
+  std::tuple<int, double, compatible2, char> comp;
+  std::string b;
+};
+
+struct compatible4 {
+  std::string a;
+  std::optional<compatible3> comp;
+  std::string b;
+};
+
+struct compatible5 {
+  std::string a;
+  struct_pack::expected<compatible4, int> comp;
+  std::string b;
+};
+
+struct compatible6 {
+  std::string a;
+  struct_pack::expected<int, compatible5> comp;
+  std::string b;
+};
+
+struct compatible7 {
+  std::string a;
+  std::set<compatible6> j;
+  std::string b;
+};
+
+struct compatible8 {
+  std::string a;
+  std::map<compatible7, int> j;
+  std::string b;
+};
+
+struct compatible9 {
+  std::string a;
+  std::map<int, compatible8> j;
+  std::string b;
+};
+
+struct compatible10 {
+  std::string a;
+  std::vector<compatible9> j;
+  std::string b;
+};
+
+struct compatible11 {
+  std::string a;
+  std::variant<int, compatible10> j;
+  std::string b;
+};
+
+struct compatible12 {
+  std::string a;
+  std::unique_ptr<compatible10> j;
+  std::string b;
+};
+
+TEST_CASE("test compatible check") {
+  static_assert(!struct_pack::detail::exist_compatible_member<nested_object>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible1>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible2>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible3>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible4>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible5>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible6>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible7>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible8>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible9>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible10>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible11>,
+                "check compatible failed");
+  static_assert(struct_pack::detail::exist_compatible_member<compatible12>,
+                "check compatible failed");
+};
+
+TEST_CASE("test compatible") {
+  SUBCASE("serialize person1 2 person") {
+    person1 p1{20, "tom", 1, false};
+    std::vector<char> buffer;
+    auto size = get_needed_size(p1);
+    buffer.resize(size);
+    serialize_to(buffer.data(), size, p1);
+
+    person p;
+    auto res = deserialize_to(p, buffer.data(), buffer.size());
+    CHECK(res == struct_pack::errc{});
+    CHECK(p.name == p1.name);
+    CHECK(p.age == p1.age);
+
+    auto size2 = get_needed_size(p);
+    // short data
+    for (int i = 0, lim = size2; i < lim; ++i)
+      CHECK(deserialize_to(p, buffer.data(), i) ==
+            struct_pack::errc::no_buffer_space);
+
+    serialize_to(buffer.data(), size2, p);
+
+    person1 p2;
+    CHECK(deserialize_to(p2, buffer.data(), buffer.size()) ==
+          struct_pack::errc{});
+    CHECK((p2.age == p.age && p2.name == p.name));
+  }
+  SUBCASE("serialize person 2 person1") {
+    std::vector<char> buffer;
+    person p{20, "tom"};
+    struct_pack::serialize_to(buffer, p);
+    struct_pack::serialize_to(buffer, p);
+    struct_pack::serialize_to(buffer, p);
+
+    person1 p1, p0 = {.age = 20, .name = "tom"};
+    auto ec = struct_pack::deserialize_to(p1, buffer);
+    CHECK(ec == struct_pack::errc{});
+    CHECK(p1 == p0);
+  }
+  SUBCASE("big compatible metainfo") {
+    {
+#ifdef NDEBUG
+      constexpr size_t array_sz = 247;
+#else
+      constexpr size_t array_sz = 244;
+#endif
+      std::tuple<compatible<std::array<char, array_sz>>> big =
+          std::array<char, array_sz>{'A', 'E', 'I', 'O', 'U'};
+      auto sz = get_needed_size(big);
+      CHECK(sz == 255);
+      auto buffer = serialize(big);
+      CHECK(sz == buffer.size());
+      CHECK(buffer[0] % 2 == 1);
+      CHECK((buffer[4] & 0b11) == 1);
+      std::size_t r_sz = 0;
+      memcpy(&r_sz, &buffer[5], 2);
+      CHECK(r_sz == sz);
+      auto big2 =
+          deserialize<std::tuple<compatible<std::array<char, array_sz>>>>(
+              buffer);
+      CHECK(big2);
+      CHECK(std::get<0>(big2.value()).value() == std::get<0>(big).value());
+    }
+    {
+#ifdef NDEBUG
+      constexpr size_t array_sz = 248;
+#else
+      constexpr size_t array_sz = 245;
+#endif
+      std::tuple<compatible<std::array<char, array_sz>>> big =
+          std::array<char, array_sz>{'A', 'E', 'I', 'O', 'U'};
+      auto sz = get_needed_size(big);
+      CHECK(sz == 256);
+      auto buffer = serialize(big);
+      CHECK(sz == buffer.size());
+      CHECK(buffer[0] % 2 == 1);
+      CHECK((buffer[4] & 0b11) == 1);
+      std::size_t r_sz = 0;
+      memcpy(&r_sz, &buffer[5], 2);
+      CHECK(r_sz == sz);
+      auto big2 =
+          deserialize<std::tuple<compatible<std::array<char, array_sz>>>>(
+              buffer);
+      CHECK(big2);
+      CHECK(std::get<0>(big2.value()).value() == std::get<0>(big).value());
+    }
+    {
+#ifdef NDEBUG
+      constexpr size_t array_sz = 65525;
+#else
+      constexpr size_t array_sz = 65522;
+#endif
+      std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
+      std::get<0>(big).value().resize(array_sz);
+      auto sz = get_needed_size(big);
+      CHECK(sz == 65535);
+      auto buffer = serialize(big);
+      CHECK(sz == buffer.size());
+      CHECK(buffer[0] % 2 == 1);
+      CHECK((buffer[4] & 0b11) == 1);
+      std::size_t r_sz = 0;
+      memcpy(&r_sz, &buffer[5], 2);
+      CHECK(r_sz == sz);
+      auto big2 = deserialize<std::tuple<compatible<std::string>>>(buffer);
+      CHECK(big2);
+      CHECK(std::get<0>(big2.value()).value() == std::get<0>(big).value());
+    }
+    {
+#ifdef NDEBUG
+      constexpr size_t array_sz = 65526;
+#else
+      constexpr size_t array_sz = 65523;
+#endif
+      std::tuple<compatible<std::string>> big = {std::string{"Hello"}};
+      std::get<0>(big).value().resize(array_sz);
+      auto sz = get_needed_size(big);
+      CHECK(sz == 65538);
+      auto buffer = serialize(big);
+      CHECK(sz == buffer.size());
+      CHECK(buffer[0] % 2 == 1);
+      CHECK((buffer[4] & 0b11) == 2);
+      std::size_t r_sz = 0;
+      memcpy(&r_sz, &buffer[5], 4);
+      CHECK(r_sz == sz);
+      auto big2 = deserialize<std::tuple<compatible<std::string>>>(buffer);
+      CHECK(big2);
+      CHECK(std::get<0>(big2.value()).value() == std::get<0>(big).value());
+    }
+    // TODO: test 8byte-len compatible object
+  }
+}
+
+struct compatible_nested1_old {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  } b;
+  std::string c;
+  bool operator==(const compatible_nested1_old&) const = default;
+};
+
+struct compatible_nested1 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string> b;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  } b;
+  std::string c;
+  bool operator==(const compatible_nested1&) const = default;
+};
+
+TEST_CASE("test nested compatible1") {
+  compatible_nested1_old obj_old = {"Hello", {"Hi", "Hey"}, "HooooooooooHo"};
+  compatible_nested1 obj = {"Hello", {"Hi", "42", "Hey"}, "HooooooooooHo"};
+  compatible_nested1 obj_empty = {
+      "Hello", {"Hi", std::nullopt, "Hey"}, "HooooooooooHo"};
+  SUBCASE("test compatible_nested1 to compatible_nested1") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested1>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested1_old to compatible_nested1") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested1>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested1 to compatible_nested1_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested1_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+
+struct compatible_nested2_old {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::vector<nested> b;
+  std::string c;
+  bool operator==(const compatible_nested2_old&) const = default;
+};
+
+struct compatible_nested2 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string> b;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::vector<nested> b;
+  std::string c;
+  bool operator==(const compatible_nested2&) const = default;
+};
+
+TEST_CASE("test nested compatible2") {
+  compatible_nested2_old obj_old = {
+      "Hello", {{"Hi1", "Hey1"}, {"Hi2", "Hey2"}}, "HooooooooooHo"};
+  compatible_nested2 obj = {
+      "Hello", {{"Hi1", "42", "Hey1"}, {"Hi2", "43", "Hey2"}}, "HooooooooooHo"};
+  compatible_nested2 obj_empty = {
+      "Hello",
+      {{"Hi1", std::nullopt, "Hey1"}, {"Hi2", std::nullopt, "Hey2"}},
+      "HooooooooooHo"};
+  SUBCASE("test compatible_nested2 to compatible_nested2") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested2>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested2_old to compatible_nested2") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested2>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested2 to compatible_nested2_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested2_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+
+struct compatible_nested3_old {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::optional<nested> b;
+  std::string c;
+  bool operator==(const compatible_nested3_old&) const = default;
+};
+struct compatible_nested3 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string> b;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::optional<nested> b;
+  std::string c;
+  bool operator==(const compatible_nested3&) const = default;
+};
+
+TEST_CASE("test nested compatible3") {
+  compatible_nested3_old obj_old = {"Hello", {{"Hi", "Hey"}}, "HooooooooooHo"};
+  compatible_nested3 obj = {"Hello", {{"Hi", "42", "Hey"}}, "HooooooooooHo"};
+  compatible_nested3 obj_empty = {
+      "Hello", {{"Hi", std::nullopt, "Hey"}}, "HooooooooooHo"};
+  SUBCASE("test compatible_nested3 to compatible_nested3") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested3>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested3_old to compatible_nested3") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested3>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested3 to compatible_nested3_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested3_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+
+struct compatible_nested4_old {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  struct_pack::expected<nested, int> b;
+  std::string c;
+  bool operator==(const compatible_nested4_old&) const = default;
+};
+struct compatible_nested4 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string> b;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  struct_pack::expected<nested, int> b;
+  std::string c;
+  bool operator==(const compatible_nested4&) const = default;
+};
+
+TEST_CASE("test nested compatible4") {
+  compatible_nested4_old obj_old = {"Hello", {{"Hi", "Hey"}}, "HooooooooooHo"};
+  compatible_nested4 obj = {"Hello", {{"Hi", "42", "Hey"}}, "HooooooooooHo"};
+  compatible_nested4 obj_empty = {
+      "Hello", {{"Hi", std::nullopt, "Hey"}}, "HooooooooooHo"};
+  SUBCASE("test compatible_nested4 to compatible_nested4") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested4>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested4_old to compatible_nested4") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested4>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested4 to compatible_nested4_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested4_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+
+struct compatible_nested5_old {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  struct_pack::expected<int, nested> b;
+  std::string c;
+  bool operator==(const compatible_nested5_old&) const = default;
+};
+struct compatible_nested5 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string> b;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  struct_pack::expected<int, nested> b;
+  std::string c;
+  bool operator==(const compatible_nested5&) const = default;
+};
+
+TEST_CASE("test nested compatible5") {
+  compatible_nested5_old obj_old = {
+      "Hello", unexpected<compatible_nested5_old::nested>{{"Hi", "Hey"}},
+      "HooooooooooHo"};
+  compatible_nested5 obj = {
+      "Hello", unexpected<compatible_nested5::nested>{{"Hi", "42", "Hey"}},
+      "HooooooooooHo"};
+  compatible_nested5 obj_empty = {
+      "Hello",
+      unexpected<compatible_nested5::nested>{{"Hi", std::nullopt, "Hey"}},
+      "HooooooooooHo"};
+  SUBCASE("test compatible_nested5 to compatible_nested5") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested5>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested5_old to compatible_nested5") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested5>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested5 to compatible_nested5_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested5_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+
+struct compatible_nested6_old {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::variant<int, nested> b;
+  std::string c;
+  bool operator==(const compatible_nested6_old&) const = default;
+};
+struct compatible_nested6 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string> b;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::variant<int, nested> b;
+  std::string c;
+  bool operator==(const compatible_nested6&) const = default;
+};
+
+TEST_CASE("test nested compatible6") {
+  compatible_nested6_old obj_old = {
+      "Hello", compatible_nested6_old::nested{"Hi", "Hey"}, "HooooooooooHo"};
+  compatible_nested6 obj = {
+      "Hello", compatible_nested6::nested{"Hi", "42", "Hey"}, "HooooooooooHo"};
+  compatible_nested6 obj_empty = {
+      "Hello", compatible_nested6::nested{"Hi", std::nullopt, "Hey"},
+      "HooooooooooHo"};
+  SUBCASE("test compatible_nested6 to compatible_nested6") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested6>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested6_old to compatible_nested6") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested6>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested6 to compatible_nested6_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested6_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+
+struct compatible_nested7_old {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::unique_ptr<nested> b;
+  std::string c;
+  bool operator==(const compatible_nested7_old& other) const {
+    if (this->a == other.a && this->c == other.c) {
+      if (this->b != nullptr && other.b != nullptr) {
+        return *(this->b) == *(other.b);
+      }
+      else if (this->b == nullptr && other.b == nullptr) {
+        return true;
+      }
+      else {
+        return false;
+      }
+    }
+    else {
+      return false;
+    }
+  }
+};
+
+struct compatible_nested7 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string> b;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::unique_ptr<nested> b;
+  std::string c;
+  bool operator==(const compatible_nested7& other) const {
+    if (this->a == other.a && this->c == other.c) {
+      if (this->b != nullptr && other.b != nullptr) {
+        return *(this->b) == *(other.b);
+      }
+      else if (this->b == nullptr && other.b == nullptr) {
+        return true;
+      }
+      else {
+        return false;
+      }
+    }
+    else {
+      return false;
+    }
+  }
+};
+#include <iostream>
+TEST_CASE("test nested compatible7") {
+  compatible_nested7_old obj_old = {
+      "Hello",
+      std::make_unique<compatible_nested7_old::nested>(
+          compatible_nested7_old::nested{"Hi", "Hey"}),
+      "HooooooooooHo"};
+  compatible_nested7 obj = {"Hello",
+                            std::make_unique<compatible_nested7::nested>(
+                                compatible_nested7::nested{"Hi", "42", "Hey"}),
+                            "HooooooooooHo"};
+  compatible_nested7 obj_empty = {
+      "Hello",
+      std::make_unique<compatible_nested7::nested>(
+          compatible_nested7::nested{"Hi", std::nullopt, "Hey"}),
+      "HooooooooooHo"};
+  SUBCASE("test compatible_nested7 to compatible_nested7") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested7>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested7_old to compatible_nested7") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested7>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested7 to compatible_nested7_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested7_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+
+struct compatible_nested8_old {
+  std::string a;
+  std::tuple<std::string, std::string> b;
+  std::string c;
+  bool operator==(const compatible_nested8_old&) const = default;
+};
+
+struct compatible_nested8 {
+  std::string a;
+  std::tuple<std::string, struct_pack::compatible<std::string>, std::string> b;
+  std::string c;
+  bool operator==(const compatible_nested8&) const = default;
+};
+
+TEST_CASE("test nested compatible8") {
+  compatible_nested8_old obj_old = {"Hello", {"Hi", "Hey"}, "HooooooooooHo"};
+  compatible_nested8 obj = {"Hello", {"Hi", "42", "Hey"}, "HooooooooooHo"};
+  compatible_nested8 obj_empty = {
+      "Hello", {"Hi", std::nullopt, "Hey"}, "HooooooooooHo"};
+  SUBCASE("test compatible_nested8 to compatible_nested8") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested8>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested8_old to compatible_nested8") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested8>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested8 to compatible_nested8_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested8_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+// TODO: test set, map_key, map_value
+
+struct compatible_nested9_old {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::map<std::string, nested> b;
+  std::string c;
+  bool operator==(const compatible_nested9_old&) const = default;
+};
+
+struct compatible_nested9 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string> b;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::map<std::string, nested> b;
+  std::string c;
+  bool operator==(const compatible_nested9&) const = default;
+};
+
+TEST_CASE("test nested compatible9") {
+  compatible_nested9_old obj_old = {
+      "Hello", {{"1", {"Hi", "Ho"}}, {"2", {"Hi2", "Ho2"}}}, "HooooooooooHo"};
+  compatible_nested9 obj = {
+      "Hello",
+      {{"1", {"Hi", "Hey", "Ho"}}, {"2", {"Hi2", "Hey2", "Ho2"}}},
+      "HooooooooooHo"};
+  compatible_nested9 obj_empty = {
+      "Hello",
+      {{"1", {"Hi", std::nullopt, "Ho"}}, {"2", {"Hi2", std::nullopt, "Ho2"}}},
+      "HooooooooooHo"};
+  SUBCASE("test compatible_nested9 to compatible_nested9") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested9>(buffer);
+    CHECK(result == obj);
+  }
+  SUBCASE("test compatible_nested9_old to compatible_nested9") {
+    auto buffer = struct_pack::serialize(obj_old);
+    auto result = struct_pack::deserialize<compatible_nested9>(buffer);
+    CHECK(result == obj_empty);
+  }
+  SUBCASE("test compatible_nested9 to compatible_nested9_old") {
+    auto buffer = struct_pack::serialize(obj);
+    auto result = struct_pack::deserialize<compatible_nested9_old>(buffer);
+    CHECK(result == obj_old);
+  }
+}
+
+struct compatible_with_version_0 {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::map<std::string, nested> b;
+  std::string c;
+  bool operator==(const compatible_with_version_0&) const = default;
+};
+
+struct compatible_with_version_1 {
+  std::string a;
+  struct nested {
+    std::string a;
+    std::string c;
+    bool operator==(const nested&) const = default;
+  };
+  std::map<std::string, nested> b;
+  std::string c;
+  struct_pack::compatible<std::string> d;
+  struct_pack::compatible<std::string> e;
+  bool operator==(const compatible_with_version_1&) const = default;
+};
+
+struct compatible_with_version_20230110 {
+  std::string a;
+  struct nested {
+    std::string a;
+    struct_pack::compatible<std::string, 20230110> b;
+    std::string c;
+    struct_pack::compatible<std::string, 20230110> d;
+    bool operator==(const nested&) const = default;
+  };
+  std::map<std::string, nested> b;
+  std::string c;
+  struct_pack::compatible<std::string> d;
+  struct_pack::compatible<std::string> e;
+  bool operator==(const compatible_with_version_20230110&) const = default;
+};
+
+TEST_CASE("test compatible version number") {
+  static_assert(struct_pack::detail::compatible_version_number<
+                    compatible_with_version_20230110> ==
+                std::array<uint64_t, 2>{0, 20230110});
+}
+
+TEST_CASE("test compatible_with_version") {
+  compatible_with_version_0 obj_0 = {
+      "Hello", {{"1", {"Hi", "Ho"}}, {"2", {"Hi2", "Ho2"}}}, "HooooooooooHo"};
+  compatible_with_version_1 obj_1 = {
+      "Hello",
+      {{"1", {"Hi", "Ho"}}, {"2", {"Hi2", "Ho2"}}},
+      "HooooooooooHo",
+      "42",
+      "43"};
+  compatible_with_version_1 obj_1_empty = {
+      "Hello",
+      {{"1", {"Hi", "Ho"}}, {"2", {"Hi2", "Ho2"}}},
+      "HooooooooooHo",
+      std::nullopt,
+      std::nullopt};
+  compatible_with_version_20230110 obj_20230110 = {
+      "Hello",
+      {{"1", {"Hi", "11", "Ho", "12"}}, {"2", {"Hi2", "21", "Ho2", "22"}}},
+      "HooooooooooHo",
+      "42",
+      "43"};
+  compatible_with_version_20230110 obj_20230110_empty_1 = {
+      "Hello",
+      {{"1", {"Hi", std::nullopt, "Ho", std::nullopt}},
+       {"2", {"Hi2", std::nullopt, "Ho2", std::nullopt}}},
+      "HooooooooooHo",
+      "42",
+      "43"};
+  compatible_with_version_20230110 obj_20230110_empty_0 = {
+      "Hello",
+      {{"1", {"Hi", std::nullopt, "Ho", std::nullopt}},
+       {"2", {"Hi2", std::nullopt, "Ho2", std::nullopt}}},
+      "HooooooooooHo",
+      std::nullopt,
+      std::nullopt};
+  SUBCASE("test compatible_with_version_1 to compatible_with_version_1") {
+    auto buffer = struct_pack::serialize(obj_1);
+    auto result = struct_pack::deserialize<compatible_with_version_1>(buffer);
+    CHECK(result == obj_1);
+  }
+  SUBCASE(
+      "test compatible_with_version_20230110 to "
+      "compatible_with_version_20230110") {
+    auto buffer = struct_pack::serialize(obj_20230110);
+    auto result =
+        struct_pack::deserialize<compatible_with_version_20230110>(buffer);
+    CHECK(result == obj_20230110);
+  }
+  SUBCASE("test compatible_with_version_0 to compatible_with_version_1") {
+    auto buffer = struct_pack::serialize(obj_0);
+    auto result = struct_pack::deserialize<compatible_with_version_1>(buffer);
+    CHECK(result == obj_1_empty);
+  }
+  SUBCASE("test compatible_with_version_1 to compatible_with_version_0") {
+    auto buffer = struct_pack::serialize(obj_1);
+    auto result = struct_pack::deserialize<compatible_with_version_0>(buffer);
+    CHECK(result == obj_0);
+  }
+  SUBCASE(
+      "test compatible_with_version_0 to compatible_with_version_20230110") {
+    auto buffer = struct_pack::serialize(obj_0);
+    auto result =
+        struct_pack::deserialize<compatible_with_version_20230110>(buffer);
+    CHECK(result == obj_20230110_empty_0);
+  }
+  SUBCASE(
+      "test compatible_with_version_20230110 to compatible_with_version_0") {
+    auto buffer = struct_pack::serialize(obj_20230110);
+    auto result = struct_pack::deserialize<compatible_with_version_0>(buffer);
+    CHECK(result == obj_0);
+  }
+  SUBCASE(
+      "test compatible_with_version_20230110 to compatible_with_version_1") {
+    auto buffer = struct_pack::serialize(obj_20230110);
+    auto result = struct_pack::deserialize<compatible_with_version_1>(buffer);
+    CHECK(result == obj_1);
+  }
+  SUBCASE(
+      "test compatible_with_version_1 to compatible_with_version_20230110") {
+    auto buffer = struct_pack::serialize(obj_1);
+    auto result =
+        struct_pack::deserialize<compatible_with_version_20230110>(buffer);
+    CHECK(result == obj_20230110_empty_1);
+  }
+}

--- a/src/struct_pack/tests/test_compile_time_calculate.cpp
+++ b/src/struct_pack/tests/test_compile_time_calculate.cpp
@@ -1,13 +1,10 @@
+#include <memory>
+
 #include "doctest.h"
 #include "struct_pack/struct_pack.hpp"
 #include "test_struct.hpp"
 
 using namespace struct_pack;
-
-struct compatible_in_nested_class {
-  int a;
-  struct_pack::compatible<int> c;
-};
 
 struct bug_member_count_struct1 {
   int i;
@@ -21,6 +18,8 @@ struct bug_member_count_struct2 : bug_member_count_struct1 {};
 
 template <>
 constexpr std::size_t struct_pack::members_count<bug_member_count_struct2> = 3;
+
+
 
 TEST_CASE("test members_count") {
   {
@@ -37,24 +36,6 @@ TEST_CASE("test members_count") {
     auto ret = struct_pack::deserialize<t>(res.data(), res.size());
     CHECK(ret);
   }
-}
-
-TEST_CASE("compatible not in the end of struct") {
-  static_assert(
-      detail::check_if_compatible_element_exist<
-          0, int, struct_pack::compatible<short>, std::string>() == -1,
-      "compatible member not in the end is illegal!");
-  static_assert(detail::check_if_compatible_element_exist<
-                    0, int, compatible_in_nested_class>() == -1,
-                "compatible member in the nested class is illegal!");
-  static_assert(
-      detail::check_if_compatible_element_exist<0, compatible_in_nested_class,
-                                                double>() == -1,
-      "compatible member in the nested class is illegal!");
-  static_assert(
-      detail::check_if_compatible_element_exist<
-          0, double, std::tuple<int, double, compatible<std::string>>>() == -1,
-      "compatible member in the nested class is illegal!");
 }
 
 struct type_calculate_test_1 {

--- a/src/struct_pack/tests/test_compile_time_calculate.cpp
+++ b/src/struct_pack/tests/test_compile_time_calculate.cpp
@@ -19,8 +19,6 @@ struct bug_member_count_struct2 : bug_member_count_struct1 {};
 template <>
 constexpr std::size_t struct_pack::members_count<bug_member_count_struct2> = 3;
 
-
-
 TEST_CASE("test members_count") {
   {
     using t = bug_member_count_struct1;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Improve struct_pack::compatible

## What is changing

Relax the limit of compatible field. You can add it in any place of struct, even in nested struct or in the container.

Add the version number for `struct_pack::compatible`. The default version number is 1. 

## Example

```cpp
struct person_v0 {
  std::string name;
  uint64_t ID;
  struct course {
    std::string name;
  }
  std::vector<course> courses;
};
struct person_v1 {
  std::string name;
  uint64_t ID;
  struct course {
    std::string name;
  }
  std::vector<course> courses;
  struct_pack::compatible<uint32_t> age; //the default version number is 1.
};
struct person_v2 { //update at 2023/01/11
  std::string name;
  uint64_t ID;
   struct course {
    struct_pack::compatible<uint64_t, 20230111> ID;
    std::string name;
    struct_pack::compatible<double, 20230111> GPA;
  }
  std::vector<course> courses;
  struct_pack::compatible<uint32_t> age; //the default version number is 1.
};
struct person_v3 { //update at 2023/01/22
  std::string first_name;
  struct_pack::compatible<std::string, 20230122> last_name;
  uint64_t ID;
   struct course {
    struct_pack::compatible<uint64_t, 20230111> ID;
    std::string name;
    struct_pack::compatible<double, 20230111> GPA;
  }
  std::vector<course> courses;
  struct_pack::compatible<uint32_t> age; //the default version number is 1.
};
```

Each time you update your struct, you should use a greater version number in compatible field. 

struct_pack ensure the forward/backward compatibility for different struct. You can serialize any version of struct and deserialize  to any version of struct.

However, if the version number is not progressively increased, then the convert is undefined behavior.