### PR TITLE
[coro_rpc] fix register_handler

### DIFF
--- a/include/coro_rpc/coro_rpc/coro_rpc_server.hpp
+++ b/include/coro_rpc/coro_rpc/coro_rpc_server.hpp
@@ -262,8 +262,8 @@ class coro_rpc_server {
    */
 
   template <auto first, auto... functions>
-  void regist_handler(class_type_t<decltype(first)> *self) {
-    router_.template regist_handler<first, functions...>(self);
+  void register_handler(class_type_t<decltype(first)> *self) {
+    router_.template register_handler<first, functions...>(self);
   }
 
   /*!
@@ -291,8 +291,8 @@ class coro_rpc_server {
    */
 
   template <auto... functions>
-  void regist_handler() {
-    router_.template regist_handler<functions...>();
+  void register_handler() {
+    router_.template register_handler<functions...>();
   }
 
   /*!

--- a/include/coro_rpc/coro_rpc/router.hpp
+++ b/include/coro_rpc/coro_rpc/router.hpp
@@ -322,7 +322,7 @@ class router {
    */
 
   template <auto first, auto... func>
-  void regist_handler(class_type_t<decltype(first)> *self) {
+  void register_handler(class_type_t<decltype(first)> *self) {
     regist_one_handler<first>(self);
     (regist_one_handler<func>(self), ...);
   }
@@ -352,7 +352,7 @@ class router {
    */
 
   template <auto first, auto... func>
-  void regist_handler() {
+  void register_handler() {
     regist_one_handler<first>();
     (regist_one_handler<func>(), ...);
   }

--- a/src/coro_rpc/benchmark/server.hpp
+++ b/src/coro_rpc/benchmark/server.hpp
@@ -21,12 +21,12 @@
 
 inline int start_server(coro_rpc::coro_rpc_server<>& server) {
   using namespace coro_rpc;
-  server.regist_handler<
+  server.register_handler<
       echo_4B, echo_100B, echo_500B, echo_1KB, echo_5KB, echo_10KB, async_io,
       block_io, heavy_calculate, long_tail_async_io, long_tail_block_io,
       long_tail_heavy_calculate, array_1K_int, array_1K_str_4B, array_1K_rect,
       monsterFunc, ValidateRequestFunc, download_10KB>();
-  server.regist_handler<
+  server.register_handler<
       many_argument<int, int, int, int, int, int, int, int, int, int, double,
                     double, double, double, double, double>>();
   std::cout << "hardware_concurrency=" << std::thread::hardware_concurrency()

--- a/src/coro_rpc/doc/coro_rpc_doc.hpp
+++ b/src/coro_rpc/doc/coro_rpc_doc.hpp
@@ -38,7 +38,7 @@ namespace coro_rpc {
  *
  * int main(){
  *   coro_rpc_server server(std::thread::hardware_concurrency(), 9000);
- *   server.regist_handler<hello_coro_rpc>();
+ *   server.register_handler<hello_coro_rpc>();
  *   server.start();
  * }
  * ```
@@ -110,11 +110,11 @@ class coro_rpc_server {
    * int main() {
    *   coro_rpc_server server;
    *
-   *   server.regist_handler<hello>(); //一次注册一个RPC函数
-   *   server.regist_handler<get_str, add>(); //一次注册多个RPC函数
+   *   server.register_handler<hello>(); //一次注册一个RPC函数
+   *   server.register_handler<get_str, add>(); //一次注册多个RPC函数
    *
    *   test_class obj{};
-   *   server.regist_handler<&test_class::plus_one,
+   *   server.register_handler<&test_class::plus_one,
    * &test_class::get_str>(&obj);//注册成员函数
    * }
    * ```
@@ -123,7 +123,7 @@ class coro_rpc_server {
    * @tparam func
    */
   template <auto first, auto... func>
-  void regist_handler();
+  void register_handler();
 
   /*!
    * \ingroup coro_rpc
@@ -136,7 +136,7 @@ class coro_rpc_server {
    * @param self 成员函数对应的对象指针
    */
   template <auto first, auto... func>
-  void regist_handler(class_type_t<decltype(first)> *self);
+  void register_handler(class_type_t<decltype(first)> *self);
 };
 
 /*!

--- a/src/coro_rpc/doc/coro_rpc_introduction_cn.md
+++ b/src/coro_rpc/doc/coro_rpc_introduction_cn.md
@@ -48,7 +48,7 @@ int main() {
   // 初始化服务器
   coro_rpc_server server(/*thread_num =*/10, /*port =*/9000);
 
-  server.regist_handler<echo>(); // 注册rpc函数
+  server.register_handler<echo>(); // 注册rpc函数
 
   server.start(); // 启动server并阻塞等待
 }
@@ -124,10 +124,10 @@ int main() {
 
   coro_rpc_server server(/*thread_num =*/10, /*port =*/9000);
 
-  server.regist_handler<hello, get_value, get_person>();//注册任意参数类型的普通函数
+  server.register_handler<hello, get_value, get_person>();//注册任意参数类型的普通函数
 
   dummy d{};
-  server.regist_handler<&dummy::echo>(&d); //注册成员函数
+  server.register_handler<&dummy::echo>(&d); //注册成员函数
 
   server.start(); // 启动server
 }
@@ -331,7 +331,7 @@ std::string hello() { return "hello coro_rpc"; }
 
 int main() {
   coro_rpc_server server(/*thread_num =*/10, /*port =*/9000);
-  server.regist_handler<hello>();
+  server.register_handler<hello>();
 
   server.start();
 }
@@ -345,7 +345,7 @@ std::string hello() { return "hello coro_rpc"; }
 
 int main() {
   async_rpc_server server(/*thread_num =*/10, /*port =*/9000);
-  server.regist_handler<hello>();
+  server.register_handler<hello>();
   server.start();
 }
 ```

--- a/src/coro_rpc/doc/coro_rpc_introduction_en.md
+++ b/src/coro_rpc/doc/coro_rpc_introduction_en.md
@@ -41,7 +41,7 @@ inline std::string echo(std::string str) { return str; }
 
 int main() {
   coro_rpc_server server(/*thread_num =*/10, /*port =*/9000);
-  server.regist_handler<echo>(); // register rpc function
+  server.register_handler<echo>(); // register rpc function
   server.start(); // start the server and blocking wait
 }
 ```
@@ -112,10 +112,10 @@ And in server, we define the following:
 int main() {
   coro_rpc_server server(/*thread_num =*/10, /*port =*/9000);
 
-  server.regist_handler<hello, get_value, get_person>();//register the RPC functions of any signature 
+  server.register_handler<hello, get_value, get_person>();//register the RPC functions of any signature 
 
   dummy d{};
-  server.regist_handler<&dummy::echo>(&d); //register the member functions
+  server.register_handler<&dummy::echo>(&d); //register the member functions
 
   server.start(); // start the server
 }
@@ -318,7 +318,7 @@ std::string hello() { return "hello coro_rpc"; }
 
 int main() {
   coro_rpc_server server(/*thread_num =*/10, /*port =*/9000);
-  server.regist_handler<hello>();
+  server.register_handler<hello>();
   server.start();
 }
 ```
@@ -331,7 +331,7 @@ std::string hello() { return "hello coro_rpc"; }
 
 int main() {
   async_rpc_server server(/*thread_num =*/10, /*port =*/9000);
-  server.regist_handler<hello, echo>();
+  server.register_handler<hello, echo>();
   server.start();
 }
 ```

--- a/src/coro_rpc/examples/file_transfer/file_server/main.cpp
+++ b/src/coro_rpc/examples/file_transfer/file_server/main.cpp
@@ -6,10 +6,10 @@
 int main() {
   coro_rpc::coro_rpc_server server(4, 9000);
 
-  server.regist_handler<echo, upload, upload_file, download_file>();
+  server.register_handler<echo, upload, upload_file, download_file>();
 
   dummy d{};
-  server.regist_handler<&dummy::echo>(&d);
+  server.register_handler<&dummy::echo>(&d);
 
   [[maybe_unused]] auto ret = server.start();
   assert(ret == std::errc{});

--- a/src/coro_rpc/examples/helloworld/server/main.cpp
+++ b/src/coro_rpc/examples/helloworld/server/main.cpp
@@ -25,13 +25,14 @@ int main() {
   coro_rpc_server server(std::thread::hardware_concurrency(), 8801);
 
   // regist normal function for rpc
-  server.regist_handler<hello_world, A_add_B, hello_with_delay, echo,
-                        coro_echo>();
+  server.register_handler<hello_world, A_add_B, hello_with_delay, echo,
+                          coro_echo>();
 
   // regist member function for rpc
   HelloService hello_service;
-  server.regist_handler<&HelloService::hello, &HelloService::hello_with_delay>(
-      &hello_service);
+  server
+      .register_handler<&HelloService::hello, &HelloService::hello_with_delay>(
+          &hello_service);
 
   auto ec = server.start();
   return ec == std::errc{};

--- a/src/coro_rpc/examples/user_defined_rpc_protocol/rest_rpc/server/main.cpp
+++ b/src/coro_rpc/examples/user_defined_rpc_protocol/rest_rpc/server/main.cpp
@@ -56,11 +56,11 @@ int main() {
       std::thread::hardware_concurrency(), 8801);
 
   // regist normal function for rpc
-  server.regist_handler<hello_world, add, echo>();
+  server.register_handler<hello_world, add, echo>();
 
   // regist member function for rpc
   HelloService hello_service;
-  server.regist_handler<&HelloService::hello, &HelloService::echo>(
+  server.register_handler<&HelloService::hello, &HelloService::echo>(
       &hello_service);
 
   auto ec = server.start();

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -119,7 +119,7 @@ TEST_CASE("testing client") {
       CHECK_MESSAGE(ret.error().code == std::errc::timed_out, ret.error().msg);
       co_return;
     };
-    server.regist_handler<hello_timeout>();
+    server.register_handler<hello_timeout>();
     syncAwait(f());
   }
 
@@ -133,7 +133,7 @@ TEST_CASE("testing client") {
       CHECK(ret.value() == std::string("hello"));
       co_return;
     };
-    server.regist_handler<hello>();
+    server.register_handler<hello>();
     syncAwait(f());
   }
 
@@ -147,7 +147,7 @@ TEST_CASE("testing client") {
       CHECK(ret.value() == arg);
       co_return;
     };
-    server.regist_handler<large_arg_fun>();
+    server.register_handler<large_arg_fun>();
     syncAwait(f());
   }
 
@@ -174,7 +174,7 @@ TEST_CASE("testing client with inject server") {
   });
   CHECK_MESSAGE(server.wait_for_start(3s), "server start timeout");
 
-  server.regist_handler<hello>();
+  server.register_handler<hello>();
 
   SUBCASE("server run ok") {
     g_action = {};
@@ -236,7 +236,7 @@ class SSLClientTester {
     inject("dh", dh_path, dh);
     ssl_configure config{base_path, server_crt_path, server_key_path, dh_path};
     server.init_ssl_context(config);
-    server.template regist_handler<hi>();
+    server.template register_handler<hi>();
     server.async_start().start([](auto&&) {
     });
     CHECK_MESSAGE(server.wait_for_start(3s), "server start timeout");
@@ -370,7 +370,7 @@ TEST_CASE("testing client with eof") {
   auto ec = client.sync_connect("127.0.0.1", "8801");
   REQUIRE_MESSAGE(ec == std::errc{}, make_error_code(ec).message());
 
-  server.regist_handler<hello, client_hello>();
+  server.register_handler<hello, client_hello>();
   auto ret = client.sync_call<hello>();
   CHECK(ret.value() == "hello"s);
 
@@ -391,7 +391,7 @@ TEST_CASE("testing client with shutdown") {
   coro_rpc_client client(g_client_id++);
   auto ec = client.sync_connect("127.0.0.1", "8801");
   REQUIRE_MESSAGE(ec == std::errc{}, make_error_code(ec).message());
-  server.regist_handler<hello, client_hello>();
+  server.register_handler<hello, client_hello>();
 
   g_action = inject_action::nothing;
   auto ret = client.sync_call<hello>();
@@ -485,8 +485,8 @@ TEST_CASE("testing client call timeout") {
     g_action = {};
     coro_rpc_server server(2, 8801);
 
-    server.regist_handler<hello_timeout>();
-    server.regist_handler<hi>();
+    server.register_handler<hello_timeout>();
+    server.register_handler<hi>();
     server.async_start().start([](auto&&) {
     });
     CHECK_MESSAGE(server.wait_for_start(3s), "server start timeout");

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -102,27 +102,27 @@ struct CoroServerTester : ServerTester {
   void register_all_function() override {
     g_action = {};
     ELOGV(INFO, "run %s", __func__);
-    server.regist_handler<async_hi, large_arg_fun, client_hello>();
-    server.regist_handler<long_run_func>();
-    server.regist_handler<&ns_login::LoginService::login>(&login_service_);
-    server.regist_handler<&HelloService::hello>(&hello_service_);
-    server.regist_handler<hello>();
-    server.regist_handler<coro_fun_with_delay_return_void>();
-    server.regist_handler<coro_fun_with_delay_return_void_twice>();
-    server.regist_handler<coro_fun_with_delay_return_void_cost_long_time>();
-    server.regist_handler<coro_fun_with_delay_return_string>();
-    server.regist_handler<coro_fun_with_delay_return_string_twice>();
-    server.regist_handler<coro_func>();
-    server.regist_handler<coro_func_return_void>();
-    server.regist_handler<coro_func_delay_return_int>();
-    server.regist_handler<coro_func_delay_return_void>();
-    server.regist_handler<&HelloService::coro_func,
-                          &HelloService::coro_func_return_void,
-                          &HelloService::coro_func_delay_return_void,
-                          &HelloService::coro_func_delay_return_int>(
+    server.register_handler<async_hi, large_arg_fun, client_hello>();
+    server.register_handler<long_run_func>();
+    server.register_handler<&ns_login::LoginService::login>(&login_service_);
+    server.register_handler<&HelloService::hello>(&hello_service_);
+    server.register_handler<hello>();
+    server.register_handler<coro_fun_with_delay_return_void>();
+    server.register_handler<coro_fun_with_delay_return_void_twice>();
+    server.register_handler<coro_fun_with_delay_return_void_cost_long_time>();
+    server.register_handler<coro_fun_with_delay_return_string>();
+    server.register_handler<coro_fun_with_delay_return_string_twice>();
+    server.register_handler<coro_func>();
+    server.register_handler<coro_func_return_void>();
+    server.register_handler<coro_func_delay_return_int>();
+    server.register_handler<coro_func_delay_return_void>();
+    server.register_handler<&HelloService::coro_func,
+                            &HelloService::coro_func_return_void,
+                            &HelloService::coro_func_delay_return_void,
+                            &HelloService::coro_func_delay_return_int>(
         &hello_service_);
-    server.regist_handler<get_coro_value>();
-    server.regist_handler<&CoroServerTester::get_value>(this);
+    server.register_handler<get_coro_value>();
+    server.register_handler<&CoroServerTester::get_value>(this);
   }
 
   void test_function_not_registered() {
@@ -139,7 +139,7 @@ struct CoroServerTester : ServerTester {
     ret = call<function_not_registered>(client);
     REQUIRE_MESSAGE(ret.error().code == std::errc::io_error, ret.error().msg);
     CHECK(client->has_closed() == true);
-    server.regist_handler<function_not_registered>();
+    server.register_handler<function_not_registered>();
   }
 
   void test_server_start_again() {
@@ -281,7 +281,7 @@ TEST_CASE("test server accept error") {
   ELOGV(INFO, "run test server accept error");
   g_action = inject_action::force_inject_server_accept_error;
   coro_rpc_server server(2, 8810);
-  server.regist_handler<hi>();
+  server.register_handler<hi>();
   server.async_start().start([](auto &&) {
   });
   CHECK_MESSAGE(server.wait_for_start(3s), "server start timeout");
@@ -311,7 +311,7 @@ TEST_CASE("test server write queue") {
   ELOGV(INFO, "run server write queue");
   g_action = {};
   coro_rpc_server server(2, 8810);
-  server.regist_handler<coro_fun_with_delay_return_void_cost_long_time>();
+  server.register_handler<coro_fun_with_delay_return_void_cost_long_time>();
   server.async_start().start([](auto &&) {
   });
   CHECK_MESSAGE(server.wait_for_start(3s), "server start timeout");
@@ -375,7 +375,7 @@ TEST_CASE("testing coro rpc write error") {
   ELOGV(INFO, "run testing coro rpc write error");
   g_action = inject_action::force_inject_connection_close_socket;
   coro_rpc_server server(2, 8810);
-  server.regist_handler<hi>();
+  server.register_handler<hi>();
   server.async_start().start([](auto &&) {
   });
   CHECK_MESSAGE(server.wait_for_start(3s), "server start timeout");

--- a/src/coro_rpc/tests/test_register_duplication_1.cpp
+++ b/src/coro_rpc/tests/test_register_duplication_1.cpp
@@ -19,8 +19,8 @@
 using namespace coro_rpc;
 int main() {
   coro_rpc_server server(1, 9001);
-  server.regist_handler<hi>();
-  server.regist_handler<hi>();
+  server.register_handler<hi>();
+  server.register_handler<hi>();
   assert(false && "can not reach");
   return 0;
 }

--- a/src/coro_rpc/tests/test_register_duplication_2.cpp
+++ b/src/coro_rpc/tests/test_register_duplication_2.cpp
@@ -19,7 +19,7 @@
 using namespace coro_rpc;
 int main() {
   coro_rpc_server server(1, 9001);
-  server.regist_handler<&HelloService::hello>(nullptr);
+  server.register_handler<&HelloService::hello>(nullptr);
   assert(false && "can not reach");
   return 0;
 }

--- a/src/coro_rpc/tests/test_register_duplication_3.cpp
+++ b/src/coro_rpc/tests/test_register_duplication_3.cpp
@@ -20,8 +20,8 @@ using namespace coro_rpc;
 int main() {
   coro_rpc_server server(1, 9001);
   HelloService s;
-  server.regist_handler<&HelloService::hello>(&s);
-  server.regist_handler<&HelloService::hello>(&s);
+  server.register_handler<&HelloService::hello>(&s);
+  server.register_handler<&HelloService::hello>(&s);
   assert(false && "can not reach");
   return 0;
 }

--- a/src/coro_rpc/tests/test_router.cpp
+++ b/src/coro_rpc/tests/test_router.cpp
@@ -190,7 +190,7 @@ async_simple::coro::Lazy<void> coro_func() {
 }
 
 TEST_CASE("testing coro_handler") {
-  router.regist_handler<coro_func>();
+  router.register_handler<coro_func>();
   auto buf = pack();
   constexpr auto id = func_id<coro_func>();
   auto handler = router.get_coro_handler(id);
@@ -228,7 +228,7 @@ TEST_CASE("testing invalid arguments") {
 
   SUBCASE("test member functions") {
     test_class obj{};
-    router.regist_handler<&test_class::plus_one, &test_class::get_str>(&obj);
+    router.register_handler<&test_class::plus_one, &test_class::get_str>(&obj);
     pair = test_route<plus_one>(coro_conn, 42);
     CHECK(pair.first == std::errc::function_not_supported);
 
@@ -254,8 +254,8 @@ TEST_CASE("testing invalid arguments") {
     CHECK(r.value() == "test");
   }
 
-  router.regist_handler<plus_one>();
-  router.regist_handler<get_str>();
+  router.register_handler<plus_one>();
+  router.register_handler<get_str>();
 
   pair = test_route<get_str>(coro_conn, "test");
   CHECK(pair.first == std::errc::invalid_argument);
@@ -302,7 +302,7 @@ void throw_exception_func() { throw std::runtime_error("runtime error"); }
 void throw_exception_func1() { throw 1; }
 
 TEST_CASE("testing exceptions") {
-  router.regist_handler<throw_exception_func, throw_exception_func1>();
+  router.register_handler<throw_exception_func, throw_exception_func1>();
 
   std::pair<std::errc, std::string> pair{};
   pair = test_route<throw_exception_func>(coro_conn);
@@ -317,7 +317,7 @@ TEST_CASE("testing exceptions") {
 }
 
 TEST_CASE("testing object arguments") {
-  router.regist_handler<get_person>();
+  router.register_handler<get_person>();
 
   person p{1, "tom"};
   auto buf = struct_pack::serialize(p);
@@ -326,23 +326,23 @@ TEST_CASE("testing object arguments") {
   REQUIRE(ec == struct_pack::errc{});
   test_route_and_check<get_person>(coro_conn, p);
 
-  router.regist_handler<get_person1>();
+  router.register_handler<get_person1>();
   test_route_and_check<get_person1>(coro_conn, p, 42, std::string("jerry"));
 }
 
 TEST_CASE("testing basic rpc register and route") {
-  router.regist_handler<bar>();
-  router.regist_handler<bar3>();
+  router.register_handler<bar>();
+  router.register_handler<bar3>();
 
-  router.regist_handler<foo, foo1, foo2>();
+  router.register_handler<foo, foo1, foo2>();
 
   test_route_and_check<foo>(coro_conn, 42);
   test_route_and_check<foo1>(coro_conn, 42);
   test_route_and_check<foo2>(coro_conn);
 
   SUBCASE("test static functions") {
-    router.regist_handler<plus_two>();
-    router.regist_handler<test_class::plus_two>();
+    router.register_handler<plus_two>();
+    router.register_handler<test_class::plus_two>();
 
     test_route_and_check<plus_two>(coro_conn, 42, 42);
     test_route_and_check<test_class::plus_two>(coro_conn, 42, 42);

--- a/src/coro_rpc/tests/test_variadic.cpp
+++ b/src/coro_rpc/tests/test_variadic.cpp
@@ -31,7 +31,7 @@ TEST_CASE("test varadic param") {
   auto server = std::make_unique<coro_rpc::coro_rpc_server<>>(
       std::thread::hardware_concurrency(), 8808);
   std::thread thrd([&] {
-    server->regist_handler<test_func>();
+    server->register_handler<test_func>();
     try {
       auto ec = server->start();
       REQUIRE(ec == std::errc{});


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

fix the error pronounce of register_handler

## What is changing

rename coro_rpc_server::regist_handler to coro_rpc_server::register_hander

## Example