### PR TITLE
[struct_json, struct_xml, struct_yaml][feat]inner reflection

### DIFF
--- a/include/ylt/thirdparty/iguana/json_writer.hpp
+++ b/include/ylt/thirdparty/iguana/json_writer.hpp
@@ -242,7 +242,7 @@ IGUANA_INLINE void to_json(T &&t, Stream &s) {
   s.push_back('{');
   for_each(std::forward<T>(t),
            [&t, &s](const auto &v, auto i) IGUANA__INLINE_LAMBDA {
-             using M = decltype(iguana_reflect_members(std::forward<T>(t)));
+             using M = decltype(iguana_reflect_type(std::forward<T>(t)));
              constexpr auto Idx = decltype(i)::value;
              constexpr auto Count = M::value();
              static_assert(Idx < Count);

--- a/include/ylt/thirdparty/iguana/xml_writer.hpp
+++ b/include/ylt/thirdparty/iguana/xml_writer.hpp
@@ -162,7 +162,7 @@ IGUANA_INLINE void render_xml_value(Stream &ss, T &&t, std::string_view name) {
   }
   for_each(std::forward<T>(t),
            [&](const auto &v, auto i) IGUANA__INLINE_LAMBDA {
-             using M = decltype(iguana_reflect_members(std::forward<T>(t)));
+             using M = decltype(iguana_reflect_type(std::forward<T>(t)));
              using value_type = std::remove_cvref_t<decltype(t.*v)>;
              constexpr auto Idx = decltype(i)::value;
              constexpr auto Count = M::value();

--- a/include/ylt/thirdparty/iguana/yaml_writer.hpp
+++ b/include/ylt/thirdparty/iguana/yaml_writer.hpp
@@ -153,7 +153,7 @@ template <typename Stream, typename T, std::enable_if_t<refletable_v<T>, int>>
 IGUANA_INLINE void to_yaml(T &&t, Stream &s, size_t min_spaces) {
   for_each(std::forward<T>(t),
            [&t, &s, min_spaces](const auto &v, auto i) IGUANA__INLINE_LAMBDA {
-             using M = decltype(iguana_reflect_members(std::forward<T>(t)));
+             using M = decltype(iguana_reflect_type(std::forward<T>(t)));
              constexpr auto Idx = decltype(i)::value;
              constexpr auto Count = M::value();
              static_assert(Idx < Count);

--- a/src/struct_json/examples/main.cpp
+++ b/src/struct_json/examples/main.cpp
@@ -15,6 +15,30 @@ bool operator==(const person& a, const person& b) {
 
 REFLECTION(person, name, age);
 
+class some_object {
+  int id;
+  std::string name;
+
+ public:
+  some_object() = default;
+  some_object(int i, std::string str) : id(i), name(str) {}
+  int get_id() const { return id; }
+  std::string get_name() const { return name; }
+  REFLECTION(some_object, id, name);
+};
+
+void test_inner_object() {
+  some_object obj{20, "tom"};
+  std::string str;
+  iguana::to_json(obj, str);
+  std::cout << str << "\n";
+
+  some_object obj1;
+  iguana::from_json(obj1, str);
+  assert(obj1.get_id() == 20);
+  assert(obj1.get_name() == "tom");
+}
+
 int main() {
   person p{"tom", 20};
   std::string str;
@@ -33,4 +57,6 @@ int main() {
   struct_json::parse(val, str);
   assert(val.at<std::string>("name") == "tom");
   assert(val.at<int>("age") == 20);
+
+  test_inner_object();
 }

--- a/src/struct_xml/examples/main.cpp
+++ b/src/struct_xml/examples/main.cpp
@@ -231,6 +231,30 @@ void required_field() {
   }
 }
 
+class some_object {
+  int id;
+  std::string name;
+
+ public:
+  some_object() = default;
+  some_object(int i, std::string str) : id(i), name(str) {}
+  int get_id() const { return id; }
+  std::string get_name() const { return name; }
+  REFLECTION(some_object, id, name);
+};
+
+void test_inner_object() {
+  some_object obj{20, "tom"};
+  std::string str;
+  iguana::to_xml(obj, str);
+  std::cout << str << "\n";
+
+  some_object obj1;
+  iguana::from_xml(obj1, str);
+  assert(obj1.get_id() == 20);
+  assert(obj1.get_name() == "tom");
+}
+
 int main() {
   basic_usage();
   type_to_string();
@@ -238,4 +262,5 @@ int main() {
   attribute();
   get_error();
   required_field();
+  test_inner_object();
 }

--- a/src/struct_yaml/examples/main.cpp
+++ b/src/struct_yaml/examples/main.cpp
@@ -65,4 +65,31 @@ contacts:
   iguana::from_yaml(p2, ss);
 }
 
-int main() { person_example(); }
+class some_object {
+  int id;
+  std::string name;
+
+ public:
+  some_object() = default;
+  some_object(int i, std::string str) : id(i), name(str) {}
+  int get_id() const { return id; }
+  std::string get_name() const { return name; }
+  REFLECTION(some_object, id, name);
+};
+
+void test_inner_object() {
+  some_object obj{20, "tom"};
+  std::string str;
+  iguana::to_yaml(obj, str);
+  std::cout << str << "\n";
+
+  some_object obj1;
+  iguana::from_yaml(obj1, str);
+  assert(obj1.get_id() == 20);
+  assert(obj1.get_name() == "tom");
+}
+
+int main() {
+  person_example();
+  test_inner_object();
+}


### PR DESCRIPTION
## Why

support inner reflection:
```c++
class some_object {
  int id;
  std::string name;

 public:
  some_object() = default;
  some_object(int i, std::string str) : id(i), name(str) {}
  int get_id() const { return id; }
  std::string get_name() const { return name; }
  REFLECTION(some_object, id, name);
};

void test_inner_object() {
  some_object obj{20, "tom"};
  std::string str;
  iguana::to_yaml(obj, str);
  std::cout << str << "\n";

  some_object obj1;
  iguana::from_yaml(obj1, str);
  assert(obj1.get_id() == 20);
  assert(obj1.get_name() == "tom");
}
```
