### PR TITLE
[struct_pack:readability] improve string_literal readability

### DIFF
--- a/include/struct_pack/struct_pack/md5_constexpr.hpp
+++ b/include/struct_pack/struct_pack/md5_constexpr.hpp
@@ -87,8 +87,8 @@ string_literal(const CharType (&value)[Size])
     -> string_literal<CharType, Size - 1>;
 
 template <typename CharType, size_t Len1, size_t Len2>
-consteval auto operator+(string_literal<CharType, Len1> str1,
-                         string_literal<CharType, Len2> str2) {
+decltype(auto) consteval operator+(string_literal<CharType, Len1> str1,
+                                   string_literal<CharType, Len2> str2) {
   string_literal<CharType, Len1 + Len2> ret{};
   // don't use std::copy_n here to support low version stdlibc++
   for (size_t i = 0; i < Len1; ++i) {

--- a/include/struct_pack/struct_pack/md5_constexpr.hpp
+++ b/include/struct_pack/struct_pack/md5_constexpr.hpp
@@ -88,8 +88,8 @@ string_literal(const CharType (&value)[Size])
 
 template <typename CharType, size_t Len1, size_t Len2>
 consteval auto operator+(string_literal<CharType, Len1> str1,
-                                   string_literal<CharType, Len2> str2) {
-  string_literal<CharType, Len1 + Len2> ret {};
+                         string_literal<CharType, Len2> str2) {
+  string_literal<CharType, Len1 + Len2> ret{};
   // don't use std::copy_n here to support low version stdlibc++
   for (size_t i = 0; i < Len1; ++i) {
     ret[i] = str1[i];

--- a/include/struct_pack/struct_pack/md5_constexpr.hpp
+++ b/include/struct_pack/struct_pack/md5_constexpr.hpp
@@ -87,15 +87,15 @@ string_literal(const CharType (&value)[Size])
     -> string_literal<CharType, Size - 1>;
 
 template <typename CharType, size_t Len1, size_t Len2>
-decltype(auto) consteval operator+(string_literal<CharType, Len1> str1,
+consteval auto operator+(string_literal<CharType, Len1> str1,
                                    string_literal<CharType, Len2> str2) {
-  auto ret = string_literal<CharType, Len1 + Len2>{};
+  string_literal<CharType, Len1 + Len2> ret {};
   // don't use std::copy_n here to support low version stdlibc++
   for (size_t i = 0; i < Len1; ++i) {
     ret[i] = str1[i];
   }
-  for (size_t i = Len1; i < Len1 + Len2; ++i) {
-    ret[i] = str2[i - Len1];
+  for (size_t i = 0; i < Len2; ++i) {
+    ret[i + Len1] = str2[i];
   }
   return ret;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->
1. 此处返回类型直接设置为auto 优于 decltype(auto ) ，因为内部返回数据没有引用和const 修饰等。
2. 变量类型前置声明。
3. 第二个循环中，直接使用 i + Len1 作为索引，避免 i - Len1 的计算。i+offset 可读性更好

