### PR TITLE
[struct_pack] workaround for gcc 12.2

### DIFF
--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -142,8 +142,8 @@ STRUCT_PACK_INLINE consteval std::uint32_t get_type_code() {
   static_assert(sizeof...(Args) > 0);
   std::uint32_t ret;
   if constexpr (sizeof...(Args) == 1) {
-    ret = detail::get_types_code<Args..., decltype(detail::get_types(
-                                              std::declval<Args...>()))>();
+    ret = detail::get_types_code<Args...,
+                                 decltype(detail::get_types<Args...>())>();
   }
   else {
     ret = detail::get_types_code<std::tuple<std::remove_cvref_t<Args>...>,
@@ -157,7 +157,7 @@ template <typename... Args>
 STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal() {
   static_assert(sizeof...(Args) > 0);
   if constexpr (sizeof...(Args) == 1) {
-    using Types = decltype(detail::get_types(Args{}...));
+    using Types = decltype(detail::get_types<Args...>());
     return detail::get_types_literal<Args..., Types>(
         std::make_index_sequence<std::tuple_size_v<Types>>());
   }
@@ -412,8 +412,7 @@ template <typename T, typename... Args>
 template <typename T, size_t I, typename Field, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc get_field_to(Field &dst,
                                                                 const View &v) {
-  using T_Field =
-      std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
+  using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   static_assert(std::is_same_v<Field, T_Field>,
                 "The dst's type is not correct. It should be as same as the "
                 "T's Ith field's type");
@@ -426,8 +425,7 @@ template <typename T, size_t I, typename Field, detail::deserialize_view View>
 template <typename T, size_t I, typename Field>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc get_field_to(
     Field &dst, const char *data, size_t size) {
-  using T_Field =
-      std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
+  using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   static_assert(std::is_same_v<Field, T_Field>,
                 "The dst's type is not correct. It should be as same as the "
                 "T's Ith field's type");
@@ -439,8 +437,7 @@ template <typename T, size_t I, typename Field>
 template <typename T, size_t I, typename Field, struct_pack::reader_t Reader>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc get_field_to(
     Field &dst, Reader &reader) {
-  using T_Field =
-      std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
+  using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   static_assert(std::is_same_v<Field, T_Field>,
                 "The dst's type is not correct. It should be as same as the "
                 "T's Ith field's type");
@@ -450,8 +447,7 @@ template <typename T, size_t I, typename Field, struct_pack::reader_t Reader>
 
 template <typename T, size_t I, detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE auto get_field(const View &v) {
-  using T_Field =
-      std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
+  using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   expected<T_Field, struct_pack::errc> ret;
   if (auto ec = get_field_to<T, I>(ret.value(), v); ec != struct_pack::errc{})
       [[unlikely]] {
@@ -462,8 +458,7 @@ template <typename T, size_t I, detail::deserialize_view View>
 
 template <typename T, size_t I>
 [[nodiscard]] STRUCT_PACK_INLINE auto get_field(const char *data, size_t size) {
-  using T_Field =
-      std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
+  using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   expected<T_Field, struct_pack::errc> ret;
   if (auto ec = get_field_to<T, I>(ret.value(), data, size);
       ec != struct_pack::errc{}) [[unlikely]] {
@@ -474,8 +469,7 @@ template <typename T, size_t I>
 
 template <typename T, size_t I, struct_pack::reader_t Reader>
 [[nodiscard]] STRUCT_PACK_INLINE auto get_field(Reader &reader) {
-  using T_Field =
-      std::tuple_element_t<I, decltype(detail::get_types(std::declval<T>()))>;
+  using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   expected<T_Field, struct_pack::errc> ret;
   if (auto ec = get_field_to<T, I>(ret.value(), reader);
       ec != struct_pack::errc{}) [[unlikely]] {

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -180,8 +180,8 @@ constexpr inline bool is_trivial_tuple = false;
 template <typename... T>
 constexpr inline bool is_trivial_tuple<tuplet::tuple<T...>> = true;
 
-template <class U>
-constexpr auto get_types(U &&t) {
+template <typename U>
+constexpr auto get_types() {
   using T = std::remove_cvref_t<U>;
   if constexpr (std::is_fundamental_v<T> || std::is_enum_v<T> || varint_t<T> ||
                 std::is_same_v<std::string, T> || container<T> || optional<T> ||
@@ -201,7 +201,7 @@ constexpr auto get_types(U &&t) {
   else if constexpr (std::is_aggregate_v<T>) {
     // clang-format off
     return visit_members(
-        std::forward<U>(t), [&]<typename... Args>(Args &&
+        std::forward<U>(T{}), [&]<typename... Args>(Args &&
                                                   ...) CONSTEXPR_INLINE_LAMBDA {
           return std::tuple<std::remove_cvref_t<Args>...>{};
         });
@@ -247,7 +247,7 @@ struct is_trivial_serializable {
       (std::make_index_sequence<std::tuple_size_v<T>>{});
     }
     else if constexpr (std::is_class_v<T>) {
-      using T_ = decltype(get_types(T{}));
+      using T_ = decltype(get_types<T>());
       return []<std::size_t... I>(std::index_sequence<I...>)
           CONSTEXPR_INLINE_LAMBDA {
         return (is_trivial_serializable<std::tuple_element_t<I, T_>>::value &&
@@ -264,10 +264,11 @@ struct is_trivial_serializable {
 };
 
 template <typename Type>
-concept trivially_copyable_container = continuous_container<Type> &&
+concept trivially_copyable_container =
+    continuous_container<Type> &&
     requires(Type container) {
-  requires is_trivial_serializable<typename Type::value_type>::value;
-};
+      requires is_trivial_serializable<typename Type::value_type>::value;
+    };
 
 // clang-format off
 template <typename T>
@@ -653,7 +654,7 @@ consteval decltype(auto) get_type_literal() {
   constexpr auto ret = string_literal<char, 1>{{static_cast<char>(id)}};
   if constexpr (id == type_id::non_trivial_class_t ||
                 id == type_id::trivial_class_t) {
-    using Args = decltype(get_types(Arg{}));
+    using Args = decltype(get_types<Arg>());
     constexpr auto body = get_type_literal<Args, Arg, ParentArgs...>(
         std::make_index_sequence<std::tuple_size_v<Args>>());
     if constexpr (is_trivial_serializable<Arg>::value) {
@@ -833,7 +834,7 @@ constexpr bool check_if_compatible_element_exist_impl_helper() {
   else {
     if constexpr (id == type_id::non_trivial_class_t ||
                   id == type_id::trivial_class_t) {
-      using subArgs = decltype(get_types(T{}));
+      using subArgs = decltype(get_types<T>());
       return check_if_compatible_element_exist_impl<version, subArgs, T,
                                                     ParentArgs...>(
           std::make_index_sequence<std::tuple_size_v<subArgs>>());
@@ -1036,13 +1037,12 @@ consteval bool check_if_compatible_element_exist() {
 }
 
 template <typename T, uint64_t version = 0>
-concept exist_compatible_member = check_if_compatible_element_exist<
-    decltype(get_types(std::remove_cvref_t<T>{})), version>();
+concept exist_compatible_member =
+    check_if_compatible_element_exist<decltype(get_types<T>()), version>();
 
 template <typename T, uint64_t version = 0>
-concept unexist_compatible_member =
-    !exist_compatible_member<decltype(get_types(std::remove_cvref_t<T>{})),
-                             version>;
+concept unexist_compatible_member = !
+exist_compatible_member<decltype(get_types<T>()), version>;
 
 template <typename Args, typename... ParentArgs>
 constexpr std::size_t calculate_compatible_version_size();
@@ -1076,7 +1076,7 @@ constexpr std::size_t calculate_compatible_version_size() {
   else {
     if constexpr (id == type_id::non_trivial_class_t ||
                   id == type_id::trivial_class_t) {
-      using subArgs = decltype(get_types(T{}));
+      using subArgs = decltype(get_types<T>());
       return calculate_compatible_version_size<subArgs, T, ParentArgs...>(
           std::make_index_sequence<std::tuple_size_v<subArgs>>());
     }
@@ -1154,7 +1154,7 @@ constexpr void get_compatible_version_numbers(auto &buffer, std::size_t &sz) {
   else {
     if constexpr (id == type_id::non_trivial_class_t ||
                   id == type_id::trivial_class_t) {
-      using subArgs = decltype(get_types(T{}));
+      using subArgs = decltype(get_types<T>());
       get_compatible_version_numbers<subArgs, T, ParentArgs...>(
           buffer, sz, std::make_index_sequence<std::tuple_size_v<subArgs>>());
     }
@@ -1377,9 +1377,8 @@ class packer {
   template <typename T, typename... Args>
   static consteval uint32_t STRUCT_PACK_INLINE calculate_raw_hash() {
     if constexpr (sizeof...(Args) == 0) {
-      return get_types_code<
-          std::remove_cvref_t<T>,
-          std::remove_cvref_t<decltype(get_types(std::declval<T>()))>>();
+      return get_types_code<std::remove_cvref_t<T>,
+                            std::remove_cvref_t<decltype(get_types<T>())>>();
     }
     else {
       return get_types_code<
@@ -1783,9 +1782,7 @@ class unpacker {
 
   template <typename U, size_t I, size_t... Is>
   STRUCT_PACK_INLINE struct_pack::errc deserialize_compatible_fields(
-      std::tuple_element_t<
-          I, decltype(get_types(std::declval<std::remove_cvref_t<U>>()))>
-          &field,
+      std::tuple_element_t<I, decltype(get_types<U>())> &field,
       std::index_sequence<Is...>) {
     using T = std::remove_cvref_t<U>;
     using Type = get_args_type<T>;
@@ -1856,7 +1853,7 @@ class unpacker {
   STRUCT_PACK_INLINE struct_pack::errc deserialize(T &t, Args &...args) {
     using Type = get_args_type<T, Args...>;
     constexpr bool has_compatible =
-        check_if_compatible_element_exist<decltype(get_types(Type{}))>();
+        check_if_compatible_element_exist<decltype(get_types<Type>())>();
     if constexpr (has_compatible) {
       data_len_ = reader_.tellg();
     }
@@ -1908,7 +1905,7 @@ class unpacker {
                                                             Args &...args) {
     using Type = get_args_type<T, Args...>;
     constexpr bool has_compatible =
-        check_if_compatible_element_exist<decltype(get_types(Type{}))>();
+        check_if_compatible_element_exist<decltype(get_types<Type>())>();
     if constexpr (has_compatible) {
       data_len_ = reader_.tellg();
     }
@@ -1957,14 +1954,12 @@ class unpacker {
 
   template <typename U, size_t I>
   STRUCT_PACK_INLINE struct_pack::errc get_field(
-      std::tuple_element_t<
-          I, decltype(get_types(std::declval<std::remove_cvref_t<U>>()))>
-          &field) {
+      std::tuple_element_t<I, decltype(get_types<U>())> &field) {
     using T = std::remove_cvref_t<U>;
     using Type = get_args_type<T>;
 
     constexpr bool has_compatible =
-        check_if_compatible_element_exist<decltype(get_types(Type{}))>();
+        check_if_compatible_element_exist<decltype(get_types<Type>())>();
     if constexpr (has_compatible) {
       data_len_ = reader_.tellg();
     }
@@ -2013,9 +2008,7 @@ class unpacker {
 
   template <std::size_t size_type, uint64_t version, typename U, size_t I>
   STRUCT_PACK_INLINE struct_pack::errc get_field_impl(
-      std::tuple_element_t<
-          I, decltype(get_types(std::declval<std::remove_cvref_t<U>>()))>
-          &field) {
+      std::tuple_element_t<I, decltype(get_types<U>())> &field) {
     using T = std::remove_cvref_t<U>;
 
     T t;
@@ -2104,7 +2097,7 @@ class unpacker {
       return {struct_pack::errc::no_buffer_space, 0};
     }
     constexpr uint32_t types_code =
-        get_types_code<T, decltype(get_types(std::declval<T>()))>();
+        get_types_code<T, decltype(get_types<T>())>();
     if ((current_types_code / 2) != (types_code / 2)) [[unlikely]] {
       return {struct_pack::errc::invalid_buffer, 0};
     }

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -262,7 +262,7 @@ struct is_trivial_serializable {
  public:
   static inline constexpr bool value = is_trivial_serializable::solve();
 };
-
+// clang-format off
 template <typename Type>
 concept trivially_copyable_container =
     continuous_container<Type> &&
@@ -270,7 +270,6 @@ concept trivially_copyable_container =
       requires is_trivial_serializable<typename Type::value_type>::value;
     };
 
-// clang-format off
 template <typename T>
 concept struct_pack_byte = std::is_same_v<char, T>
                            || std::is_same_v<unsigned char, T>
@@ -1039,11 +1038,11 @@ consteval bool check_if_compatible_element_exist() {
 template <typename T, uint64_t version = 0>
 concept exist_compatible_member =
     check_if_compatible_element_exist<decltype(get_types<T>()), version>();
-
+// clang-format off
 template <typename T, uint64_t version = 0>
 concept unexist_compatible_member = !
 exist_compatible_member<decltype(get_types<T>()), version>;
-
+// clang-format on
 template <typename Args, typename... ParentArgs>
 constexpr std::size_t calculate_compatible_version_size();
 

--- a/src/struct_pack/tests/test_data_struct.cpp
+++ b/src/struct_pack/tests/test_data_struct.cpp
@@ -213,10 +213,10 @@ TEST_CASE("test_trivial_copy_tuple") {
   static_assert(std::is_same_v<decltype(tp), tuplet::tuple<int, int>>);
   static_assert(!std::is_same_v<decltype(tp), std::tuple<int, int>>);
 
-  static_assert(
-      std::is_same_v<decltype(detail::get_types(tp)), tuplet::tuple<int, int>>);
-  static_assert(
-      !std::is_same_v<decltype(detail::get_types(tp)), std::tuple<int, int>>);
+  static_assert(std::is_same_v<decltype(detail::get_types<decltype(tp)>()),
+                               tuplet::tuple<int, int>>);
+  static_assert(!std::is_same_v<decltype(detail::get_types<decltype(tp)>()),
+                                std::tuple<int, int>>);
   static_assert(get_type_code<decltype(tp)>() !=
                 get_type_code<std::tuple<int, int>>());
   [[maybe_unused]] constexpr auto i = get_type_literal<decltype(tp)>();

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -548,25 +548,23 @@ TEST_CASE("test get type code") {
   }
 
   SUBCASE("test get_types") {
-    person p;
-    nested_object nested;
     using namespace struct_pack::detail;
-    auto t = get_types(p);
+    auto t = get_types<person>();
     static_assert(std::is_same_v<std::tuple<int, std::string>, decltype(t)>);
 
-    auto t1 = get_types(std::tuple<int, std::string>{});
+    auto t1 = get_types<std::tuple<int, std::string>>();
     static_assert(std::is_same_v<std::tuple<int, std::string>, decltype(t1)>);
 
-    auto t2 = get_types(int(1));
+    auto t2 = get_types<int>();
     static_assert(std::is_same_v<std::tuple<int>, decltype(t2)>);
 
-    auto t3 = get_types(std::vector<int>{});
+    auto t3 = get_types<std::vector<int>>();
     static_assert(std::is_same_v<std::tuple<std::vector<int>>, decltype(t3)>);
 
-    static_assert(
-        std::is_same_v<decltype(get_types(p)), std::tuple<int, std::string>>);
+    static_assert(std::is_same_v<decltype(get_types<person>()),
+                                 std::tuple<int, std::string>>);
     static_assert(std::is_same_v<
-                  decltype(get_types(nested)),
+                  decltype(get_types<nested_object>()),
                   std::tuple<int, std::string, person, complicated_object>>);
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The gcc 12.2.0 in Ubuntu 20.10 crash when compile test_serialize. See #209 

## What is changing

We make a workaround for struct_pack::detail::get_types to avoid gcc crash.

There is no interface changed.

## Example