### PR TITLE
update for gcc11

### DIFF
--- a/thirdparty/iguana/iguana/detail/string_stream.hpp
+++ b/thirdparty/iguana/iguana/detail/string_stream.hpp
@@ -5,10 +5,12 @@
 #endif
 
 namespace iguana {
+#ifdef IGUANA_ENABLE_PMR
 #if __has_include(<memory_resource>)
 inline char iguana_buf[2048];
 inline std::pmr::monotonic_buffer_resource iguana_resource(iguana_buf, 2048);
 using string_stream = std::pmr::string;
+#endif
 #else
 using string_stream = std::string;
 #endif


### PR DESCRIPTION
## Why

add pmr control macro for struct_json
