### PR TITLE
[coro_http] fix example build fail with openssl

### DIFF
--- a/src/coro_http/CMakeLists.txt
+++ b/src/coro_http/CMakeLists.txt
@@ -18,7 +18,7 @@ option(ENABLE_SSL "Enable ssl support" OFF)
 if (ENABLE_SSL)
     message(STATUS "Use SSL")
     find_package(OpenSSL REQUIRED)
-    target_compile_definitions(coro_http INTERFACE CINATRA_ENABLE_SSL)
+    target_compile_definitions(coro_http INTERFACE CINATRA_ENABLE_SSL ENABLE_SSL)
     target_link_libraries(coro_http INTERFACE OpenSSL::SSL OpenSSL::Crypto)
 endif ()
 

--- a/src/coro_http/examples/main.cpp
+++ b/src/coro_http/examples/main.cpp
@@ -68,13 +68,11 @@ async_simple::coro::Lazy<void> test_async_ssl_client(
 #ifdef ENABLE_SSL
   std::string uri2 = "https://www.baidu.com";
   std::string uri3 = "https://cn.bing.com";
-  coro_http_client client{};
   client.init_ssl("../../include/cinatra", "server.crt");
-  data = co_await client.async_get(uri2);
-  print(data.status);
-
+  auto data = co_await client.async_get(uri2);
+  std::cout << data.status << std::endl;
   data = co_await client.async_get(uri3);
-  print(data.status);
+  std::cout << data.status << std::endl;
 #endif
   co_return;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

fix example build fail when `ENABLE_SSL` is ON

## What is changing

- `target_compile_definitions(coro_http INTERFACE ENABLE_SSL)`

## Example