### PR TITLE
[struct_json][fix]fix json

### DIFF
--- a/include/ylt/thirdparty/iguana/json_reader.hpp
+++ b/include/ylt/thirdparty/iguana/json_reader.hpp
@@ -451,8 +451,6 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end) {
 template <typename U, typename It, std::enable_if_t<smart_ptr_v<U>, int>>
 IGUANA_INLINE void parse_item(U &value, It &&it, It &&end) {
   skip_ws(it, end);
-  if (it < end && *it == '"')
-    IGUANA_LIKELY { ++it; }
   if (it == end)
     IGUANA_UNLIKELY { throw std::runtime_error("Unexexpected eof"); }
   if (*it == 'n') {

--- a/src/struct_json/examples/main.cpp
+++ b/src/struct_json/examples/main.cpp
@@ -52,7 +52,7 @@ void use_smart_pointer() {
   iguana::to_json(p, str);
 
   person1 p1;
-  iguana::from_json(p1, str); // here throw exception
+  iguana::from_json(p1, str);  // here throw exception
 
   assert(*p1.name == "tom");
   assert(*p1.age == 42);

--- a/src/struct_json/examples/main.cpp
+++ b/src/struct_json/examples/main.cpp
@@ -39,6 +39,25 @@ void test_inner_object() {
   assert(obj1.get_name() == "tom");
 }
 
+struct person1 {
+  std::shared_ptr<std::string> name;
+  std::unique_ptr<int64_t> age;
+};
+REFLECTION(person1, name, age);
+
+void use_smart_pointer() {
+  person1 p{std::make_shared<std::string>("tom"),
+            std::make_unique<int64_t>(42)};
+  std::string str;
+  iguana::to_json(p, str);
+
+  person1 p1;
+  iguana::from_json(p1, str); // here throw exception
+
+  assert(*p1.name == "tom");
+  assert(*p1.age == 42);
+}
+
 int main() {
   person p{"tom", 20};
   std::string str;
@@ -59,4 +78,5 @@ int main() {
   assert(val.at<int>("age") == 20);
 
   test_inner_object();
+  use_smart_pointer();
 }

--- a/src/struct_json/examples/main.cpp
+++ b/src/struct_json/examples/main.cpp
@@ -52,7 +52,7 @@ void use_smart_pointer() {
   iguana::to_json(p, str);
 
   person1 p1;
-  iguana::from_json(p1, str);  // here throw exception
+  iguana::from_json(p1, str);
 
   assert(*p1.name == "tom");
   assert(*p1.age == 42);


### PR DESCRIPTION
## Why

fix a bug in from_json.

## What is changing

## Example

```c++
struct person1 {
  std::shared_ptr<std::string> name;
  std::unique_ptr<int64_t> age;
};
REFLECTION(person1, name, age);

void use_smart_pointer() {
  person1 p{std::make_shared<std::string>("tom"),
            std::make_unique<int64_t>(42)};
  std::string str;
  iguana::to_json(p, str);

  person1 p1;
  iguana::from_json(p1, str); 

  assert(*p1.name == "tom");
  assert(*p1.age == 42);
}
```