### PR TITLE
[coro_rpc] mark the paramater as const

### DIFF
--- a/include/ylt/coro_rpc/impl/common_service.hpp
+++ b/include/ylt/coro_rpc/impl/common_service.hpp
@@ -45,7 +45,7 @@ struct ssl_configure {
  * @param path
  * @return true if file exist, otherwise false
  */
-inline bool file_exists(auto &path) {
+inline bool file_exists(const auto &path) {
   std::error_code ec;
   if (!std::filesystem::is_directory(path, ec) &&
       std::filesystem::exists(path, ec)) {


### PR DESCRIPTION
## Why
mark the paramater "path" of the function "file_exists" as const
Closes #373 
