### PR TITLE
fix for clang old version

### DIFF
--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -154,7 +154,7 @@ STRUCT_PACK_INLINE consteval std::uint32_t get_type_code() {
 }
 
 template <typename... Args>
-STRUCT_PACK_INLINE constexpr decltype(auto) get_type_literal() {
+STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal() {
   static_assert(sizeof...(Args) > 0);
   if constexpr (sizeof...(Args) == 1) {
     using Types = decltype(detail::get_types<Args...>());

--- a/include/struct_pack/struct_pack.hpp
+++ b/include/struct_pack/struct_pack.hpp
@@ -154,7 +154,7 @@ STRUCT_PACK_INLINE consteval std::uint32_t get_type_code() {
 }
 
 template <typename... Args>
-STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal() {
+STRUCT_PACK_INLINE constexpr decltype(auto) get_type_literal() {
   static_assert(sizeof...(Args) > 0);
   if constexpr (sizeof...(Args) == 1) {
     using Types = decltype(detail::get_types<Args...>());

--- a/include/struct_pack/struct_pack/md5_constexpr.hpp
+++ b/include/struct_pack/struct_pack/md5_constexpr.hpp
@@ -71,7 +71,11 @@ template <typename Char, std::size_t Size1, std::size_t Size2>
 constexpr bool operator!=(const string_literal<Char, Size1> &s1,
                           const string_literal<Char, Size2> &s2) {
   if constexpr (Size1 == Size2) {
-    return !(s1 == s2);
+    for (int i = 0; i < Size1; ++i) {
+      if (s1[i] != s2[i])
+        return true;
+    }
+    return false;
   }
   else {
     return true;

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -197,7 +197,7 @@ constexpr inline type_info_config enable_type_info =
     type_info_config::automatic;
 
 template <typename... Args>
-STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal();
+STRUCT_PACK_INLINE constexpr decltype(auto) get_type_literal();
 
 struct serialize_buffer_size;
 

--- a/include/struct_pack/struct_pack/struct_pack_impl.hpp
+++ b/include/struct_pack/struct_pack/struct_pack_impl.hpp
@@ -197,7 +197,7 @@ constexpr inline type_info_config enable_type_info =
     type_info_config::automatic;
 
 template <typename... Args>
-STRUCT_PACK_INLINE constexpr decltype(auto) get_type_literal();
+STRUCT_PACK_INLINE consteval decltype(auto) get_type_literal();
 
 struct serialize_buffer_size;
 


### PR DESCRIPTION
## Why

test router test failed with clang old version, so test it.