### PR TITLE
[coro_rpc] fix client join itself

### DIFF
--- a/include/coro_rpc/coro_rpc/rpc_protocol.h
+++ b/include/coro_rpc/coro_rpc/rpc_protocol.h
@@ -93,8 +93,8 @@ using unexpect_t = tl::unexpect_t;
 constexpr auto REQ_HEAD_LEN = struct_pack::get_needed_size(req_header{});
 static_assert(REQ_HEAD_LEN == 16);
 
-constexpr auto RESP_HEADER_LEN = struct_pack::get_needed_size(resp_header{});
-static_assert(RESP_HEADER_LEN == 16);
+constexpr auto RESP_HEAD_LEN = struct_pack::get_needed_size(resp_header{});
+static_assert(RESP_HEAD_LEN == 16);
 
 constexpr int FUNCTION_ID_LEN = 4;
 

--- a/src/coro_rpc/examples/helloworld/client/main.cpp
+++ b/src/coro_rpc/examples/helloworld/client/main.cpp
@@ -24,7 +24,9 @@ using namespace std::string_literals;
  * \brief helloworld example client code
  */
 
-Lazy<void> show_rpc_call(coro_rpc_client &client) {
+Lazy<void> show_rpc_call() {
+  coro_rpc_client client;
+
   [[maybe_unused]] auto ec = co_await client.connect("127.0.0.1", "8801");
   assert(ec == err_ok);
   auto ret = co_await client.call<hello_world>();
@@ -65,8 +67,7 @@ Lazy<void> show_rpc_call(coro_rpc_client &client) {
 }
 
 int main() {
-  coro_rpc_client client;
-  syncAwait(show_rpc_call(client));
+  syncAwait(show_rpc_call());
 
   std::cout << "Done!" << std::endl;
   return 0;

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -550,7 +550,7 @@ std::errc init_acceptor(auto& acceptor_, auto port_) {
 //      REQUIRE(!ec2);
 //      std::array<std::byte, RPC_HEAD_LEN> head;
 //      read(socket, asio::buffer(head, RPC_HEAD_LEN));
-//      rpc_header header;
+//      req_header header;
 //      auto errc = struct_pack::deserialize_to(header, head);
 //      REQUIRE(errc == std::errc{});
 //      std::vector<std::byte> body_;
@@ -558,12 +558,12 @@ std::errc init_acceptor(auto& acceptor_, auto port_) {
 //      auto ret = read(socket, asio::buffer(body_.data(), header.length));
 //      REQUIRE(!ret.first);
 //      auto buf = struct_pack::serialize_with_offset(
-//          /*offset = */ RESP_HEADER_LEN, std::monostate{});
-//      *((uint32_t*)buf.data()) = buf.size() - RESP_HEADER_LEN;
-//      write(socket, asio::buffer(buf.data(), RESP_HEADER_LEN));
+//          /*offset = */ RESP_HEAD_LEN, std::monostate{});
+//      *((uint32_t*)buf.data()) = buf.size() - RESP_HEAD_LEN;
+//      write(socket, asio::buffer(buf.data(), RESP_HEAD_LEN));
 //      std::this_thread::sleep_for(50ms);
-//      write(socket, asio::buffer(buf.data() + RESP_HEADER_LEN,
-//                                 buf.size() - RESP_HEADER_LEN));
+//      write(socket, asio::buffer(buf.data() + RESP_HEAD_LEN,
+//                                 buf.size() - RESP_HEAD_LEN));
 //      p.set_value();
 //    });
 //    easylog::info("wait for server start");

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -330,16 +330,16 @@ TEST_CASE("test server write queue") {
     CHECK(err.second == buffer.size());
   }
   for (int i = 0; i < 10; ++i) {
-    std::byte resp_len_buf[RESP_HEADER_LEN];
+    std::byte resp_len_buf[RESP_HEAD_LEN];
     std::monostate r;
     auto buf = struct_pack::serialize<std::string>(r);
     std::string buffer_read;
     buffer_read.resize(buf.size());
-    read(socket, asio::buffer(resp_len_buf, RESP_HEADER_LEN));
+    read(socket, asio::buffer(resp_len_buf, RESP_HEAD_LEN));
 
     req_header header{};
     [[maybe_unused]] auto errc = struct_pack::deserialize_to(
-        header, (const char *)resp_len_buf, RESP_HEADER_LEN);
+        header, (const char *)resp_len_buf, RESP_HEAD_LEN);
     uint32_t body_len = header.length;
     CHECK(body_len == buf.size());
     read(socket, asio::buffer(buffer_read, body_len));

--- a/src/coro_rpc/tests/test_router.cpp
+++ b/src/coro_rpc/tests/test_router.cpp
@@ -139,7 +139,7 @@ template <auto func, typename... Args>
 void test_route_and_check(auto conn, Args &&...args) {
   auto pair = test_route<func>(conn, std::forward<Args>(args)...);
   using R = function_return_type_t<decltype(func)>;
-  check_result<R>(pair, RESP_HEADER_LEN);
+  check_result<R>(pair, RESP_HEAD_LEN);
 }
 }  // namespace test_util
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Don‘t create a thread to join client io thread when ~client() running in io thread, just detach itself.

## What is changing

## Example