### PR TITLE
[coro_rpc] rename coro_rpc::connection as coro_rpc::context. Allow us…

### DIFF
--- a/include/coro_rpc/coro_rpc/coro_rpc_client.hpp
+++ b/include/coro_rpc/coro_rpc/coro_rpc_client.hpp
@@ -31,7 +31,7 @@
 #include "asio_util/asio_coro_util.hpp"
 #include "async_simple/coro/SyncAwait.h"
 #include "common_service.hpp"
-#include "coro_rpc/coro_rpc/connection.hpp"
+#include "coro_rpc/coro_rpc/context.hpp"
 #include "coro_rpc/coro_rpc/protocol/coro_rpc_protocol.hpp"
 #include "easylog/easylog.h"
 #include "expected.hpp"
@@ -366,7 +366,7 @@ class coro_rpc_client {
     using param_type = function_parameters_t<Function>;
     if constexpr (!std::is_void_v<param_type>) {
       using First = std::tuple_element_t<0, param_type>;
-      constexpr bool is_conn = is_specialization<First, connection>::value;
+      constexpr bool is_conn = requires { typename First::return_type; };
 
       if constexpr (std::is_member_function_pointer_v<Function>) {
         using Self = class_type_t<Function>;
@@ -598,7 +598,7 @@ class coro_rpc_client {
   template <typename FuncArgs>
   auto get_func_args() {
     using First = std::tuple_element_t<0, FuncArgs>;
-    constexpr bool has_conn_v = is_specialization<First, connection>::value;
+    constexpr bool has_conn_v = is_specialization<First, context>::value;
     return get_args<has_conn_v, FuncArgs>();
   }
 

--- a/include/coro_rpc/rpc_connection.hpp
+++ b/include/coro_rpc/rpc_connection.hpp
@@ -15,5 +15,5 @@
  */
 #pragma once
 
-#include <coro_rpc/coro_rpc/connection.hpp>
+#include <coro_rpc/coro_rpc/context.hpp>
 #include <coro_rpc/coro_rpc/coro_connection.hpp>

--- a/src/coro_rpc/benchmark/api/rpc_functions.hpp
+++ b/src/coro_rpc/benchmark/api/rpc_functions.hpp
@@ -48,9 +48,9 @@ inline void monsterFunc(Monster monster) { return; }
 
 inline void ValidateRequestFunc(ValidateRequest req) { return; }
 
-inline void heavy_calculate(coro_rpc::connection<int> conn, int a) {
+inline void heavy_calculate(coro_rpc::context<int> conn, int a) {
   [&ioc = pool.get_io_context()](
-      int a, coro_rpc::connection<int> conn) -> async_simple::coro::Lazy<void> {
+      int a, coro_rpc::context<int> conn) -> async_simple::coro::Lazy<void> {
     std::vector<int> ar;
     ar.reserve(10001);
     for (int i = 0; i < 10000; ++i) ar.push_back((std::max)(a, rand()));
@@ -59,14 +59,14 @@ inline void heavy_calculate(coro_rpc::connection<int> conn, int a) {
     conn.response_msg(ar[0]);
     co_return;
   }(a, std::move(conn))
-                                                    .start([](auto &&e) {
-                                                    });
+                                                 .start([](auto &&e) {
+                                                 });
   return;
 }
 
 inline std::string download_10KB(int a) { return std::string(10000, 'A'); }
 
-inline void long_tail_heavy_calculate(coro_rpc::connection<int> conn, int a) {
+inline void long_tail_heavy_calculate(coro_rpc::context<int> conn, int a) {
   static std::atomic<uint64_t> g_index = 0;
   g_index++;
   if (g_index % 100 == 0) {
@@ -77,21 +77,21 @@ inline void long_tail_heavy_calculate(coro_rpc::connection<int> conn, int a) {
   }
 }
 
-inline void async_io(coro_rpc::connection<int> conn, int a) {
+inline void async_io(coro_rpc::context<int> conn, int a) {
   using namespace std::chrono;
   [&ioc = pool.get_io_context()](
-      int a, coro_rpc::connection<int> conn) -> async_simple::coro::Lazy<void> {
+      int a, coro_rpc::context<int> conn) -> async_simple::coro::Lazy<void> {
     auto timer = asio_util::period_timer(ioc);
     timer.expires_after(10ms);
     co_await timer.async_await();
     conn.response_msg(a);
   }(a, std::move(conn))
-                                                    .start([](auto &&e) {
-                                                    });
+                                                 .start([](auto &&e) {
+                                                 });
   return;
 }
 
-inline void long_tail_async_io(coro_rpc::connection<int> conn, int a) {
+inline void long_tail_async_io(coro_rpc::context<int> conn, int a) {
   static std::atomic<uint64_t> g_index = 0;
   g_index++;
   if (g_index % 100 == 0) {
@@ -103,7 +103,7 @@ inline void long_tail_async_io(coro_rpc::connection<int> conn, int a) {
   return;
 }
 
-inline void block_io(coro_rpc::connection<int> conn, int a) {
+inline void block_io(coro_rpc::context<int> conn, int a) {
   using namespace std::chrono;
   asio::post(pool.get_io_context(), [conn = std::move(conn), a]() mutable {
     std::this_thread::sleep_for(50ms);
@@ -112,7 +112,7 @@ inline void block_io(coro_rpc::connection<int> conn, int a) {
   return;
 }
 
-inline void long_tail_block_io(coro_rpc::connection<int> conn, int a) {
+inline void long_tail_block_io(coro_rpc::context<int> conn, int a) {
   static std::atomic<uint64_t> g_index = 0;
   g_index++;
   if (g_index % 100 == 0) {

--- a/src/coro_rpc/doc/coro_rpc_introduction_cn.md
+++ b/src/coro_rpc/doc/coro_rpc_introduction_cn.md
@@ -305,14 +305,13 @@ coro_rpc已经考虑到了这个问题，coro_rpc认为rpc任务分为实时任�
 将之前实时任务改成延时任务
 
 ```cpp
-#include <coro_rpc/connection.hpp>
-#include <coro_rpc/coro_rpc_server.hpp>
+#include <coro_rpc/context.hpp>
 
 //实时任务，io线程中实时处理和发送结果
 std::string echo(std::string str) { return str; }
 
 //延时任务，在另外的独立线程中处理并发送结果
-void delay_echo(coro_connection<std::string> conn, std::string str) {
+void delay_echo(coro_rpc::context<std::string> conn, std::string str) {
   std::thread([conn, str]{
     conn.response_msg(str); //在独立线程中发送rpc结果
   }).detach();

--- a/src/coro_rpc/examples/file_transfer/file_server/rpc_service.cpp
+++ b/src/coro_rpc/examples/file_transfer/file_server/rpc_service.cpp
@@ -4,7 +4,7 @@
 
 std::string echo(std::string str) { return str; }
 
-void upload_file(coro_rpc::connection<std::errc> conn, file_part part) {
+void upload_file(coro_rpc::context<std::errc> conn, file_part part) {
   std::shared_ptr<std::ofstream> stream = nullptr;
   if (!conn.get_tag().has_value()) {
     stream = std::make_shared<std::ofstream>();
@@ -29,7 +29,7 @@ void upload_file(coro_rpc::connection<std::errc> conn, file_part part) {
   conn.response_msg(std::errc{});
 }
 
-void download_file(coro_rpc::connection<response_part> conn,
+void download_file(coro_rpc::context<response_part> conn,
                    std::string filename) {
   std::shared_ptr<std::ifstream> stream = nullptr;
   if (!conn.get_tag().has_value()) {

--- a/src/coro_rpc/examples/file_transfer/rpc_service/rpc_service.h
+++ b/src/coro_rpc/examples/file_transfer/rpc_service/rpc_service.h
@@ -20,7 +20,7 @@ struct file_part {
 std::errc upload(file_part part);
 
 // support arbitrary clients to upload file.
-void upload_file(coro_rpc::connection<std::errc> conn, file_part part);
+void upload_file(coro_rpc::context<std::errc> conn, file_part part);
 
 struct response_part {
   std::errc ec;
@@ -28,5 +28,4 @@ struct response_part {
   bool eof;
 };
 
-void download_file(coro_rpc::connection<response_part> conn,
-                   std::string filename);
+void download_file(coro_rpc::context<response_part> conn, std::string filename);

--- a/src/coro_rpc/examples/helloworld/rpc_service/rpc_service.h
+++ b/src/coro_rpc/examples/helloworld/rpc_service/rpc_service.h
@@ -24,16 +24,14 @@
 
 std::string hello_world();
 int A_add_B(int a, int b);
-void hello_with_delay(coro_rpc::connection<std::string> conn,
-                      std::string hello);
+void hello_with_delay(coro_rpc::context<std::string> conn, std::string hello);
 std::string_view echo(std::string_view sv);
 async_simple::coro::Lazy<std::string> coro_echo(std::string_view sv);
 
 class HelloService {
  public:
   std::string hello();
-  void hello_with_delay(coro_rpc::connection<std::string> conn,
-                        std::string hello);
+  void hello_with_delay(coro_rpc::context<std::string> conn, std::string hello);
 };
 
 #endif  // CORO_RPC_RPC_API_HPP

--- a/src/coro_rpc/examples/helloworld/server/rpc_service.cpp
+++ b/src/coro_rpc/examples/helloworld/server/rpc_service.cpp
@@ -44,7 +44,7 @@ async_simple::coro::Lazy<std::string> coro_echo(std::string_view sv) {
   co_return std::string{sv};
 }
 
-void hello_with_delay(connection</*response type:*/ std::string> conn,
+void hello_with_delay(context</*response type:*/ std::string> conn,
                       std::string hello) {
   ELOGV(INFO, "call HelloServer hello_with_delay");
   // create a new thread
@@ -64,8 +64,7 @@ std::string HelloService::hello() {
 }
 
 void HelloService::hello_with_delay(
-    coro_rpc::connection</*response type:*/ std::string> conn,
-    std::string hello) {
+    coro_rpc::context</*response type:*/ std::string> conn, std::string hello) {
   ELOGV(INFO, "call HelloServer::hello_with_delay");
   std::thread([conn = std::move(conn), hello = std::move(hello)]() mutable {
     conn.response_msg("HelloService::hello_with_delay");

--- a/src/coro_rpc/tests/rpc_api.hpp
+++ b/src/coro_rpc/tests/rpc_api.hpp
@@ -18,6 +18,8 @@
 #include <coro_rpc/rpc_connection.hpp>
 #include <string>
 #include <thread>
+
+#include "coro_rpc/coro_rpc/coro_connection.hpp"
 void hi();
 std::string hello();
 std::string hello_timeout();
@@ -27,24 +29,31 @@ std::string large_arg_fun(std::string data);
 void function_not_registered();
 int long_run_func(int val);
 std::string async_hi();
-void coro_fun_with_delay_return_void(coro_rpc::connection<void> conn);
-void coro_fun_with_delay_return_string(coro_rpc::connection<std::string> conn);
-void coro_fun_with_delay_return_void_twice(coro_rpc::connection<void> conn);
+struct my_context {
+  coro_rpc::context<void> ctx_;
+  my_context(coro_rpc::context<void>&& ctx) : ctx_(std::move(ctx)) {}
+  using return_type = void;
+};
+
+void coro_fun_with_user_define_connection_type(my_context conn);
+void coro_fun_with_delay_return_void(coro_rpc::context<void> conn);
+void coro_fun_with_delay_return_string(coro_rpc::context<std::string> conn);
+void coro_fun_with_delay_return_void_twice(coro_rpc::context<void> conn);
 void coro_fun_with_delay_return_string_twice(
-    coro_rpc::connection<std::string> conn);
+    coro_rpc::context<std::string> conn);
 void coro_fun_with_delay_return_void_cost_long_time(
-    coro_rpc::connection<void> conn);
+    coro_rpc::context<void> conn);
 inline async_simple::coro::Lazy<void> coro_func_return_void(int i) {
   co_return;
 }
 inline async_simple::coro::Lazy<int> coro_func(int i) { co_return i; }
 inline async_simple::coro::Lazy<void> coro_func_delay_return_int(
-    coro_rpc::connection<int> conn, int i) {
+    coro_rpc::context<int> conn, int i) {
   conn.response_msg(i);
   co_return;
 }
 inline async_simple::coro::Lazy<void> coro_func_delay_return_void(
-    coro_rpc::connection<void> conn, int i) {
+    coro_rpc::context<void> conn, int i) {
   conn.response_msg();
   co_return;
 }
@@ -56,12 +65,12 @@ class HelloService {
   async_simple::coro::Lazy<int> coro_func(int i) { co_return i; }
   async_simple::coro::Lazy<void> coro_func_return_void(int i) { co_return; }
   async_simple::coro::Lazy<void> coro_func_delay_return_int(
-      coro_rpc::connection<int> conn, int i) {
+      coro_rpc::context<int> conn, int i) {
     conn.response_msg(i);
     co_return;
   }
   async_simple::coro::Lazy<void> coro_func_delay_return_void(
-      coro_rpc::connection<void> conn, int i) {
+      coro_rpc::context<void> conn, int i) {
     conn.response_msg();
     co_return;
   }

--- a/src/coro_rpc/tests/rpc_service.cpp
+++ b/src/coro_rpc/tests/rpc_service.cpp
@@ -46,43 +46,45 @@ int long_run_func(int val) {
   return val;
 }
 
-void fun_with_delay_return_void(coro_rpc::connection<void> conn) {
+void coro_fun_with_user_define_connection_type(my_context conn) {
+  conn.ctx_.response_msg();
+}
+
+void fun_with_delay_return_void(coro_rpc::context<void> conn) {
   conn.response_msg();
 }
 
-void fun_with_delay_return_string(coro_rpc::connection<std::string> conn) {
+void fun_with_delay_return_string(coro_rpc::context<std::string> conn) {
   conn.response_msg("string"s);
 }
 
-void fun_with_delay_return_void_twice(coro_rpc::connection<void> conn) {
+void fun_with_delay_return_void_twice(coro_rpc::context<void> conn) {
   conn.response_msg();
   conn.response_msg();
 }
 
-void fun_with_delay_return_string_twice(
-    coro_rpc::connection<std::string> conn) {
+void fun_with_delay_return_string_twice(coro_rpc::context<std::string> conn) {
   conn.response_msg("string"s);
   conn.response_msg("string"s);
 }
-void coro_fun_with_delay_return_void(coro_rpc::connection<void> conn) {
+void coro_fun_with_delay_return_void(coro_rpc::context<void> conn) {
   fun_with_delay_return_void(std::move(conn));
 }
 
-void coro_fun_with_delay_return_string(coro_rpc::connection<std::string> conn) {
+void coro_fun_with_delay_return_string(coro_rpc::context<std::string> conn) {
   fun_with_delay_return_string(std::move(conn));
 }
 
-void coro_fun_with_delay_return_void_twice(coro_rpc::connection<void> conn) {
+void coro_fun_with_delay_return_void_twice(coro_rpc::context<void> conn) {
   fun_with_delay_return_void_twice(std::move(conn));
 }
 
 void coro_fun_with_delay_return_string_twice(
-    coro_rpc::connection<std::string> conn) {
+    coro_rpc::context<std::string> conn) {
   fun_with_delay_return_string_twice(std::move(conn));
 }
 
-void fun_with_delay_return_void_cost_long_time(
-    coro_rpc::connection<void> conn) {
+void fun_with_delay_return_void_cost_long_time(coro_rpc::context<void> conn) {
   std::thread([conn = std::move(conn)]() mutable {
     std::this_thread::sleep_for(700ms);
     conn.response_msg();
@@ -90,7 +92,7 @@ void fun_with_delay_return_void_cost_long_time(
 }
 
 void coro_fun_with_delay_return_void_cost_long_time(
-    coro_rpc::connection<void> conn) {
+    coro_rpc::context<void> conn) {
   fun_with_delay_return_void_cost_long_time(std::move(conn));
 }
 

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -87,6 +87,8 @@ struct CoroServerTester : ServerTester {
     test_server_send_bad_rpc_result();
     test_server_send_no_body();
     this->test_call_with_delay_func<coro_fun_with_delay_return_void>();
+    this->test_call_with_delay_func<
+        coro_fun_with_user_define_connection_type>();
     this->test_call_with_delay_func<coro_fun_with_delay_return_void_twice>();
     this->test_call_with_delay_func_client_read_length_error<
         coro_fun_with_delay_return_void>();
@@ -107,6 +109,7 @@ struct CoroServerTester : ServerTester {
     server.register_handler<&ns_login::LoginService::login>(&login_service_);
     server.register_handler<&HelloService::hello>(&hello_service_);
     server.register_handler<hello>();
+    server.register_handler<coro_fun_with_user_define_connection_type>();
     server.register_handler<coro_fun_with_delay_return_void>();
     server.register_handler<coro_fun_with_delay_return_void_twice>();
     server.register_handler<coro_fun_with_delay_return_void_cost_long_time>();

--- a/src/coro_rpc/tests/test_router.cpp
+++ b/src/coro_rpc/tests/test_router.cpp
@@ -150,10 +150,10 @@ void test_route_and_check(auto conn, Args &&...args) {
 }  // namespace test_util
 
 void foo(int val) { std::cout << "foo " << val << "\n"; }
-void foo1(coro_rpc::connection<void> conn, int val) {
+void foo1(coro_rpc::context<void> conn, int val) {
   std::cout << "foo1 " << val << "\n";
 }
-void foo2(coro_rpc::connection<void> conn) {
+void foo2(coro_rpc::context<void> conn) {
   std::cout << "foo2 "
             << "\n";
 }
@@ -358,12 +358,11 @@ TEST_CASE("test get_return_type in connection") {
   }
   SUBCASE("return void") {
     static_assert(
-        std::is_same_v<decltype(get_return_type<true, connection<void>>()),
-                       void>);
+        std::is_same_v<decltype(get_return_type<true, context<void>>()), void>);
   }
   SUBCASE("return std::string") {
-    static_assert(std::is_same_v<
-                  decltype(get_return_type<true, connection<std::string>>()),
-                  std::string>);
+    static_assert(
+        std::is_same_v<decltype(get_return_type<true, context<std::string>>()),
+                       std::string>);
   }
 }


### PR DESCRIPTION
…er-defined coro_rpc::connection type

<!-- Thank you for your contribution! -->

## Why

## What is changing

1. rename coro_rpc::connection as coro_rpc::context
2. support user-define context type

## Example

```cpp
struct my_context {
  coro_rpc::context<void> ctx_;
  my_context(coro_rpc::context<void>&& ctx) : ctx_(std::move(ctx)) {}
  using return_type = void;
};

void coro_fun_with_user_define_connection_type(my_context conn);
```