### PR TITLE
[struct_pack] relax the limitation for non-aggregate type.

### DIFF
--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -263,7 +263,7 @@ constexpr auto get_types() {
     return declval<
         std::tuple<typename T::first_type, typename T::second_type>>();
   }
-  else if constexpr (std::is_aggregate_v<T>) {
+  else if constexpr (std::is_class_v<T>) {
     // clang-format off
     return visit_members(
         declval<T>(), []<typename... Args>(Args &&
@@ -556,7 +556,6 @@ consteval type_id get_type_id() {
     return type_id::non_trivial_class_t;
   }
   else if constexpr (std::is_class_v<T>) {
-    static_assert(std::is_aggregate_v<std::remove_cvref_t<T>>);
     return type_id::trivial_class_t;
   }
   else {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Now we can use non-aggregate type. But we need to add reflection info manually.

See #278 

## What is changing

Disable check for aggregate. 

## Example

```cpp
template <size_t out>
struct stat1 {
  std::array<int, out> sb = init_sb();
  friend bool operator==(const stat1&, const stat1&) = default;
  init1() {
    for (int i = 0; i < out; i++) {
      sb[i] = rand() % 100;
    }
  }
};

template <size_t in, size_t out>
struct person1 {
  int age;
  std::array<stat1<out>, in> state;
  std::string name;
  friend bool operator==(const person1&, const person1&) = default;
};

// manually add reflection info
template <size_t out>
constexpr std::size_t struct_pack::members_count<stat1<out>> = 1;

template <size_t in, size_t out>
constexpr std::size_t struct_pack::members_count<person1<in, out>> = 3;
```