### PR TITLE
change website CI branch and logic

### DIFF
--- a/.github/workflows/update_cache.yml
+++ b/.github/workflows/update_cache.yml
@@ -1,4 +1,4 @@
-name: Compile Code Daily
+name: CI Daily
 
 on:
   # Allows you to run this workflow manually from the Actions tab
@@ -14,3 +14,8 @@ jobs:
     uses: ./.github/workflows/mac.yml
   windows:
     uses: ./.github/workflows/windows.yml
+  website:
+    uses: ./.github/workflows/website.yml
+
+# run compile daily to make the cache in github update
+# run website to keep it follow main.

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,13 +1,14 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy Website static content
 
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: [ main, doc ,website ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  workflow_call:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
## Why
"Closes #270 "
## What is changing
developers can update website in branch doc or website, in this way there will be fewer  commits in branch main.
every time a push in doc or website will call the website CI.
Dont worry about we  change the original website.
Every day in 1:00 Chinese time  , the website will CI with branch main .You can also call the Ci by yourself in anytime. I make the workflow "called " 
```yml
  # Allows you to run this workflow manually from the Actions tab
  workflow_dispatch:
  workflow_call:
```
It is a solution now for developer who want to change website file.
In the future I will try to make different branch webiste deploy in different url such as "/yalanting-doc/coro_rpc" to make it better to develop.