### PR TITLE
[struct_json, struct_xml, struct_yaml][feat]support alias

### DIFF
--- a/src/struct_xml/examples/main.cpp
+++ b/src/struct_xml/examples/main.cpp
@@ -279,7 +279,38 @@ void test_sp() {
   std::cout << cont.b << "\n";
 }
 
+struct next_obj_t {
+  int x;
+  int y;
+};
+REFLECTION_ALIAS(next_obj_t, "next", FLDALIAS(&next_obj_t::x, "w"),
+                 FLDALIAS(&next_obj_t::y, "h"));
+
+struct out_object {
+  std::unique_ptr<int> id;
+  std::string_view name;
+  next_obj_t obj;
+  REFLECTION_ALIAS(out_object, "qi", FLDALIAS(&out_object::id, "i"),
+                   FLDALIAS(&out_object::name, "na"),
+                   FLDALIAS(&out_object::obj, "obj"));
+};
+
+void test_alias() {
+  out_object m{std::make_unique<int>(20), "tom", {21, 42}};
+  std::string xml_str;
+  iguana::to_xml(m, xml_str);
+
+  std::cout << xml_str << "\n";
+
+  out_object m1;
+  iguana::from_xml(m1, xml_str);
+  assert(m1.name == "tom");
+  assert(m1.obj.x == 21);
+  assert(m1.obj.y == 42);
+}
+
 int main() {
+  test_alias();
   test_sp();
   basic_usage();
   type_to_string();


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

support reflect with  alias.

## What is changing

## Example
```c++
struct next_obj_t {
  int x;
  int y;
};

// struct alias name and fileds alias names.
REFLECTION_ALIAS(next_obj_t, "next", FLDALIAS(&next_obj_t::x, "w"),
                 FLDALIAS(&next_obj_t::y, "h"));

struct out_object {
  std::unique_ptr<int> id;
  std::string_view name;
  next_obj_t obj;
  REFLECTION_ALIAS(out_object, "qi", FLDALIAS(&out_object::id, "i"),
                   FLDALIAS(&out_object::name, "na"),
                   FLDALIAS(&out_object::obj, "obj"));
};

void test_alias() {
  out_object m{std::make_unique<int>(20), "tom", {21, 42}};
  std::string xml_str;
  iguana::to_xml(m, xml_str);

  std::cout << xml_str << "\n";

  out_object m1;
  iguana::from_xml(m1, xml_str);
  assert(m1.name == "tom");
  assert(m1.obj.x == 21);
  assert(m1.obj.y == 42);
}
```