### PR TITLE
[easylog] [improve]优化日志级别的使用

### DIFF
--- a/include/ylt/easylog.hpp
+++ b/include/ylt/easylog.hpp
@@ -52,8 +52,7 @@ class logger {
       append_format(record);
     }
 
-    if (record.get_severity() == Severity::CRITICAL ||
-        record.get_severity() == Severity::FATAL) {
+    if (record.get_severity() == Severity::CRITICAL) {
       flush();
       std::exit(EXIT_FAILURE);
     }
@@ -214,8 +213,7 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
         easylog::record_t(std::chrono::system_clock::now(), severity, \
                           GET_STRING(__FILE__, __LINE__))             \
             .sprintf(fmt, __VA_ARGS__);                               \
-    if (severity == easylog::Severity::CRITICAL ||                    \
-        severity == easylog::Severity::FATAL) {                       \
+    if (severity == easylog::Severity::CRITICAL) {                    \
       easylog::flush<Id>();                                           \
       std::exit(EXIT_FAILURE);                                        \
     }                                                                 \
@@ -242,8 +240,7 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
         easylog::record_t(std::chrono::system_clock::now(), severity, \
                           GET_STRING(__FILE__, __LINE__))             \
             .format(prefix::format(format_str, __VA_ARGS__));         \
-    if (severity == easylog::Severity::CRITICAL ||                    \
-        severity == Severity::FATAL) {                                \
+    if (severity == easylog::Severity::CRITICAL) {                    \
       easylog::flush<Id>();                                           \
       std::exit(EXIT_FAILURE);                                        \
     }                                                                 \

--- a/include/ylt/easylog/appender.hpp
+++ b/include/ylt/easylog/appender.hpp
@@ -242,19 +242,19 @@ class appender {
 
   void add_color(Severity severity) {
 #if defined(_WIN32)
-    if (severity == Severity::WARN || severity == Severity::WARNING)
+    if (severity == Severity::WARN)
       windows_set_color(color_type::black, color_type::yellow);
     if (severity == Severity::ERROR)
       windows_set_color(color_type::black, color_type::red);
-    if (severity == Severity::CRITICAL || severity == Severity::FATAL)
+    if (severity == Severity::CRITICAL)
       windows_set_color(color_type::white_bright, color_type::red);
 #elif __APPLE__
 #else
-    if (severity == Severity::WARN || severity == Severity::WARNING)
+    if (severity == Severity::WARN)
       std::cout << "\x1B[93m";
     if (severity == Severity::ERROR)
       std::cout << "\x1B[91m";
-    if (severity == Severity::CRITICAL || severity == Severity::FATAL)
+    if (severity == Severity::CRITICAL)
       std::cout << "\x1B[97m\x1B[41m";
 #endif
   }

--- a/include/ylt/easylog/record.hpp
+++ b/include/ylt/easylog/record.hpp
@@ -81,15 +81,15 @@ constexpr inline bool has_str_v = has_str<std::remove_cvref_t<T>>::value;
 }  // namespace detail
 
 enum class Severity {
-  NONE = 0,
-  TRACE = 1,
-  DEBUG = 2,
-  INFO = 3,
-  WARN = 4,
-  WARNING = 5,
-  ERROR = 6,
-  CRITICAL = 7,
-  FATAL = 8,
+  NONE,
+  TRACE,
+  DEBUG,
+  INFO,
+  WARN,
+  WARNING = WARN,
+  ERROR,
+  CRITICAL,
+  FATAL = CRITICAL,
 };
 
 inline std::string_view severity_str(Severity severity) {
@@ -101,12 +101,10 @@ inline std::string_view severity_str(Severity severity) {
     case Severity::INFO:
       return "INFO    ";
     case Severity::WARN:
-    case Severity::WARNING:
       return "WARNING ";
     case Severity::ERROR:
       return "ERROR   ";
     case Severity::CRITICAL:
-    case Severity::FATAL:
       return "CRITICAL";
     default:
       return "NONE    ";

--- a/website/docs/zh/easylog/easylog_introduction.md
+++ b/website/docs/zh/easylog/easylog_introduction.md
@@ -34,15 +34,15 @@ ELOGV(INFO, "easylog %d", 42);
 easylog 定义了如下日志级别：
 ```c++
 enum class Severity {
-  NONE = 0,
-  TRACE = 1,
-  DEBUG = 2,
-  INFO = 3,
-  WARN = 4,
-  WARNING = 5,
-  ERROR = 6,
-  CRITICAL = 7,
-  FATAL = 8,
+  NONE,
+  TRACE,
+  DEBUG,
+  INFO,
+  WARN,
+  WARNING = WARN,
+  ERROR,
+  CRITICAL,
+  FATAL = CRITICAL,
 };
 ```
 用户可以根据需要输出这几种级别的日志，默认的日志级别是DEBUG，其中WARN 和 WARNING 是等价的，CRITICAL 和FATAL 是等价的，主要是为了适配其它日志库。


### PR DESCRIPTION
## Why
根据enum可以数值相等的特性，把等价的日志级别设为数值一致。然后可以减少对日志级别的判断

