### PR TITLE
remove remove_handler method

### DIFF
--- a/include/coro_rpc/coro_rpc/coro_rpc_server.hpp
+++ b/include/coro_rpc/coro_rpc/coro_rpc_server.hpp
@@ -312,13 +312,6 @@ class coro_rpc_server {
    * false.
    */
 
-  template <auto func>
-  bool remove_handler() {
-    return router_.template remove_handler<func>();
-  }
-
-  void clear_handlers() { router_.clear_handlers(); }
-
  private:
   std::errc listen() {
     ELOGV(INFO, "begin to listen");

--- a/include/coro_rpc/coro_rpc/router.hpp
+++ b/include/coro_rpc/coro_rpc/router.hpp
@@ -129,18 +129,6 @@ class router {
 
   template <auto first, auto... func>
   void regist_handler();
-
-  /*!
-   * Remove registered RPC function
-   * @tparam func the address of RPC function. e.g. `&foo::bar`, `foobar`
-   * @return true, if the function existed and removed success. otherwise,
-   * false.
-   */
-
-  template <auto func>
-  bool remove_handler();
-
-  void clear_handlers();
 };
 
 }  // namespace internal

--- a/include/coro_rpc/coro_rpc/router_impl.hpp
+++ b/include/coro_rpc/coro_rpc/router_impl.hpp
@@ -230,29 +230,6 @@ inline void router<rpc_protocol>::regist_one_handler() {
 }
 
 template <typename rpc_protocol>
-template <auto func>
-inline bool router<rpc_protocol>::remove_handler() {
-  constexpr auto name = get_func_name<func>();
-  constexpr auto id =
-      struct_pack::MD5::MD5Hash32Constexpr(name.data(), name.length());
-
-  id2name_.erase(id);
-
-  auto it = handlers_.find(id);
-  if (it != handlers_.end()) {
-    return handlers_.erase(id);
-  }
-  else {
-    auto coro_it = coro_handlers_.find(id);
-    if (coro_it != coro_handlers_.end()) {
-      return coro_handlers_.erase(id);
-    }
-
-    return false;
-  }
-}
-
-template <typename rpc_protocol>
 template <auto first, auto... func>
 inline void router<rpc_protocol>::regist_handler(
     class_type_t<decltype(first)> *self) {
@@ -265,13 +242,6 @@ template <auto first, auto... func>
 inline void router<rpc_protocol>::regist_handler() {
   regist_one_handler<first>();
   (regist_one_handler<func>(), ...);
-}
-
-template <typename rpc_protocol>
-inline void router<rpc_protocol>::clear_handlers() {
-  handlers_.clear();
-  coro_handlers_.clear();
-  id2name_.clear();
 }
 
 }  // namespace coro_rpc::internal

--- a/src/coro_rpc/tests/ServerTester.hpp
+++ b/src/coro_rpc/tests/ServerTester.hpp
@@ -107,7 +107,6 @@ struct ServerTester : TesterConfig {
     ELOGV(INFO, "run test: heartbeat=%d, ssl=%d", enable_heartbeat, use_ssl);
     register_all_function();
     test_all();
-    remove_all_rpc_function();
   }
   virtual void test_all() {
     test_connect_timeout();

--- a/src/coro_rpc/tests/rpc_api.hpp
+++ b/src/coro_rpc/tests/rpc_api.hpp
@@ -24,6 +24,7 @@ std::string hello_timeout();
 std::string client_hello();
 std::string client_hello_not_reg();
 std::string large_arg_fun(std::string data);
+void function_not_registered();
 int long_run_func(int val);
 std::string async_hi();
 void coro_fun_with_delay_return_void(

--- a/src/coro_rpc/tests/rpc_service.cpp
+++ b/src/coro_rpc/tests/rpc_service.cpp
@@ -30,6 +30,8 @@ std::string hello_timeout() {
   return "hello";
 }
 
+void function_not_registered() {}
+
 std::string client_hello() { return "client hello"; }
 
 std::string client_hello_not_reg() { return "client hello"; }

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -122,7 +122,6 @@ TEST_CASE("testing client") {
     };
     server.regist_handler<hello_timeout>();
     syncAwait(f());
-    server.remove_handler<hello_timeout>();
   }
 
   SUBCASE("call rpc success") {
@@ -137,7 +136,6 @@ TEST_CASE("testing client") {
     };
     server.regist_handler<hello>();
     syncAwait(f());
-    server.remove_handler<hello>();
   }
 
   SUBCASE("call with large buffer") {
@@ -152,7 +150,6 @@ TEST_CASE("testing client") {
     };
     server.regist_handler<large_arg_fun>();
     syncAwait(f());
-    server.remove_handler<large_arg_fun>();
   }
 
   server.stop();
@@ -211,8 +208,6 @@ TEST_CASE("testing client with inject server") {
     };
     syncAwait(f());
   }
-
-  server.remove_handler<hello>();
 
   server.stop();
   io_context.stop();
@@ -386,9 +381,6 @@ TEST_CASE("testing client with eof") {
   g_action = inject_action::client_close_socket_after_send_partial_header;
   ret = client.sync_call<hello>();
   REQUIRE_MESSAGE(ret.error().code == std::errc::io_error, ret.error().msg);
-
-  server.remove_handler<hello>();
-  server.remove_handler<client_hello>();
 }
 
 TEST_CASE("testing client with shutdown") {
@@ -414,8 +406,6 @@ TEST_CASE("testing client with shutdown") {
   REQUIRE_MESSAGE(ret.error().code == std::errc::io_error, ret.error().msg);
 
   g_action = {};
-  server.remove_handler<hello>();
-  server.remove_handler<client_hello>();
 }
 TEST_CASE("testing client timeout") {
   // SUBCASE("connect, 0ms timeout") {
@@ -508,9 +498,6 @@ TEST_CASE("testing client call timeout") {
     auto ret = client.call_for<hello_timeout>(10ms);
     auto val = syncAwait(ret);
     CHECK_MESSAGE(val.error().code == std::errc::timed_out, val.error().msg);
-
-    server.remove_handler<hello_timeout>();
-    server.remove_handler<hi>();
   }
   g_action = {};
 }
@@ -576,7 +563,6 @@ std::errc init_acceptor(auto& acceptor_, auto port_) {
 //    auto ret = client.call_for<hello>(50ms);
 //    auto val = syncAwait(ret);
 //    CHECK_MESSAGE(val.error().code == std::errc::timed_out, val.error().msg);
-//    remove_handler<hello>();
 //    thd.join();
 //    p.get_future().wait();
 //  }

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -118,37 +118,22 @@ struct CoroServerTester : ServerTester {
     server.regist_handler<get_coro_value>();
     server.regist_handler<&CoroServerTester::get_value>(this);
   }
-  void remove_all_rpc_function() override {
-    ELOGV(INFO, "run %s", __func__);
-    test_server_start_again();
-    ServerTester::remove_all_rpc_function();
-    server.remove_handler<coro_fun_with_delay_return_void>();
-    server.remove_handler<coro_fun_with_delay_return_void_twice>();
-    server.remove_handler<coro_fun_with_delay_return_void_cost_long_time>();
-    server.remove_handler<coro_fun_with_delay_return_string>();
-    server.remove_handler<coro_fun_with_delay_return_string_twice>();
-    server.remove_handler<coro_func>();
-    server.remove_handler<&HelloService::coro_func>();
-    server.remove_handler<get_coro_value>();
-    server.remove_handler<&CoroServerTester::get_value>();
-  }
 
   void test_function_not_registered() {
     g_action = {};
-    server.remove_handler<async_hi>();
     auto client = create_client();
     ELOGV(INFO, "run %s, client_id %d", __func__, client->get_client_id());
-    auto ret = call<async_hi>(client);
+    auto ret = call<function_not_registered>(client);
     REQUIRE_MESSAGE(
         ret.error().code == std::errc::function_not_supported,
         std::to_string(client->get_client_id()).append(ret.error().msg));
     REQUIRE(client->has_closed() == true);
-    ret = call<async_hi>(client);
+    ret = call<function_not_registered>(client);
     CHECK(client->has_closed() == true);
-    ret = call<async_hi>(client);
+    ret = call<function_not_registered>(client);
     REQUIRE_MESSAGE(ret.error().code == std::errc::io_error, ret.error().msg);
     CHECK(client->has_closed() == true);
-    server.regist_handler<async_hi>();
+    server.regist_handler<function_not_registered>();
   }
 
   void test_server_start_again() {
@@ -291,7 +276,6 @@ TEST_CASE("test server accept error") {
   ret = syncAwait(client.call<hi>());
   CHECK(!ret);
   REQUIRE(client.has_closed() == true);
-  server.remove_handler<hi>();
   g_action = {};
 }
 
@@ -299,7 +283,6 @@ TEST_CASE("test server write queue") {
   ELOGV(INFO, "run server write queue");
   g_action = {};
   coro_rpc_server server(2, 8810);
-  server.remove_handler<coro_fun_with_delay_return_void_cost_long_time>();
   server.regist_handler<coro_fun_with_delay_return_void_cost_long_time>();
   server.async_start().start([](auto &&) {
   });
@@ -357,7 +340,6 @@ TEST_CASE("test server write queue") {
   io_context.stop();
   thd.join();
   server.stop();
-  server.remove_handler<coro_fun_with_delay_return_void_cost_long_time>();
 }
 
 TEST_CASE("testing coro rpc write error") {
@@ -381,5 +363,4 @@ TEST_CASE("testing coro rpc write error") {
       std::to_string(client.get_client_id()).append(ret.error().msg));
   REQUIRE(client.has_closed() == true);
   g_action = inject_action::nothing;
-  server.remove_handler<hi>();
 }

--- a/src/coro_rpc/tests/test_register_handler.cpp
+++ b/src/coro_rpc/tests/test_register_handler.cpp
@@ -55,8 +55,6 @@ using namespace coro_rpc;
 //       CHECK(WEXITSTATUS(status) == 1);
 //     }
 //   }
-//   remove_handler<hi>();
-//   remove_handler<&HelloService::hello>();
 // }
 
 // TEST_CASE("register with nullptr") {


### PR DESCRIPTION
## Why

Don't need to remove_hander anymore, because the handlers are not global and in the server now.