### PR TITLE
[coro_rpc][bugfix] fix example client

### DIFF
--- a/include/ylt/coro_io/client_pool.hpp
+++ b/include/ylt/coro_io/client_pool.hpp
@@ -133,7 +133,8 @@ class client_pool : public std::enable_shared_from_this<
             std::this_thread::yield();
             ++cnt;
             if (cnt % 10000 == 0) {
-              ELOG_WARN << "spinlock of client{" << client.get()
+              ELOG_WARN << "spinlock of client{" << client.get() << "},host:{"
+                        << client->get_host() << ":" << client->get_port()
                         << "}cost too much time, spin count: " << cnt;
             }
           }
@@ -167,7 +168,8 @@ class client_pool : public std::enable_shared_from_this<
       if (wait_time.count() > 0)
         co_await coro_io::sleep_for(wait_time);
     }
-    ELOG_WARN << "reconnect client{" << client.get()
+    ELOG_WARN << "reconnect client{" << client.get() << "},host:{"
+              << client->get_host() << ":" << client->get_port()
               << "} out of max limit, stop retry. connect failed";
     client = nullptr;
   }

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -31,44 +31,45 @@ Lazy<void> show_rpc_call() {
   assert(ec == std::errc{});
   auto ret = co_await client.call<hello_world>();
   if (!ret) {
-    std::cout << "err: " << ret.error().msg << std::endl;
+    std::cout << "hello_world err: " << ret.error().msg << std::endl;
   }
   assert(ret.value() == "hello_world"s);
 
   auto ret_int = co_await client.call<A_add_B>(12, 30);
   if (!ret_int) {
-    std::cout << "err: " << ret_int.error().msg << std::endl;
+    std::cout << "A_add_B err: " << ret_int.error().msg << std::endl;
   }
   assert(ret_int.value() == 42);
 
   ret = co_await client.call<coro_echo>("coro_echo");
   if (!ret) {
-    std::cout << "err: " << ret.error().msg << std::endl;
+    std::cout << "coro_echo err: " << ret.error().msg << std::endl;
   }
   assert(ret.value() == "coro_echo"s);
 
   ret = co_await client.call<hello_with_delay>("hello_with_delay"s);
   if (!ret) {
-    std::cout << "err: " << ret.error().msg << std::endl;
+    std::cout << "hello_with_delay err: " << ret.error().msg << std::endl;
   }
   assert(ret.value() == "hello_with_delay"s);
 
-  ret = co_await client.call<nested_echo>("hello_with_delay"s);
+  ret = co_await client.call<nested_echo>("nested_echo"s);
   if (!ret) {
-    std::cout << "err: " << ret.error().msg << std::endl;
+    std::cout << "nested_echo err: " << ret.error().msg << std::endl;
   }
-  assert(ret.value() == "hello_with_delay"s);
+  assert(ret.value() == "nested_echo"s);
 
   ret = co_await client.call<&HelloService::hello>();
   if (!ret) {
-    std::cout << "err: " << ret.error().msg << std::endl;
+    std::cout << "HelloService::hello err: " << ret.error().msg << std::endl;
   }
   assert(ret.value() == "HelloService::hello"s);
 
   ret = co_await client.call<&HelloService::hello_with_delay>(
       "HelloService::hello_with_delay"s);
   if (!ret) {
-    std::cout << "err: " << ret.error().msg << std::endl;
+    std::cout << "HelloService::hello_with_delay err: " << ret.error().msg
+              << std::endl;
   }
   assert(ret.value() == "HelloService::hello_with_delay"s);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

The example client crash because we forget regist rpc function `nested_echo`. fix it.

## What is changing

## Example