### PR TITLE
treat the same with WARN/WARNING and CRITICAL/FATAL

### DIFF
--- a/include/ylt/easylog.hpp
+++ b/include/ylt/easylog.hpp
@@ -243,7 +243,7 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
                           GET_STRING(__FILE__, __LINE__))             \
             .format(prefix::format(format_str, __VA_ARGS__));         \
     if (severity == easylog::Severity::CRITICAL ||                    \
-        record.get_severity() == Severity::FATAL) {                   \
+        severity == Severity::FATAL) {                                \
       easylog::flush<Id>();                                           \
       std::exit(EXIT_FAILURE);                                        \
     }                                                                 \

--- a/include/ylt/easylog.hpp
+++ b/include/ylt/easylog.hpp
@@ -52,7 +52,8 @@ class logger {
       append_format(record);
     }
 
-    if (record.get_severity() == Severity::CRITICAL) {
+    if (record.get_severity() == Severity::CRITICAL ||
+        record.get_severity() == Severity::FATAL) {
       flush();
       std::exit(EXIT_FAILURE);
     }
@@ -213,7 +214,8 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
         easylog::record_t(std::chrono::system_clock::now(), severity, \
                           GET_STRING(__FILE__, __LINE__))             \
             .sprintf(fmt, __VA_ARGS__);                               \
-    if (severity == easylog::Severity::CRITICAL) {                    \
+    if (severity == easylog::Severity::CRITICAL ||                    \
+        severity == easylog::Severity::FATAL) {                       \
       easylog::flush<Id>();                                           \
       std::exit(EXIT_FAILURE);                                        \
     }                                                                 \
@@ -240,7 +242,8 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
         easylog::record_t(std::chrono::system_clock::now(), severity, \
                           GET_STRING(__FILE__, __LINE__))             \
             .format(prefix::format(format_str, __VA_ARGS__));         \
-    if (severity == easylog::Severity::CRITICAL) {                    \
+    if (severity == easylog::Severity::CRITICAL ||                    \
+        record.get_severity() == Severity::FATAL) {                   \
       easylog::flush<Id>();                                           \
       std::exit(EXIT_FAILURE);                                        \
     }                                                                 \
@@ -285,6 +288,9 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
 #ifndef ELOG_CRITICAL
 #define ELOG_CRITICAL ELOG(CRITICAL)
 #endif
+#ifndef ELOG_FATAL
+#define ELOG_FATAL ELOG(FATAL)
+#endif
 
 #ifndef MELOG_TRACE
 #define MELOG_TRACE(id) ELOG(INFO, id)
@@ -301,8 +307,8 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
 #ifndef MELOG_ERROR
 #define MELOG_ERROR(id) ELOG(ERROR, id)
 #endif
-#ifndef MELOG_CRITICAL
-#define MELOG_CRITICAL(id) ELOG(CRITICAL, id)
+#ifndef MELOG_FATAL
+#define MELOG_FATAL(id) ELOG(FATAL, id)
 #endif
 
 #ifndef ELOGT
@@ -322,4 +328,7 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
 #endif
 #ifndef ELOGC
 #define ELOGC ELOG_CRITICAL
+#endif
+#ifndef ELOGF
+#define ELOGF ELOG_FATAL
 #endif

--- a/include/ylt/easylog/appender.hpp
+++ b/include/ylt/easylog/appender.hpp
@@ -242,11 +242,11 @@ class appender {
 
   void add_color(Severity severity) {
 #if defined(_WIN32)
-    if (severity == Severity::WARN)
+    if (severity == Severity::WARN || severity == Severity::WARNING)
       windows_set_color(color_type::black, color_type::yellow);
     if (severity == Severity::ERROR)
       windows_set_color(color_type::black, color_type::red);
-    if (severity == Severity::CRITICAL)
+    if (severity == Severity::CRITICAL || severity == Severity::FATAL)
       windows_set_color(color_type::white_bright, color_type::red);
 #elif __APPLE__
 #else

--- a/src/easylog/tests/test_easylog.cpp
+++ b/src/easylog/tests/test_easylog.cpp
@@ -89,7 +89,6 @@ TEST_CASE("test basic") {
 
   ELOG(WARN) << "warn";
   ELOG(WARNING) << "warning";
-  ELOG(FATAL) << "fatal";
 
   ELOG(INFO) << "test log";
   easylog::flush();


### PR DESCRIPTION
## Why

Close #438 

## What is changing

## Example

```c++
ELOG(CRITICAL) same with ELOG(FATAL)
ELOG(WARN) same with ELOG(WARNING)
```