### PR TITLE
support fmt/std::format

### DIFF
--- a/include/ylt/easylog/record.hpp
+++ b/include/ylt/easylog/record.hpp
@@ -194,16 +194,21 @@ class record_t {
   }
 
   template <typename... Args>
-  record_t &sprintf(const char *fmt, Args... args) {
-    printf_string_format(fmt, args...);
+  record_t &sprintf(const char *fmt, Args &&...args) {
+    printf_string_format(fmt, std::forward<Args>(args)...);
+    return *this;
+  }
 
+  template <typename String>
+  record_t &format(String &&str) {
+    ss_.append(str.data());
     return *this;
   }
 
  private:
   template <typename... Args>
-  void printf_string_format(const char *fmt, Args... args) {
-    size_t size = snprintf(nullptr, 0, fmt, args...);
+  void printf_string_format(const char *fmt, Args &&...args) {
+    size_t size = snprintf(nullptr, 0, fmt, std::forward<Args>(args)...);
 
 #ifdef YLT_ENABLE_PMR
 #if __has_include(<memory_resource>)

--- a/src/easylog/tests/test_easylog.cpp
+++ b/src/easylog/tests/test_easylog.cpp
@@ -73,6 +73,11 @@ TEST_CASE("test basic") {
   auto id = std::this_thread::get_id();
   ELOG_INFO << buf << ", " << str << ", " << sv << ", " << id;
 
+#if defined(HAS_FMT_LIB) || defined(HAS_STD_FORMAT)
+  ELOGFMT(INFO, "{} {}", 20, 42);
+  ELOGFMT(INFO, "it is a long string test {} {}", 42, "fmt");
+#endif
+
   ELOGV(INFO, "test");
   ELOGV(INFO, "it is a long string test %d %s", 2, "ok");
   CHECK(get_last_line(filename).rfind("test 2 ok") != std::string::npos);


### PR DESCRIPTION
## Why

support fmt and std::format.

## What is changing

## Example

```c++
#if defined(HAS_FMT_LIB) || defined(HAS_STD_FORMAT)
  ELOGFMT(INFO, "{} {}", 20, 42);
  ELOGFMT(INFO, "it is a long string test {} {}", 42, "fmt");
#endif
```