### PR TITLE
[struct_xml, struct_json, struct_yaml][feat]support shared_ptr

### DIFF
--- a/include/ylt/thirdparty/iguana/json_writer.hpp
+++ b/include/ylt/thirdparty/iguana/json_writer.hpp
@@ -24,7 +24,7 @@ template <typename Stream, typename T,
 IGUANA_INLINE void render_json_value(Stream &ss, const T &v);
 
 template <typename Stream, typename T,
-          std::enable_if_t<unique_ptr_v<T>, int> = 0>
+          std::enable_if_t<smart_ptr_v<T>, int> = 0>
 IGUANA_INLINE void render_json_value(Stream &ss, const T &v);
 
 template <typename Stream, typename T,
@@ -203,7 +203,7 @@ constexpr auto write_json_key = [](auto &s, auto i,
   s.push_back('"');
 };
 
-template <typename Stream, typename T, std::enable_if_t<unique_ptr_v<T>, int>>
+template <typename Stream, typename T, std::enable_if_t<smart_ptr_v<T>, int>>
 IGUANA_INLINE void render_json_value(Stream &ss, const T &v) {
   if (v) {
     render_json_value(ss, *v);

--- a/include/ylt/thirdparty/iguana/util.hpp
+++ b/include/ylt/thirdparty/iguana/util.hpp
@@ -123,6 +123,13 @@ constexpr inline bool unique_ptr_v =
     is_template_instant_of<std::unique_ptr, std::remove_cvref_t<T>>::value;
 
 template <typename T>
+constexpr inline bool shared_ptr_v =
+    is_template_instant_of<std::shared_ptr, std::remove_cvref_t<T>>::value;
+
+template <typename T>
+constexpr inline bool smart_ptr_v = shared_ptr_v<T> || unique_ptr_v<T>;
+
+template <typename T>
 struct is_variant : std::false_type {};
 
 template <typename... T>
@@ -134,7 +141,7 @@ constexpr inline bool variant_v = is_variant<std::remove_cvref_t<T>>::value;
 template <class T>
 constexpr inline bool non_refletable_v =
     container_v<T> || c_array_v<T> || tuple_v<T> || optional_v<T> ||
-    unique_ptr_v<T> || std::is_fundamental_v<std::remove_cvref_t<T>> ||
+    smart_ptr_v<T> || std::is_fundamental_v<std::remove_cvref_t<T>> ||
     variant_v<T>;
 
 template <typename T>
@@ -143,6 +150,29 @@ constexpr inline bool refletable_v = is_reflection_v<std::remove_cvref_t<T>>;
 template <typename T>
 constexpr inline bool plain_v =
     string_container_v<T> || num_v<T> || char_v<T> || bool_v<T> || enum_v<T>;
+
+template <typename T>
+struct underline_type {
+  using type = T;
+};
+
+template <typename T>
+struct underline_type<std::unique_ptr<T>> {
+  using type = typename underline_type<T>::type;
+};
+
+template <typename T>
+struct underline_type<std::shared_ptr<T>> {
+  using type = typename underline_type<T>::type;
+};
+
+template <typename T>
+struct underline_type<std::optional<T>> {
+  using type = typename underline_type<T>::type;
+};
+
+template <typename T>
+using underline_type_t = typename underline_type<std::remove_cvref_t<T>>::type;
 
 template <char... C, typename It>
 IGUANA_INLINE void match(It &&it, It &&end) {

--- a/include/ylt/thirdparty/iguana/xml_reader.hpp
+++ b/include/ylt/thirdparty/iguana/xml_reader.hpp
@@ -12,7 +12,7 @@ template <typename U, typename It, std::enable_if_t<optional_v<U>, int> = 0>
 IGUANA_INLINE void parse_item(U &value, It &&it, It &&end,
                               std::string_view name);
 
-template <typename U, typename It, std::enable_if_t<unique_ptr_v<U>, int> = 0>
+template <typename U, typename It, std::enable_if_t<smart_ptr_v<U>, int> = 0>
 IGUANA_INLINE void parse_item(U &value, It &&it, It &&end,
                               std::string_view name);
 
@@ -178,10 +178,16 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end,
   }
 }
 
-template <typename U, typename It, std::enable_if_t<unique_ptr_v<U>, int>>
+template <typename U, typename It, std::enable_if_t<smart_ptr_v<U>, int>>
 IGUANA_INLINE void parse_item(U &value, It &&it, It &&end,
                               std::string_view name) {
-  value = std::make_unique<typename std::remove_cvref_t<U>::element_type>();
+  if constexpr (unique_ptr_v<U>) {
+    value = std::make_unique<typename std::remove_cvref_t<U>::element_type>();
+  }
+  else {
+    value = std::make_shared<typename std::remove_cvref_t<U>::element_type>();
+  }
+
   parse_item(*value, it, end, name);
 }
 

--- a/include/ylt/thirdparty/iguana/xml_writer.hpp
+++ b/include/ylt/thirdparty/iguana/xml_writer.hpp
@@ -119,7 +119,7 @@ IGUANA_INLINE void render_xml_value(Stream &ss, const T &value,
 }
 
 template <bool pretty, size_t spaces, typename Stream, typename T,
-          std::enable_if_t<unique_ptr_v<T>, int> = 0>
+          std::enable_if_t<smart_ptr_v<T>, int> = 0>
 IGUANA_INLINE void render_xml_value(Stream &ss, const T &value,
                                     std::string_view name) {
   if (value) {
@@ -142,7 +142,8 @@ template <bool pretty, size_t spaces, typename Stream, typename T,
           std::enable_if_t<sequence_container_v<T>, int>>
 IGUANA_INLINE void render_xml_value(Stream &ss, const T &value,
                                     std::string_view name) {
-  using value_type = typename std::remove_cvref_t<T>::value_type;
+  using value_type =
+      underline_type_t<typename std::remove_cvref_t<T>::value_type>;
   for (const auto &v : value) {
     if constexpr (attr_v<value_type>) {
       render_xml_value<pretty, spaces>(ss, v, name);
@@ -163,7 +164,7 @@ IGUANA_INLINE void render_xml_value(Stream &ss, T &&t, std::string_view name) {
   for_each(std::forward<T>(t),
            [&](const auto &v, auto i) IGUANA__INLINE_LAMBDA {
              using M = decltype(iguana_reflect_type(std::forward<T>(t)));
-             using value_type = std::remove_cvref_t<decltype(t.*v)>;
+             using value_type = underline_type_t<decltype(t.*v)>;
              constexpr auto Idx = decltype(i)::value;
              constexpr auto Count = M::value();
              constexpr std::string_view tag_name =

--- a/include/ylt/thirdparty/iguana/yaml_reader.hpp
+++ b/include/ylt/thirdparty/iguana/yaml_reader.hpp
@@ -241,7 +241,7 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end, size_t min_spaces) {
 template <typename U, typename It, std::enable_if_t<optional_v<U>, int> = 0>
 IGUANA_INLINE void parse_item(U &value, It &&it, It &&end, size_t min_spaces);
 
-template <typename U, typename It, std::enable_if_t<unique_ptr_v<U>, int> = 0>
+template <typename U, typename It, std::enable_if_t<smart_ptr_v<U>, int> = 0>
 IGUANA_INLINE void parse_item(U &value, It &&it, It &&end, size_t min_spaces);
 
 // minspaces : The minimum indentation
@@ -418,12 +418,17 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end, size_t min_spaces) {
   }
 }
 
-template <typename U, typename It, std::enable_if_t<unique_ptr_v<U>, int>>
+template <typename U, typename It, std::enable_if_t<smart_ptr_v<U>, int>>
 IGUANA_INLINE void parse_item(U &value, It &&it, It &&end, size_t min_spaces) {
   using T = std::remove_reference_t<U>;
-  value = std::make_unique<typename T::element_type>();
+  if constexpr (unique_ptr_v<T>) {
+    value = std::make_unique<typename T::element_type>();
+  }
+  else {
+    value = std::make_shared<typename T::element_type>();
+  }
   static_assert(!string_v<typename T::element_type>,
-                "unique_ptr<string> is not allowed");
+                "smart_ptr<string> is not allowed");
   parse_item(*value, it, end, min_spaces);
 }
 

--- a/include/ylt/thirdparty/iguana/yaml_writer.hpp
+++ b/include/ylt/thirdparty/iguana/yaml_writer.hpp
@@ -80,7 +80,7 @@ IGUANA_INLINE void render_yaml_value(Stream &ss, const T &val,
                                      size_t min_spaces);
 
 template <typename Stream, typename T,
-          std::enable_if_t<unique_ptr_v<T>, int> = 0>
+          std::enable_if_t<smart_ptr_v<T>, int> = 0>
 IGUANA_INLINE void render_yaml_value(Stream &ss, const T &val,
                                      size_t min_spaces);
 
@@ -132,7 +132,7 @@ IGUANA_INLINE void render_yaml_value(Stream &ss, const T &val,
   }
 }
 
-template <typename Stream, typename T, std::enable_if_t<unique_ptr_v<T>, int>>
+template <typename Stream, typename T, std::enable_if_t<smart_ptr_v<T>, int>>
 IGUANA_INLINE void render_yaml_value(Stream &ss, const T &val,
                                      size_t min_spaces) {
   if (!val) {
@@ -174,7 +174,7 @@ template <typename Stream, typename T,
           std::enable_if_t<non_refletable_v<T>, int> = 0>
 IGUANA_INLINE void to_yaml(T &&t, Stream &s) {
   if constexpr (tuple_v<T> || map_container_v<T> || sequence_container_v<T> ||
-                optional_v<T> || unique_ptr_v<T>)
+                optional_v<T> || smart_ptr_v<T>)
     render_yaml_value(s, std::forward<T>(t), 0);
   else
     static_assert(!sizeof(T), "don't suppport this type");

--- a/src/struct_xml/examples/main.cpp
+++ b/src/struct_xml/examples/main.cpp
@@ -255,7 +255,32 @@ void test_inner_object() {
   assert(obj1.get_name() == "tom");
 }
 
+struct shared_object {
+  std::shared_ptr<std::vector<std::shared_ptr<int>>> vec;
+  std::string b;
+  std::shared_ptr<int> c;
+  std::vector<std::shared_ptr<int>> d;
+};
+REFLECTION(shared_object, vec, b, c, d);
+
+void test_sp() {
+  auto vec = std::make_shared<std::vector<std::shared_ptr<int>>>();
+  vec->push_back(std::make_unique<int>(42));
+  vec->push_back(std::make_unique<int>(21));
+  shared_object contents{std::move(vec),
+                         "test",
+                         std::make_shared<int>(24),
+                         {std::make_shared<int>(1), std::make_shared<int>(4)}};
+  std::string str;
+  iguana::to_xml(contents, str);
+
+  shared_object cont;
+  iguana::from_xml(cont, str);  // throw exception.
+  std::cout << cont.b << "\n";
+}
+
 int main() {
+  test_sp();
   basic_usage();
   type_to_string();
   nested_xml();


### PR DESCRIPTION
## Why

support smart pointer in struct.

## What is changing

## Example

```c++
struct shared_object {
  std::shared_ptr<std::vector<std::shared_ptr<int>>> vec;
  std::string b;
  std::shared_ptr<int> c;
  std::vector<std::shared_ptr<int>> d;
};
REFLECTION(shared_object, vec, b, c, d);

void test_sp() {
  auto vec = std::make_shared<std::vector<std::shared_ptr<int>>>();
  vec->push_back(std::make_unique<int>(42));
  vec->push_back(std::make_unique<int>(21));
  shared_object contents{std::move(vec),
                         "test",
                         std::make_shared<int>(24),
                         {std::make_shared<int>(1), std::make_shared<int>(4)}};
  std::string str;
  iguana::to_xml(contents, str);

  shared_object cont;
  iguana::from_xml(cont, str);  // throw exception.
  std::cout << cont.b << "\n";
}
```