### PR TITLE
fix cmake error in minimize ubuntu 20.04 and vcpkg ci pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(yaLanTingLibs
 
 include_directories(include)
 
+#the thread library of the system.
+find_package(Threads REQUIRED)
+
 include(cmake/utils.cmake)
 include(cmake/struct_pb.cmake)
 include(cmake/build.cmake)

--- a/cmake/dependency.cmake
+++ b/cmake/dependency.cmake
@@ -1,6 +1,3 @@
-#the thread library of the system.
-find_package(Threads REQUIRED)
-
 # 3rd-party package load
 option(USE_CONAN "Use conan package manager" OFF)
 if(USE_CONAN)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Possible solution for [#156](https://github.com/alibaba/yalantinglibs/issues/156)

Executing cmake compile command in vcpkg ci pipeline (or minimize ubuntu 20.04) gives error

move find_package(Threads REQUIRED) in cmake/dependency.cmake to project-root folder to avoid this error.

## What is changing

- move find_package(Threads REQUIRED) in cmake/dependency.cmake to project-root folder

## Example