### PR TITLE
fix: fix zh page style on gen_doc.sh(#214)

### DIFF
--- a/gen_doc.sh
+++ b/gen_doc.sh
@@ -39,8 +39,25 @@ cp ../../../src/coro_rpc/doc/coro_rpc_introduction_cn.md coro-rpc-intro.md
 cp -r ../../guide/images .
 cp -r ../../guide/src .
 
-cd "$ROOT_DIR" || exit 1
+# cd "$ROOT_DIR" || exit 1
+cd "$ROOT_DIR"
 yarn docs:build
 doxygen Doxyfile
 doxygen Doxyfile_cn
-echo 'Done!'
+echo 'Generate Done!'
+
+function handle_style(){
+    for file in `ls $1`
+    do
+        if [ -d $1"/"$file ]
+        then
+            handle_style $1"/"$file
+        else
+            if [[ $file = *.html ]];then
+                sed -i 's/class="VPContent" id="VPContent"/class="VPContent has-sidebar" id="VPContent"/g' $1"/"$file
+            fi
+        fi
+    done
+}
+handle_style $(pwd)/docs/zh
+echo "Fix Style Done!"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
zh page style error. a fix method for #214 
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing
update gen_doc.sh
traversal the html files under docs/zh and modify the missing class to fix style bug.