### PR TITLE
support int128 uint128 with gcc or clang

### DIFF
--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -311,7 +311,11 @@ namespace detail {
         if constexpr (is_compatible_v<T> || trivial_view<T>) {
           return ignore_compatible_field;
         }
-        else if constexpr (std::is_enum_v<T> || std::is_fundamental_v<T>) {
+        else if constexpr (std::is_enum_v<T> || std::is_fundamental_v<T> 
+#if __GNUC__ || __clang__
+        || std::is_same_v<__int128,T> || std::is_same_v<unsigned __int128,T>
+#endif
+        ) {
           return true;
         }
         else if constexpr (array<T>) {

--- a/include/ylt/struct_pack/struct_pack_impl.hpp
+++ b/include/ylt/struct_pack/struct_pack_impl.hpp
@@ -518,8 +518,12 @@ consteval type_id get_type_id() {
   else if constexpr (std::is_enum_v<T>) {
     return get_integral_type<std::underlying_type_t<T>>();
   }
-  else if constexpr (std::is_integral_v<T> || std::is_same_v<__int128, T> ||
-                     std::is_same_v<unsigned __int128, T>) {
+  else if constexpr (std::is_integral_v<T>
+#if __GNUC__ || __CLANG__
+                     || std::is_same_v<__int128, T> ||
+                     std::is_same_v<unsigned __int128, T>
+#endif
+  ) {
     return get_integral_type<T>();
   }
   else if constexpr (std::is_floating_point_v<T>) {
@@ -574,7 +578,7 @@ consteval type_id get_type_id() {
   else {
     static_assert(!sizeof(T), "not supported type");
   }
-}
+}  // namespace detail
 
 template <size_t size>
 consteval decltype(auto) get_size_literal() {

--- a/include/ylt/struct_pack/struct_pack_impl.hpp
+++ b/include/ylt/struct_pack/struct_pack_impl.hpp
@@ -431,6 +431,15 @@ consteval type_id get_integral_type() {
                   "sizeof(bool)!=1, which is not supported.");
     return type_id::bool_t;
   }
+#if __GNUC__ || __clang__
+  //-std=gnu++20
+  else if constexpr (std::is_same_v<__int128, T>) {
+    return type_id::int128_t;
+  }
+  else if constexpr (std::is_same_v<unsigned __int128, T>) {
+    return type_id::uint128_t;
+  }
+#endif
   else {
     /*
      * Due to different data model,
@@ -521,6 +530,7 @@ consteval type_id get_type_id() {
     return get_integral_type<T>();
   }
 #if __GNUC__ || __clang__
+  //-std=c++20
   else if constexpr (std::is_same_v<__int128, T>) {
     return type_id::int128_t;
   }

--- a/include/ylt/struct_pack/struct_pack_impl.hpp
+++ b/include/ylt/struct_pack/struct_pack_impl.hpp
@@ -1907,7 +1907,7 @@ class packer {
   friend constexpr serialize_buffer_size get_needed_size(const T &t);
   writer &writer_;
   const serialize_buffer_size &info;
-};
+};  // namespace detail
 
 template <serialize_config conf = serialize_config{},
           struct_pack::writer_t Writer, typename... Args>

--- a/include/ylt/struct_pack/struct_pack_impl.hpp
+++ b/include/ylt/struct_pack/struct_pack_impl.hpp
@@ -508,6 +508,14 @@ consteval type_id get_type_id() {
   else if constexpr (std::is_integral_v<T>) {
     return get_integral_type<T>();
   }
+#if __GNUC__ && __clang__
+  else if constexpr (std::is_same_v<__int128, T>) {
+    return type_id::int128_t;
+  }
+  else if constexpr (std::is_same_v<unsigned __int128, T>) {
+    return type_id::uint128_t;
+  }
+#endif
   else if constexpr (std::is_floating_point_v<T>) {
     return get_floating_point_type<T>();
   }

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -1029,6 +1029,29 @@ TEST_CASE("compatible convert to optional") {
   CHECK(b.value() == "hello world");
   CHECK(a.value() == "hello world");
 }
+#if __GNUC__ || __clang__
+struct test_int_128 {
+  __int128_t x;
+  __uint128_t y;
+  bool operator==(const test_int_128 &) const = default;
+};
+
+TEST_CASE("test 128-bit int") {
+  __int128_t i = INT64_MAX;
+  i *= INT64_MAX;
+  CHECK(i > INT64_MAX);
+  __uint128_t j = UINT64_MAX;
+  j *= UINT64_MAX;
+  CHECK(j > UINT64_MAX);
+  auto vec = std::vector<test_int_128>{{i, j}, {-1 * i, j + UINT64_MAX}};
+  auto buffer = struct_pack::serialize(vec);
+  auto result = struct_pack::deserialize<std::vector<test_int_128>>(buffer);
+  CHECK(result == vec);
+  CHECK(struct_pack::detail::is_trivial_serializable<test_int_128>::value);
+}
+
+TEST_CASE("test uint128") {}
+#endif
 
 #if __cpp_lib_span >= 202002L
 

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -1050,7 +1050,6 @@ TEST_CASE("test 128-bit int") {
   CHECK(struct_pack::detail::is_trivial_serializable<test_int_128>::value);
 }
 
-TEST_CASE("test uint128") {}
 #endif
 
 #if __cpp_lib_span >= 202002L

--- a/website/docs/en/struct_pack/struct_pack_type_system.md
+++ b/website/docs/en/struct_pack/struct_pack_type_system.md
@@ -15,14 +15,16 @@ supported by `struct_pack`.
 
 | Type                      | Meaning                                   | code                                       |
 | ------------------------- | ----------------------------------------- | ------------------------------------------ |
-| int8_t                    | Signed fixed-length 8-bit integer         | complementary code                         |
-| int16_t                   | Signed fixed-length 16-bit integer        | complementary cod                          |
-| int32_t                   | Signed fixed-length 32-bit integer        | complementary cod                          |
-| int64_t                   | Signed fixed-length 64-bit integer        | complementary cod                          |
+| int8_t                    | Signed fixed-length 8-bit integer         | complement code                         |
+| int16_t                   | Signed fixed-length 16-bit integer        | complement code                         |
+| int32_t                   | Signed fixed-length 32-bit integer        | complement code                         |
+| int64_t                   | Signed fixed-length 64-bit integer        | complement code                         |
+| int128_t (GCC/Clang only) | Signed fixed-length 64-bit integer        | complement code                         |
 | uint8_t                   | Unsigned fixed-length 8-bit integer       | Original Code                              |
 | uint16_t                  | Unsigned fixed-length 16-bit integer      | Original Code                              |
 | uint32_t                  | Unsigned fixed-length 32-bit integer      | Original Code                              |
 | uint64_t                  | Unsigned fixed-length 64-bit integer      | Original Code                              |
+| uint128_t (GCC/Clang only)| Unsigned fixed-length 64-bit integer      | Original Code                           |
 | struct_pack::var_uint32_t | Unsigned variable-length 32-bit integer   | `varint` variable length code              |
 | struct_pack::var_uint64_t | Unsigned variable-length 64-bit integer   | `varint` variable length code              |
 | struct_pack::var_int32_t  | Signed variable-length 32-bit integers    | `varint`+`zigzag` variable length encoding |


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

complete potion TODO

## What is changing

support int128 uint128 with gcc or clang

## Example

TEST_CASE("int128/uint128") {
  using int128_t = __int128;
  using uint128_t = signed __int128;

{
  int128_t it = -2131231231213123;

  auto ts = struct_pack::serialize(it);

  auto it_ = struct_pack::deserialize<int128_t>(ts);

  CHECK(it == it_);
}

{
    uint128_t it = 2131231231213123;

  auto ts = struct_pack::serialize(it);

  auto it_ = struct_pack::deserialize<uint128_t>(ts);

  CHECK(it == it_);
}

}
