### PR TITLE
[easylog] async console log as default

### DIFF
--- a/include/ylt/easylog.hpp
+++ b/include/ylt/easylog.hpp
@@ -75,6 +75,9 @@ class logger {
  private:
   logger() {
     static appender appender{};
+    appender.start_thread();
+    appender.enable_console(true);
+    async_ = true;
     appender_ = &appender;
   }
 


### PR DESCRIPTION
## Why

async console log as default