### PR TITLE
[easylog][improve]remove some define

### DIFF
--- a/include/ylt/easylog.hpp
+++ b/include/ylt/easylog.hpp
@@ -19,18 +19,15 @@
 #include <utility>
 #include <vector>
 
-#ifdef HAS_STD_FORMAT
 #if __has_include(<format>)
 #include <format>
 #endif
-#endif
 
-#ifdef HAS_FMT_LIB
+#if __has_include(<fmt/format.h>)
 #ifndef FMT_HEADER_ONLY
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #endif
-
 #endif
 
 #include "easylog/appender.hpp"
@@ -232,7 +229,7 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
   ELOGV_IMPL(easylog::Severity::severity, Id, __VA_ARGS__, "\n")
 #endif
 
-#if defined(HAS_FMT_LIB) || defined(HAS_STD_FORMAT)
+#if __has_include(<fmt/format.h>) || __has_include(<format>)
 
 #define ELOGFMT_IMPL0(severity, Id, prefix, format_str, ...)          \
   if (!easylog::logger<Id>::instance().check_severity(severity)) {    \
@@ -249,12 +246,12 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
     }                                                                 \
   }
 
-#ifdef HAS_FMT_LIB
+#if __has_include(<fmt/format.h>)
 #define ELOGFMT_IMPL(severity, Id, ...) \
   ELOGFMT_IMPL0(severity, Id, fmt, __VA_ARGS__)
 #endif
 
-#ifdef HAS_STD_FORMAT
+#if __has_include(<format>)
 #define ELOGFMT_IMPL(severity, Id, ...) \
   ELOGFMT_IMPL0(severity, Id, std, __VA_ARGS__)
 #endif

--- a/src/easylog/tests/test_easylog.cpp
+++ b/src/easylog/tests/test_easylog.cpp
@@ -73,7 +73,7 @@ TEST_CASE("test basic") {
   auto id = std::this_thread::get_id();
   ELOG_INFO << buf << ", " << str << ", " << sv << ", " << id;
 
-#if defined(HAS_FMT_LIB) || defined(HAS_STD_FORMAT)
+#if __has_include(<fmt/format.h>) || __has_include(<format>)
   ELOGFMT(INFO, "{} {}", 20, 42);
   ELOGFMT(INFO, "it is a long string test {} {}", 42, "fmt");
 #endif

--- a/src/easylog/tests/test_easylog.cpp
+++ b/src/easylog/tests/test_easylog.cpp
@@ -73,7 +73,7 @@ TEST_CASE("test basic") {
   auto id = std::this_thread::get_id();
   ELOG_INFO << buf << ", " << str << ", " << sv << ", " << id;
 
-#if __has_include(<fmt/format.h>) || __has_include(<format>)
+#if __has_include(<fmt/format.h>) || (__has_include(<format>) && !defined(__APPLE__))
   ELOGFMT(INFO, "{} {}", 20, 42);
   ELOGFMT(INFO, "it is a long string test {} {}", 42, "fmt");
 #endif

--- a/website/docs/zh/easylog/easylog_introduction.md
+++ b/website/docs/zh/easylog/easylog_introduction.md
@@ -23,13 +23,8 @@ ELOG(INFO) << "easylog " << 42;
 // printf输出
 ELOGV(INFO, "easylog %d", 42);
 
-// fmt::format 输出
-#if defined(HAS_FMT_LIB)
-  ELOGFMT(INFO, "easylog {}", 42);
-#endif
-
-// std::format 输出
-#if defined(HAS_STD_FORMAT)
+// fmt::format/std::format 输出
+#if __has_include(<fmt/format.h>) || __has_include(<format>)
   ELOGFMT(INFO, "easylog {}", 42);
 #endif
 ```


### PR DESCRIPTION
## Why

remove HAS_FMT_LIB and HAS_STD_FORMAT simplify usage.

## What is changing

## Example

```c++
// fmt::format/std::format stream
#if __has_include(<fmt/format.h>) || __has_include(<format>)
  ELOGFMT(INFO, "easylog {}", 42);
#endif
```