### PR TITLE
[struct_pack] fix compatible<T> in pod

### DIFF
--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -26,8 +26,6 @@
 #include <variant>
 #include <vector>
 
-#include "struct_pack/struct_pack/struct_pack_impl.hpp"
-
 #if __has_include(<span>)
 #include <span>
 #endif

--- a/include/struct_pack/struct_pack/reflection.h
+++ b/include/struct_pack/struct_pack/reflection.h
@@ -52,13 +52,17 @@
 namespace struct_pack {
 namespace detail {
 
-template <typename T, template <typename , typename , std::size_t > typename Op,
+template <typename U>
+constexpr auto get_types();
+
+template <typename T, template <typename, typename, std::size_t> typename Op,
           typename... Contexts>
 constexpr void for_each(Contexts &...contexts) {
+  using type = decltype(get_types<T>());
   [&]<std::size_t... I>(std::index_sequence<I...>) {
-    (Op<T, std::tuple_element_t<I, T>, I>{}(contexts...), ...);
+    (Op<T, std::tuple_element_t<I, type>, I>{}(contexts...), ...);
   }
-  (std::make_index_sequence<std::tuple_size_v<T>>());
+  (std::make_index_sequence<std::tuple_size_v<type>>());
 }
 
 template <typename T>

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -850,7 +850,7 @@ struct calculate_padding_size_impl {
       if (offset % align::alignment_v<T>) {
         padding_size[I] =
             (std::min)(align::pack_alignment_v<P> - 1,
-                     align::alignment_v<T> - offset % align::alignment_v<T>);
+                       align::alignment_v<T> - offset % align::alignment_v<T>);
       }
       else {
         padding_size[I] = 0;

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -849,7 +849,7 @@ struct calculate_padding_size_impl {
     else {
       if (offset % align::alignment_v<T>) {
         padding_size[I] =
-            std::min(align::pack_alignment_v<P> - 1,
+            (std::min)(align::pack_alignment_v<P> - 1,
                      align::alignment_v<T> - offset % align::alignment_v<T>);
       }
       else {

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -828,7 +828,9 @@ consteval std::size_t alignment_impl() {
     if constexpr (is_trivial_serializable<T>::value) {
       return default_alignment_v<T>;
     }
-    return pack_alignment_v<T>;
+    else {
+      return pack_alignment_v<T>;
+    }
   }
 }
 

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -278,19 +278,23 @@ constexpr auto get_types() {
   }
 }
 
-template <typename T>
+template <typename T, bool ignore_compatible_field = false>
 struct is_trivial_serializable {
  private:
   static constexpr bool solve() {
+    if constexpr (is_compatible_v<T> && ignore_compatible_field) {
+      return true;
+    }
     if constexpr (std::is_enum_v<T> || std::is_fundamental_v<T>) {
       return true;
     }
     else if constexpr (array<T>) {
-      return is_trivial_serializable<typename T::value_type>::value;
+      return is_trivial_serializable<typename T::value_type,
+                                     ignore_compatible_field>::value;
     }
     else if constexpr (c_array<T>) {
-      return is_trivial_serializable<
-          typename std::remove_all_extents<T>::type>::value;
+      return is_trivial_serializable<typename std::remove_all_extents<T>::type,
+                                     ignore_compatible_field>::value;
     }
     else if constexpr (!pair<T> && tuple<T> && !is_trivial_tuple<T>) {
       return false;
@@ -301,13 +305,16 @@ struct is_trivial_serializable {
       return false;
     }
     else if constexpr (pair<T>) {
-      return is_trivial_serializable<typename T::first_type>::value &&
-             is_trivial_serializable<typename T::second_type>::value;
+      return is_trivial_serializable<typename T::first_type,
+                                     ignore_compatible_field>::value &&
+             is_trivial_serializable<typename T::second_type,
+                                     ignore_compatible_field>::value;
     }
     else if constexpr (is_trivial_tuple<T>) {
       return []<std::size_t... I>(std::index_sequence<I...>)
           CONSTEXPR_INLINE_LAMBDA {
-        return (is_trivial_serializable<std::tuple_element_t<I, T>>::value &&
+        return (is_trivial_serializable<std::tuple_element_t<I, T>,
+                                        ignore_compatible_field>::value &&
                 ...);
       }
       (std::make_index_sequence<std::tuple_size_v<T>>{});
@@ -316,7 +323,8 @@ struct is_trivial_serializable {
       using T_ = decltype(get_types<T>());
       return []<std::size_t... I>(std::index_sequence<I...>)
           CONSTEXPR_INLINE_LAMBDA {
-        return (is_trivial_serializable<std::tuple_element_t<I, T_>>::value &&
+        return (is_trivial_serializable<std::tuple_element_t<I, T_>,
+                                        ignore_compatible_field>::value &&
                 ...);
       }
       (std::make_index_sequence<std::tuple_size_v<T_>>{});
@@ -721,6 +729,182 @@ std::size_t consteval get_array_size() {
   }
 }
 
+struct size_info {
+  std::size_t total;
+  std::size_t size_cnt;
+  std::size_t max_size;
+  constexpr size_info &operator+=(const size_info &other) {
+    this->total += other.total;
+    this->size_cnt += other.size_cnt;
+    this->max_size = (std::max)(this->max_size, other.max_size);
+    return *this;
+  }
+  constexpr size_info operator+(const size_info &other) {
+    return {this->total + other.total, this->size_cnt += other.size_cnt,
+            (std::max)(this->max_size, other.max_size)};
+  }
+};
+template <typename T>
+constexpr size_info inline calculate_one_size(const T &item);
+
+namespace align {
+
+template <typename T>
+consteval std::size_t alignment_impl();
+
+template <typename T>
+constexpr std::size_t alignment_v = alignment_impl<T>();
+
+template <typename T>
+consteval std::size_t default_alignment() {
+  using type = decltype(get_types<T>());
+  if constexpr (!is_trivial_serializable<T>::value) {
+    return [&]<std::size_t... I>(std::index_sequence<I...>) constexpr {
+      return (std::max)(
+          {(is_compatible_v<std::remove_cvref_t<std::tuple_element_t<I, type>>>
+                ? std::size_t{0}
+                : align::alignment_v<
+                      std::remove_cvref_t<std::tuple_element_t<I, type>>>)...});
+    }
+    (std::make_index_sequence<std::tuple_size_v<type>>());
+  }
+  else {
+    return std::alignment_of_v<T>;
+  }
+}
+template <typename T>
+constexpr std::size_t default_alignment_v = default_alignment<T>();
+
+template <typename T>
+consteval std::size_t alignment_impl();
+
+template <typename T>
+consteval std::size_t pack_alignment_impl() {
+  static_assert(std::is_class_v<T>);
+  constexpr auto ret = struct_pack::pack_alignment_v<T>;
+  static_assert(ret == 0 || ret == 1 || ret == 2 || ret == 4 || ret == 8 ||
+                ret == 16);
+  if constexpr (ret == 0) {
+    using type = decltype(get_types<T>());
+    return [&]<std::size_t... I>(std::index_sequence<I...>) constexpr {
+      return (std::max)(
+          {(is_compatible_v<std::remove_cvref_t<std::tuple_element_t<I, type>>>
+                ? std::size_t{0}
+                : align::alignment_v<
+                      std::remove_cvref_t<std::tuple_element_t<I, type>>>)...});
+    }
+    (std::make_index_sequence<std::tuple_size_v<type>>());
+  }
+  else {
+    return ret;
+  }
+}
+
+template <typename T>
+constexpr std::size_t pack_alignment_v = pack_alignment_impl<T>();
+
+template <typename T>
+consteval std::size_t alignment_impl() {
+  if constexpr (struct_pack::alignment_v<T> == 0 &&
+                struct_pack::pack_alignment_v<T> == 0) {
+    return default_alignment_v<T>;
+  }
+  else if constexpr (struct_pack::alignment_v<T> != 0) {
+    if constexpr (is_trivial_serializable<T>::value) {
+      static_assert(default_alignment_v<T> == alignment_v<T>);
+    }
+    constexpr auto ret = struct_pack::alignment_v<T>;
+    static_assert(
+        [](std::size_t align) constexpr {
+          while (align % 2 == 0) {
+            align /= 2;
+          }
+          return align == 1;
+        }(ret),
+        "alignment should be power of 2");
+    return ret;
+  }
+  else {
+    if constexpr (is_trivial_serializable<T>::value) {
+      return default_alignment_v<T>;
+    }
+    return pack_alignment_v<T>;
+  }
+}
+
+template <typename P, typename T, std::size_t I>
+struct calculate_trival_obj_size;
+
+template <typename P, typename T, std::size_t I>
+struct calculate_padding_size_impl {
+  constexpr void operator()(
+      std::size_t &offset,
+      std::array<std::size_t, struct_pack::members_count<P> + 1>
+          &padding_size) {
+    if constexpr (is_compatible_v<T>) {
+      padding_size[I] = 0;
+    }
+    else {
+      if (offset % align::alignment_v<T>) {
+        padding_size[I] =
+            std::min(align::pack_alignment_v<P> - 1,
+                     align::alignment_v<T> - offset % align::alignment_v<T>);
+      }
+      else {
+        padding_size[I] = 0;
+      }
+      offset += padding_size[I];
+      if constexpr (is_trivial_serializable<T>::value)
+        offset += sizeof(T);
+      else {
+        for_each<decltype(get_types<T>()), calculate_trival_obj_size>(offset);
+        static_assert(is_trivial_serializable<T, true>::value);
+      }
+    }
+  }
+};
+
+template <typename T>
+constexpr auto calculate_padding_size() {
+  constexpr auto id = get_type_id<T>();
+  std::array<std::size_t, struct_pack::members_count<T> + 1> padding_size{};
+  std::size_t offset = 0;
+  for_each<decltype(get_types<T>()), calculate_padding_size_impl>(offset,
+                                                                  padding_size);
+  if (offset % align::alignment_v<T>) {
+    padding_size[struct_pack::members_count<T>] =
+        align::alignment_v<T> - offset % align::alignment_v<T>;
+  }
+  else {
+    padding_size[struct_pack::members_count<T>] = 0;
+  }
+  return padding_size;
+}
+template <typename T>
+constexpr std::array<std::size_t, struct_pack::members_count<T> + 1>
+    padding_size = calculate_padding_size<T>();
+template <typename T>
+constexpr std::size_t total_padding_size = []() CONSTEXPR_INLINE_LAMBDA {
+  std::size_t sum = 0;
+  for (auto &e : padding_size<T>) {
+    sum += e;
+  }
+  return sum;
+}();
+
+template <typename P, typename T, std::size_t I>
+struct calculate_trival_obj_size {
+  constexpr void operator()(std::size_t &total) {
+    if constexpr (I == 0) {
+      total += total_padding_size<P>;
+    }
+    if constexpr (!is_compatible_v<T>) {
+      total += sizeof(T);
+    }
+  }
+};
+}  // namespace align
+
 // This help function is just to improve unit test coverage. :)
 // The original lambada in `get_type_literal` is a compile-time expression.
 // Currently, the unit test coverage tools like
@@ -748,16 +932,14 @@ consteval decltype(auto) get_type_literal() {
       using Args = decltype(get_types<Arg>());
       constexpr auto body = get_type_literal<Args, Arg, ParentArgs...>(
           std::make_index_sequence<std::tuple_size_v<Args>>());
-      if constexpr (is_trivial_serializable<Arg>::value) {
-        static_assert(
-            min_align<Arg>() == '0' || min_align<Arg>() <= max_align<Arg>(),
-            "#pragma pack may decrease the alignment of a class, however, "
-            "it cannot make a class over aligned.");
-        constexpr auto end = string_literal<char, 3>{
-            {static_cast<char>(min_align<Arg>()),
-             static_cast<char>(max_align<Arg>()),
-             static_cast<char>(type_id::type_end_flag)}};
-        return ret + body + end;
+      if constexpr (is_trivial_serializable<Arg, true>::value) {
+        static_assert(align::pack_alignment_v<Arg> <= align::alignment_v<Arg>,
+                      "If you add #pragma_pack to a struct, please specify the "
+                      "struct_pack::pack_alignment_v<T>.");
+        constexpr auto end = string_literal<char, 1>{
+            {static_cast<char>(type_id::type_end_flag)}};
+        return ret + body + get_size_literal<align::pack_alignment_v<Arg>>() +
+               get_size_literal<align::alignment_v<Arg>>() + end;
       }
       else {
         constexpr auto end = string_literal<char, 1>{
@@ -848,23 +1030,21 @@ consteval decltype(auto) get_types_literal_impl() {
 template <typename T, typename... Args>
 consteval decltype(auto) get_types_literal() {
   constexpr auto root_id = get_type_id<std::remove_cvref_t<T>>();
+  constexpr auto end =
+      string_literal<char, 1>{{static_cast<char>(type_id::type_end_flag)}};
   if constexpr (root_id == type_id::non_trivial_class_t ||
                 root_id == type_id::trivial_class_t) {
     constexpr auto begin =
         string_literal<char, 1>{{static_cast<char>(root_id)}};
     constexpr auto body = get_types_literal_impl<T, Args...>();
-    if constexpr (is_trivial_serializable<T>::value) {
-      static_assert(min_align<T>() == '0' || min_align<T>() <= max_align<T>(),
-                    "#pragma pack may decrease the alignment of a class, "
-                    "however, it cannot make a class over aligned.");
-      constexpr auto end = string_literal<char, 3>{
-          {static_cast<char>(min_align<T>()), static_cast<char>(max_align<T>()),
-           static_cast<char>(type_id::type_end_flag)}};
-      return begin + body + end;
+    if constexpr (is_trivial_serializable<T, true>::value) {
+      static_assert(align::pack_alignment_v<T> <= align::alignment_v<T>,
+                    "If you add #pragma_pack to a struct, please specify the "
+                    "struct_pack::pack_alignment_v<T>.");
+      return begin + body + get_size_literal<align::pack_alignment_v<T>>() +
+             get_size_literal<align::alignment_v<T>>() + end;
     }
     else {
-      constexpr auto end =
-          string_literal<char, 1>{{static_cast<char>(type_id::type_end_flag)}};
       return begin + body + end;
     }
   }
@@ -976,22 +1156,6 @@ consteval uint32_t get_types_code(std::index_sequence<I...>) {
   return get_types_code_impl<T, std::tuple_element_t<I, Tuple>...>();
 }
 
-struct size_info {
-  std::size_t total;
-  std::size_t size_cnt;
-  std::size_t max_size;
-  constexpr size_info &operator+=(const size_info &other) {
-    this->total += other.total;
-    this->size_cnt += other.size_cnt;
-    this->max_size = (std::max)(this->max_size, other.max_size);
-    return *this;
-  }
-  constexpr size_info operator+(const size_info &other) {
-    return {this->total + other.total, this->size_cnt += other.size_cnt,
-            (std::max)(this->max_size, other.max_size)};
-  }
-};
-
 template <typename T, typename... Args>
 constexpr size_info STRUCT_PACK_INLINE
 calculate_payload_size(const T &item, const Args &...items);
@@ -1073,6 +1237,12 @@ constexpr size_info inline calculate_one_size(const T &item) {
       static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
     if constexpr (is_trivial_serializable<type>::value) {
       ret.total = sizeof(type);
+    }
+    else if constexpr (is_trivial_serializable<type, true>::value) {
+      visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+        ret += calculate_payload_size(items...);
+        ret.total += align::total_padding_size<type>;
+      });
     }
     else {
       visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
@@ -1503,6 +1673,12 @@ class packer {
       serialize_many<size_type, version>(items...);
     }
   }
+  constexpr void STRUCT_PACK_INLINE write_padding(std::size_t sz) {
+    if (sz > 0) {
+      constexpr char buf = 0;
+      for (std::size_t i = 0; i < sz; ++i) writer_.write(&buf, 1);
+    }
+  }
 
   template <std::size_t size_type, uint64_t version>
   constexpr void inline serialize_one(const auto &item) {
@@ -1618,6 +1794,17 @@ class packer {
           static_assert(std::is_aggregate_v<std::remove_cvref_t<type>>);
         if constexpr (is_trivial_serializable<type>::value) {
           writer_.write((char *)&item, sizeof(type));
+        }
+        else if constexpr (is_trivial_serializable<type, true>::value) {
+          visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+            int i = 1;
+            (
+                [&]() {
+                  serialize_one<size_type, version>(items);
+                  write_padding(align::padding_size<type>[i++]);
+                }(),
+                ...);
+          });
         }
         else {
           visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
@@ -2215,6 +2402,16 @@ class unpacker {
     return deserialize_many<size_type, version, NotSkip>(items...);
   }
 
+  constexpr struct_pack::errc STRUCT_PACK_INLINE
+  ignore_padding(std::size_t sz) {
+    if (sz > 0) {
+      return reader_.ignore(sz) ? errc{} : errc::no_buffer_space;
+    }
+    else {
+      return errc{};
+    }
+  }
+
   template <size_t size_type, uint64_t version, bool NotSkip>
   constexpr struct_pack::errc inline deserialize_one(auto &item) {
     struct_pack::errc code{};
@@ -2455,6 +2652,23 @@ class unpacker {
             return reader_.ignore(sizeof(type)) ? errc{}
                                                 : errc::no_buffer_space;
           }
+        }
+        else if constexpr (is_trivial_serializable<type, true>::value) {
+          visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {
+            int i = 1;
+            [[maybe_unused]] bool op =
+                ((
+                     [&]() {
+                       if (code = deserialize_one<size_type, version, NotSkip>(
+                               items);
+                           code == errc::ok) [[likely]] {
+                         code = ignore_padding(align::padding_size<type>[i]);
+                         ++i;
+                       }
+                     }(),
+                     code == errc::ok) &&
+                 ...);
+          });
         }
         else {
           visit_members(item, [&](auto &&...items) CONSTEXPR_INLINE_LAMBDA {

--- a/src/struct_pack/benchmark/no_op.cpp
+++ b/src/struct_pack/benchmark/no_op.cpp
@@ -3,3 +3,4 @@
 void no_op(std::string& str) {}
 
 void no_op(char* data) {}
+

--- a/src/struct_pack/benchmark/no_op.cpp
+++ b/src/struct_pack/benchmark/no_op.cpp
@@ -3,4 +3,3 @@
 void no_op(std::string& str) {}
 
 void no_op(char* data) {}
-

--- a/src/struct_pack/tests/test_alignas.cpp
+++ b/src/struct_pack/tests/test_alignas.cpp
@@ -18,6 +18,7 @@
 
 #include "doctest.h"
 #include "struct_pack/struct_pack.hpp"
+#include "struct_pack/struct_pack/struct_pack_impl.hpp"
 using namespace struct_pack;
 using namespace doctest;
 // clang-format off
@@ -43,16 +44,17 @@ struct dummy {
 TEST_CASE("testing no alignas") {
   using T = test_alignas::dummy;
   static_assert(std::alignment_of_v<T> == 2);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 2);
   static_assert(alignof(T) == 2);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 2);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 2, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)131, (char)131, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   auto ret = struct_pack::deserialize<T>(buf);
@@ -69,16 +71,17 @@ struct alignas(2) dummy_2 {
 TEST_CASE("testing alignas(2)") {
   using T = test_alignas::dummy_2;
   static_assert(std::alignment_of_v<T> == 2);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 2);
   static_assert(alignof(T) == 2);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 2);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 2, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)131, (char)131, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   SUBCASE("deserialize to dummy") {
@@ -105,16 +108,17 @@ struct alignas(4) dummy_4 {
 TEST_CASE("testing alignas(4)") {
   using T = test_alignas::dummy_4;
   static_assert(std::alignment_of_v<T> == 4);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 4);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 4);
   static_assert(alignof(T) == 4);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 2);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 4, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)131, (char)133, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   SUBCASE("deserialize to dummy") {
@@ -144,16 +148,17 @@ struct alignas(8) dummy_8 {
 TEST_CASE("testing alignas(8)") {
   using T = test_alignas::dummy_8;
   static_assert(std::alignment_of_v<T> == 8);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 8);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 8);
   static_assert(alignof(T) == 8);
   static_assert(sizeof(T) == 8);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 2);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 8, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)131, (char)137, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   SUBCASE("deserialize to dummy") {
@@ -192,14 +197,15 @@ struct alignas(16) Outer {
   A a;
   B b;
 };
+
 }  // namespace test_alignas
 
 TEST_CASE("testing nesting alignas") {
   using T = test_alignas::Outer;
   static_assert(std::alignment_of_v<T> == 16);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 16);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 8);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 16);
   static_assert(alignof(T) == 16);
   static_assert(sizeof(T) == 16);
   static_assert(offsetof(T, a) == 0);
@@ -207,9 +213,9 @@ TEST_CASE("testing nesting alignas") {
   auto literal = struct_pack::get_type_literal<T>();
   // clang-format off
   string_literal<char, 16> val{{(char)-3,
-                               (char)-3,12, 7, 48,  4, (char)-1,
-                               (char)-3,12, 1, 48,  8, (char)-1,
-                                      48, 16, (char)-1}};
+                               (char)-3,12, 7, (char)131,  (char)133, (char)-1,
+                               (char)-3,12, 1, (char)133,  (char)137, (char)-1,
+                                      (char)137, (char)145, (char)-1}};
   // clang-format on
   REQUIRE(literal == val);
 }

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -1117,7 +1117,13 @@ struct A_v2 {
   } b;
   char c;
 };
-
+bool test_equal(const auto& v1, const auto& v2) {
+  return v1.a == v2.a && v1.c == v2.c &&
+         (v1.b.a == v2.b.a && v1.b.c == v2.b.c &&
+          (v1.b.b.a == v2.b.b.a && v1.b.b.c == v2.b.b.c &&
+           (v1.b.b.b.a == v2.b.b.b.a && v1.b.b.b.c == v2.b.b.b.c &&
+            (v1.b.b.b.b.a == v2.b.b.b.b.a && v1.b.b.b.b.c == v2.b.b.b.b.c))));
+}
 TEST_CASE("test nested trival_serialzable_obj_with_compatible") {
   A_v1 a_v1 = {
       .a = .123,
@@ -1141,11 +1147,13 @@ TEST_CASE("test nested trival_serialzable_obj_with_compatible") {
     auto buffer = struct_pack::serialize(a_v1);
     auto result = struct_pack::deserialize<A_v2>(buffer);
     CHECK(result.has_value());
+    CHECK(test_equal(result.value(),a_v2));
+    CHECK(result->b.b.b.b.b == std::nullopt);
   }
   {
     auto buffer = struct_pack::serialize(a_v2);
     auto result = struct_pack::deserialize<A_v1>(buffer);
     CHECK(result.has_value());
-    CHECK(memcmp(&result.value(), &a_v1, sizeof(A_v1)) == 0);
+    CHECK(test_equal(result.value(), a_v1));
   }
 }

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -1147,7 +1147,7 @@ TEST_CASE("test nested trival_serialzable_obj_with_compatible") {
     auto buffer = struct_pack::serialize(a_v1);
     auto result = struct_pack::deserialize<A_v2>(buffer);
     CHECK(result.has_value());
-    CHECK(test_equal(result.value(),a_v2));
+    CHECK(test_equal(result.value(), a_v2));
     CHECK(result->b.b.b.b.b == std::nullopt);
   }
   {

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -869,3 +869,201 @@ TEST_CASE("test compatible_with_version") {
     CHECK(result == obj_20230110_empty_1);
   }
 }
+
+struct compatible_with_trival_field_v0 {
+  int a[4];
+  char aa;
+  double b[2];
+  friend bool operator==(const compatible_with_trival_field_v0&,
+                         const compatible_with_trival_field_v0&) = default;
+};
+struct compatible_with_trival_field_v1 {
+  int a[4];
+  char aa;
+  double b[2];
+  struct_pack::compatible<std::string, 114514> c;
+  friend bool operator==(const compatible_with_trival_field_v1&,
+                         const compatible_with_trival_field_v1&) = default;
+};
+
+struct compatible_with_trival_field_v2 {
+  struct_pack::compatible<double, 114515> d;
+  int a[4];
+  char aa;
+  double b[2];
+  struct_pack::compatible<std::string, 114514> c;
+  friend bool operator==(const compatible_with_trival_field_v2&,
+                         const compatible_with_trival_field_v2&) = default;
+};
+
+struct compatible_with_trival_field_v3 {
+  struct_pack::compatible<double, 114515> d;
+  int a[4];
+  char aa;
+  struct_pack::compatible<int, 114516> e;
+  double b[2];
+  struct_pack::compatible<std::string, 114514> c;
+  friend bool operator==(const compatible_with_trival_field_v3&,
+                         const compatible_with_trival_field_v3&) = default;
+};
+
+template <typename T>
+struct nested_trival_v0 {
+  int a;
+  double b;
+  char c;
+  float d;
+  int64_t e;
+  T f;
+  char g[10];
+  int h[3];
+  friend bool operator==(const nested_trival_v0<T>&,
+                         const nested_trival_v0<T>&) = default;
+};
+
+
+
+auto i2 = struct_pack::detail::align::calculate_padding_size<
+    nested_trival_v0<compatible_with_trival_field_v1>>();
+
+template <typename T>
+struct nested_trival_v1 {
+  int a;
+  double b;
+  char c;
+  float d;
+  int64_t e;
+  T f;
+  char g[10];
+  struct_pack::compatible<int, 114516> i;
+  int h[3];
+  friend bool operator==(const nested_trival_v1<T>&,
+                         const nested_trival_v1<T>&) = default;
+};
+
+template <typename T>
+struct nested_trival_v2 {
+  int a;
+  double b;
+  char c;
+  struct_pack::compatible<double, 114516> j;
+  float d;
+  int64_t e;
+  T f;
+  char g[10];
+  struct_pack::compatible<int, 114516> i;
+  int h[3];
+  friend bool operator==(const nested_trival_v2<T>&,
+                         const nested_trival_v2<T>&) = default;
+};
+
+template <typename T>
+struct nested_trival_v3 {
+  int a;
+  double b;
+  char c;
+  struct_pack::compatible<double, 114516> j;
+  float d;
+  int64_t e;
+  T f;
+  char g[10];
+  struct_pack::compatible<int, 114516> i;
+  int h[3];
+  struct_pack::compatible<std::string, 114516> k;
+  friend bool operator==(const nested_trival_v3<T>&,
+                         const nested_trival_v3<T>&) = default;
+};
+
+
+
+TEST_CASE("test compatible_with_version") {
+  nested_trival_v0<compatible_with_trival_field_v0> to = {
+      .a = 113,
+      .b = 123.322134213,
+      .c = 'H',
+      .d = 890432.1,
+      .e = INT64_MAX - 1,
+      .f = {{123343, 7984321, 1987432, 1984327},
+            'I',
+            {798214321.98743, 821304.084321}},
+      .g = "HELLOHIHI",
+      .h = {14, 1023213, 1432143231}};
+  auto op = [&](auto from) {
+    from = {.a = 113,
+            .b = 123.322134213,
+            .c = 'H',
+            .d = 890432.1,
+            .e = INT64_MAX - 1,
+            .f = {.a = {123343, 7984321, 1987432, 1984327},
+                  .aa = 'I',
+                  .b = {798214321.98743, 821304.084321}},
+            .g = "HELLOHIHI",
+            .h = {14, 1023213, 1432143231}};
+    {
+      auto buffer = struct_pack::serialize(from);
+      auto result = struct_pack::deserialize<decltype(to)>(buffer);
+      CHECK(result == to);
+    }
+    {
+      auto buffer = struct_pack::serialize(to);
+      auto result = struct_pack::deserialize<decltype(from)>(buffer);
+      CHECK(result == from);
+    }
+  };
+  SUBCASE("test outer v0") {
+    SUBCASE("test innner v0") {
+      op(nested_trival_v0<compatible_with_trival_field_v0>{});
+    }
+    SUBCASE("test innner v1") {
+      op(nested_trival_v0<compatible_with_trival_field_v1>{});
+    }
+    SUBCASE("test innner v2") {
+      op(nested_trival_v0<compatible_with_trival_field_v2>{});
+    }
+    SUBCASE("test innner v3") {
+      op(nested_trival_v0<compatible_with_trival_field_v3>{});
+    }
+  }
+  SUBCASE("test outer v1") {
+    SUBCASE("test innner v0") {
+      op(nested_trival_v1<compatible_with_trival_field_v0>{});
+    }
+    SUBCASE("test innner v1") {
+      op(nested_trival_v1<compatible_with_trival_field_v1>{});
+    }
+    SUBCASE("test innner v2") {
+      op(nested_trival_v1<compatible_with_trival_field_v2>{});
+    }
+    SUBCASE("test innner v3") {
+      op(nested_trival_v1<compatible_with_trival_field_v3>{});
+    }
+  }
+  SUBCASE("test outer v2") {
+    SUBCASE("test innner v0") {
+      op(nested_trival_v2<compatible_with_trival_field_v0>{});
+    }
+    SUBCASE("test innner v1") {
+      op(nested_trival_v2<compatible_with_trival_field_v1>{});
+    }
+    SUBCASE("test innner v2") {
+      op(nested_trival_v2<compatible_with_trival_field_v2>{});
+    }
+    SUBCASE("test innner v3") {
+      op(nested_trival_v2<compatible_with_trival_field_v3>{});
+    }
+  }
+  SUBCASE("test outer v3") {
+    SUBCASE("test innner v0") {
+      op(nested_trival_v3<compatible_with_trival_field_v0>{});
+    }
+    SUBCASE("test innner v1") {
+      op(nested_trival_v3<compatible_with_trival_field_v1>{});
+    }
+    SUBCASE("test innner v2") {
+      op(nested_trival_v3<compatible_with_trival_field_v2>{});
+    }
+    SUBCASE("test innner v3") {
+      op(nested_trival_v3<compatible_with_trival_field_v3>{});
+    }
+  }
+}

--- a/src/struct_pack/tests/test_data_struct.cpp
+++ b/src/struct_pack/tests/test_data_struct.cpp
@@ -207,7 +207,7 @@ TEST_CASE("testing std::array") {
 TEST_CASE("test_trivial_copy_tuple") {
   tuplet::tuple tp = tuplet::make_tuple(1, 2);
 
-  constexpr auto count = detail::member_count<decltype(tp)>();
+  constexpr auto count = detail::members_count<decltype(tp)>();
   static_assert(count == 2);
 
   static_assert(std::is_same_v<decltype(tp), tuplet::tuple<int, int>>);

--- a/src/struct_pack/tests/test_pragma_pack.cpp
+++ b/src/struct_pack/tests/test_pragma_pack.cpp
@@ -15,9 +15,11 @@
  */
 #include <cstddef>
 #include <iostream>
+#include <type_traits>
 
 #include "doctest.h"
 #include "struct_pack/struct_pack.hpp"
+#include "struct_pack/struct_pack/reflection.h"
 using namespace struct_pack;
 using namespace doctest;
 // clang-format off
@@ -39,20 +41,41 @@ struct dummy {
   char a;
   short b;
 };
+struct dummy2 {
+  struct nest {
+    int a;
+    char ch[15];
+    double c;
+  };
+  std::map<int, std::vector<nest>> hi;
+};
+struct dummy3 {
+  struct nest {
+    struct_pack::compatible<int, 10234> ewr2;
+    int a;
+    char ch[15];
+    struct_pack::compatible<int> ewr;
+    double c;
+  };
+  struct_pack::compatible<int, 1021234> ewr2;
+  std::map<int, std::vector<nest>> hi;
+};
+
 }  // namespace test_pragma_pack
 TEST_CASE("testing no #pragam pack") {
   using T = test_pragma_pack::dummy;
   static_assert(std::alignment_of_v<T> == 2);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 2);
   static_assert(alignof(T) == 2);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 2);
   T t{.a = 'a', .b = 666};
-  auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 2, (char)-1}};
+  auto literal = struct_pack::get_type_literal<test_pragma_pack::dummy>();
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)131, (char)131, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   auto ret = struct_pack::deserialize<T>(buf);
@@ -69,30 +92,23 @@ struct dummy_1 {
 #pragma pack()
 }  // namespace test_pragma_pack
 template <>
-constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::dummy_1> = 1;
-namespace test_pragma_pack {
-#pragma pack(1)
-// if we forget add the template specialization like above,
-// the deserialization will be failed.
-struct dummy_1_forget {
-  char a;
-  short b;
-};
-#pragma pack()
-}  // namespace test_pragma_pack
+constexpr std::size_t struct_pack::pack_alignment_v<test_pragma_pack::dummy_1> =
+    1;
+namespace test_pragma_pack {}  // namespace test_pragma_pack
 TEST_CASE("testing #pragma pack(1)") {
   using T = test_pragma_pack::dummy_1;
   static_assert(std::alignment_of_v<T> == 1);
-  static_assert(struct_pack::min_alignment<T> == 1);
-  static_assert(struct_pack::detail::min_align<T>() == 1);
-  static_assert(struct_pack::detail::max_align<T>() == 1);
+  static_assert(struct_pack::pack_alignment_v<T> == 1);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 1);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 1);
   static_assert(alignof(T) == 1);
   static_assert(sizeof(T) == 3);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 1);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 1, 1, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)130, (char)130, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   SUBCASE("deserialize to dummy") {
@@ -106,11 +122,6 @@ TEST_CASE("testing #pragma pack(1)") {
     REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
     DT d_t = ret.value();
     CHECK(t == d_t);
-  }
-  SUBCASE("deserialize to dummy_1_forget") {
-    using DT = test_pragma_pack::dummy_1_forget;
-    auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
   }
 }
 namespace test_pragma_pack {
@@ -122,42 +133,32 @@ struct dummy_2 {
 #pragma pack()
 }  // namespace test_pragma_pack
 template <>
-constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::dummy_2> = 2;
-namespace test_pragma_pack {
-#pragma pack(2)
-struct dummy_2_forget {
-  char a;
-  short b;
-};
-#pragma pack()
-}  // namespace test_pragma_pack
+constexpr std::size_t struct_pack::pack_alignment_v<test_pragma_pack::dummy_2> =
+    2;
+namespace test_pragma_pack {}  // namespace test_pragma_pack
 TEST_CASE("testing #pragma pack(2)") {
   using T = test_pragma_pack::dummy_2;
   static_assert(std::alignment_of_v<T> == 2);
-  static_assert(struct_pack::min_alignment<T> == 2);
-  static_assert(struct_pack::detail::min_align<T>() == 2);
-  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(struct_pack::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 2);
   static_assert(alignof(T) == 2);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 2);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 2, 2, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)131, (char)131, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   SUBCASE("deserialize to dummy") {
     using DT = test_pragma_pack::dummy;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
+    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
   }
   SUBCASE("deserialize to dummy_1") {
     using DT = test_pragma_pack::dummy_1;
-    auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
-  }
-  SUBCASE("deserialize to dummy_1_forget") {
-    using DT = test_pragma_pack::dummy_1_forget;
     auto ret = struct_pack::deserialize<DT>(buf);
     REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
   }
@@ -167,14 +168,6 @@ TEST_CASE("testing #pragma pack(2)") {
     REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
     DT d_t = ret.value();
     CHECK(t == d_t);
-  }
-  SUBCASE("deserialize to dummy_2_forget") {
-    using DT = test_pragma_pack::dummy_2_forget;
-    auto ret = struct_pack::deserialize<DT>(buf);
-    // although the default alignment is 2,
-    // if we forget add the `min_alignment<dummy_2> = 2;`
-    // struct_pack can't get the actual min alignment.
-    REQUIRE_MESSAGE(!ret, alignment_requirement_err_msg);
   }
 }
 
@@ -203,17 +196,18 @@ struct Outer_1 {
 #pragma pack()
 }  // namespace test_pragma_pack
 template <>
-constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::A> = 1;
+constexpr std::size_t struct_pack::pack_alignment_v<test_pragma_pack::A> = 1;
 template <>
-constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::B> = 2;
+constexpr std::size_t struct_pack::pack_alignment_v<test_pragma_pack::B> = 2;
 template <>
-constexpr std::size_t struct_pack::min_alignment<test_pragma_pack::Outer_1> = 1;
+constexpr std::size_t struct_pack::pack_alignment_v<test_pragma_pack::Outer_1> =
+    1;
 TEST_CASE("testing nesting #pragma pack()") {
   using T = test_pragma_pack::Outer;
   static_assert(std::alignment_of_v<T> == 2);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 2);
   static_assert(alignof(T) == 2);
   static_assert(sizeof(T) == 10);
   static_assert(offsetof(T, a) == 0);
@@ -221,18 +215,18 @@ TEST_CASE("testing nesting #pragma pack()") {
   auto literal = struct_pack::get_type_literal<T>();
   // clang-format off
   string_literal<char, 16> val{{(char)-3,
-                                (char)-3,12, 7, 1, 1, (char)-1,
-                                (char)-3,12, 1, 2, 2, (char)-1,
-                                      48, 2, (char)-1}};
+                                (char)-3,12, 7, (char)130,(char) 130, (char)-1,
+                                (char)-3,12, 1, (char)131,(char) 131, (char)-1,
+                                      (char)131, (char)131, (char)-1}};
   // clang-format on
   REQUIRE(literal == val);
 }
 TEST_CASE("testing nesting #pragma pack(), outer pack(1)") {
   using T = test_pragma_pack::Outer_1;
   static_assert(std::alignment_of_v<T> == 1);
-  static_assert(struct_pack::min_alignment<T> == 1);
-  static_assert(struct_pack::detail::min_align<T>() == 1);
-  static_assert(struct_pack::detail::max_align<T>() == 1);
+  static_assert(struct_pack::pack_alignment_v<T> == 1);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 1);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 1);
   static_assert(alignof(T) == 1);
   static_assert(sizeof(T) == 9);
   static_assert(offsetof(T, a) == 0);
@@ -240,10 +234,13 @@ TEST_CASE("testing nesting #pragma pack(), outer pack(1)") {
   auto literal = struct_pack::get_type_literal<T>();
   // clang-format off
   string_literal<char, 16> val{{(char)-3,
-                                (char)-3,12, 7, 1, 1, (char)-1,
-                                (char)-3,12, 1, 2, 2, (char)-1,
-                                       1, 1, (char)-1}};
+                                (char)-3,12, 7, (char)130,(char) 130, (char)-1,
+                                (char)-3,12, 1, (char)131, (char)131, (char)-1,
+                                       (char)130, (char)130, (char)-1}};
   // clang-format on
   REQUIRE(literal == val);
 }
+static_assert(struct_pack::get_type_literal<test_pragma_pack::dummy2>() ==
+              struct_pack::get_type_literal<test_pragma_pack::dummy3>());
+
 TEST_SUITE_END;

--- a/src/struct_pack/tests/test_pragma_pack_and_alignas_mix.cpp
+++ b/src/struct_pack/tests/test_pragma_pack_and_alignas_mix.cpp
@@ -43,16 +43,17 @@ struct dummy {
 TEST_CASE("testing no one") {
   using T = test_pragma_pack_and_alignas_mix::dummy;
   static_assert(std::alignment_of_v<T> == 2);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 2);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 2);
   static_assert(alignof(T) == 2);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 2);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 48, 2, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)131, (char)131, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   auto ret = struct_pack::deserialize<T>(buf);
@@ -70,7 +71,8 @@ struct alignas(2) dummy_1_2 {
 }  // namespace test_pragma_pack_and_alignas_mix
 template <>
 constexpr std::size_t
-    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::dummy_1_2> = 1;
+    struct_pack::pack_alignment_v<test_pragma_pack_and_alignas_mix::dummy_1_2> =
+        1;
 namespace test_pragma_pack_and_alignas_mix {
 #pragma pack(1)
 struct alignas(2) dummy_1_2_forget {
@@ -82,16 +84,17 @@ struct alignas(2) dummy_1_2_forget {
 TEST_CASE("testing #pragam pack(1), alignas(2)") {
   using T = test_pragma_pack_and_alignas_mix::dummy_1_2;
   static_assert(std::alignment_of_v<T> == 2);
-  static_assert(struct_pack::min_alignment<T> == 1);
-  static_assert(struct_pack::detail::min_align<T>() == 1);
-  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(struct_pack::pack_alignment_v<T> == 1);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 1);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 2);
   static_assert(alignof(T) == 2);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 1);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 1, 2, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)130, (char)131, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   SUBCASE("deserialize to dummy") {
@@ -122,7 +125,8 @@ struct alignas(4) dummy_1_4 {
 }  // namespace test_pragma_pack_and_alignas_mix
 template <>
 constexpr std::size_t
-    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::dummy_1_4> = 1;
+    struct_pack::pack_alignment_v<test_pragma_pack_and_alignas_mix::dummy_1_4> =
+        1;
 namespace test_pragma_pack_and_alignas_mix {
 #pragma pack(1)
 struct alignas(2) dummy_1_4_forget {
@@ -134,16 +138,17 @@ struct alignas(2) dummy_1_4_forget {
 TEST_CASE("testing #pragam pack(1), alignas(2)") {
   using T = test_pragma_pack_and_alignas_mix::dummy_1_4;
   static_assert(std::alignment_of_v<T> == 4);
-  static_assert(struct_pack::min_alignment<T> == 1);
-  static_assert(struct_pack::detail::min_align<T>() == 1);
-  static_assert(struct_pack::detail::max_align<T>() == 4);
+  static_assert(struct_pack::pack_alignment_v<T> == 1);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 1);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 4);
   static_assert(alignof(T) == 4);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
   static_assert(offsetof(T, b) == 1);
   T t{.a = 'a', .b = 666};
   auto literal = struct_pack::get_type_literal<T>();
-  string_literal<char, 6> val{{(char)-3, 12, 7, 1, 4, (char)-1}};
+  string_literal<char, 6> val{
+      {(char)-3, 12, 7, (char)130, (char)133, (char)-1}};
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   SUBCASE("deserialize to dummy") {
@@ -185,7 +190,8 @@ struct alignas(2) dummy_4_2 {
 }  // namespace test_pragma_pack_and_alignas_mix
 template <>
 constexpr std::size_t
-    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::dummy_4_2> = 4;
+    struct_pack::pack_alignment_v<test_pragma_pack_and_alignas_mix::dummy_4_2> =
+        4;
 namespace test_pragma_pack_and_alignas_mix {
 #pragma pack(4)
 struct alignas(2) dummy_4_2_forget {
@@ -197,9 +203,9 @@ struct alignas(2) dummy_4_2_forget {
 TEST_CASE("testing #pragam pack(4), alignas(2)") {
   using T = test_pragma_pack_and_alignas_mix::dummy_4_2;
   static_assert(std::alignment_of_v<T> == 2);
-  static_assert(struct_pack::min_alignment<T> == 4);
-  static_assert(struct_pack::detail::min_align<T>() == 4);
-  static_assert(struct_pack::detail::max_align<T>() == 2);
+  static_assert(struct_pack::pack_alignment_v<T> == 4);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 4);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 2);
   static_assert(alignof(T) == 2);
   static_assert(sizeof(T) == 4);
   static_assert(offsetof(T, a) == 0);
@@ -229,16 +235,16 @@ struct alignas(16) Outer {
 }  // namespace test_pragma_pack_and_alignas_mix
 template <>
 constexpr std::size_t
-    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::A> = 1;
+    struct_pack::pack_alignment_v<test_pragma_pack_and_alignas_mix::A> = 1;
 template <>
 constexpr std::size_t
-    struct_pack::min_alignment<test_pragma_pack_and_alignas_mix::B> = 2;
+    struct_pack::pack_alignment_v<test_pragma_pack_and_alignas_mix::B> = 2;
 TEST_CASE("testing mix nested") {
   using T = test_pragma_pack_and_alignas_mix::Outer;
   static_assert(std::alignment_of_v<T> == 16);
-  static_assert(struct_pack::min_alignment<T> == 0);
-  static_assert(struct_pack::detail::min_align<T>() == '0');
-  static_assert(struct_pack::detail::max_align<T>() == 16);
+  static_assert(struct_pack::pack_alignment_v<T> == 0);
+  static_assert(struct_pack::detail::align::pack_alignment_v<T> == 8);
+  static_assert(struct_pack::detail::align::alignment_v<T> == 16);
   static_assert(alignof(T) == 16);
   static_assert(sizeof(T) == 16);
   static_assert(offsetof(T, a) == 0);
@@ -246,9 +252,9 @@ TEST_CASE("testing mix nested") {
   auto literal = struct_pack::get_type_literal<T>();
   // clang-format off
   string_literal<char, 16> val{{(char)-3,
-                                (char)-3,12, 7, 1,  4, (char)-1,
-                                (char)-3,12, 1, 2,  8, (char)-1,
-                                      48, 16, (char)-1}};
+                                (char)-3,12, 7, (char)130,  (char)133, (char)-1,
+                                (char)-3,12, 1, (char)131,  (char)137, (char)-1,
+                                      (char)137, (char)145, (char)-1}};
   // clang-format on
   REQUIRE(literal == val);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

fix compatible bug in pod.

```
struct foo_v1 {
   int a;
   double b;
};
struct foo_v2 {
   int a;
   struct_pack::compatible<std::string> c;
   double b;
};
struct foo_v3 {
   int a;
   struct_pack::compatible<std::string> c;
   double b;
   struct_pack::compatible<char> d;
};
```

the 2nd/3rd version of foo is not compatible with the 1st version because foo_v1 has optimized pod layout but foo_v2 & foo_v3 has normal layout.

## What is changing

The new layout of foo_v2 & foo_v3 is like:
```
struct foo_v2_equal_layout {
   struct foo_v1{
       int a;
       double b;
    } old_part;
    struct_pack::compatible<std::string> c;
};
struct foo_v3_equal_layout {
   struct foo_v1{
       int a;
       double b;
    } old_part;
    struct_pack::compatible<std::string> c;
   struct_pack::compatible<char> d;
};
```

Now the old part of  foo_v2 & foo_v3 still has optimized pod layout. 

## Example