### PR TITLE
[struct_pack][feat] add support for user_defined type id

### DIFF
--- a/include/ylt/struct_pack/md5_constexpr.hpp
+++ b/include/ylt/struct_pack/md5_constexpr.hpp
@@ -38,11 +38,11 @@ struct string_literal {
 
   constexpr bool empty() const { return !Size; }
 
-  constexpr char &operator[](std::size_t sz) { return ar[sz]; }
+  constexpr CharType &operator[](std::size_t sz) { return ar[sz]; }
 
   constexpr const char &operator[](std::size_t sz) const { return ar[sz]; }
 
-  constexpr const char *data() const { return &ar[0]; }
+  constexpr const CharType *data() const { return &ar[0]; }
 
  private:
   CharType ar[Size + 1];

--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -49,6 +49,11 @@ using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 #endif
 }
 
+template <typename T>
+[[noreturn]] constexpr T declval() {
+  unreachable();
+}
+
 template <typename U>
 constexpr auto get_types();
 
@@ -81,6 +86,28 @@ template <typename T>
 constexpr std::size_t pack_alignment_v = 0;
 template <typename T>
 constexpr std::size_t alignment_v = 0;
+
+#if __cpp_concepts < 201907L
+
+template <typename T>
+concept has_user_defined_id = requires {
+  typename std::integral_constant<std::size_t, T::struct_pack_id>;
+};
+
+#else
+
+template <typename T, typename = void>
+struct has_user_defined_id_impl : std::false_type {};
+
+template <typename T>
+struct has_user_defined_id_impl<
+    T, std::void_t<std::integral_constant<std::size_t, T::struct_pack_id>>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool has_user_defined_id = has_user_defined_id_impl<T>::value;
+
+#endif
 
 #if __cpp_concepts >= 201907L
 

--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -87,7 +87,7 @@ constexpr std::size_t pack_alignment_v = 0;
 template <typename T>
 constexpr std::size_t alignment_v = 0;
 
-#if __cpp_concepts < 201907L
+#if __cpp_concepts >= 201907L
 
 template <typename T>
 concept has_user_defined_id = requires {

--- a/include/ylt/struct_pack/struct_pack_impl.hpp
+++ b/include/ylt/struct_pack/struct_pack_impl.hpp
@@ -920,8 +920,7 @@ constexpr decltype(auto) get_type_end_flag() {
            get_size_literal<Arg::struct_pack_id>();
   }
   else {
-    return string_literal<char, 1>{
-        {static_cast<char>(type_id::type_end_flag)}};
+    return string_literal<char, 1>{{static_cast<char>(type_id::type_end_flag)}};
   }
 }
 
@@ -946,8 +945,7 @@ constexpr decltype(auto) get_type_literal() {
     }
     else {
       constexpr auto id = get_type_id<Arg>();
-      constexpr auto begin =
-          string_literal<char, 1>{{static_cast<char>(id)}};
+      constexpr auto begin = string_literal<char, 1>{{static_cast<char>(id)}};
       if constexpr (id == type_id::non_trivial_class_t ||
                     id == type_id::trivial_class_t) {
         using Args = decltype(get_types<Arg>());
@@ -1062,8 +1060,8 @@ constexpr decltype(auto) get_types_literal() {
     if constexpr (root_id == type_id::non_trivial_class_t ||
                   root_id == type_id::trivial_class_t) {
       constexpr auto end = get_type_end_flag<remove_cvref_t<T>>();
-      constexpr auto begin = string_literal<char, 1>{
-          {static_cast<char>(root_id)}};
+      constexpr auto begin =
+          string_literal<char, 1>{{static_cast<char>(root_id)}};
       constexpr auto body = get_types_literal_impl<T, Args...>();
       if constexpr (is_trivial_serializable<T, true>::value) {
         static_assert(align::pack_alignment_v<T> <= align::alignment_v<T>,

--- a/src/struct_pack/tests/test_compile_time_calculate.cpp
+++ b/src/struct_pack/tests/test_compile_time_calculate.cpp
@@ -375,33 +375,33 @@ struct foo {
   std::vector<int> a;
   std::list<foo> b;
 };
-
+struct bar;
 struct bar {
   std::vector<int> a;
-  std::deque<bar> b;
+  std::vector<bar> b;
 };
 
 struct foo_with_ID {
   std::vector<int> a;
-  std::list<foo> b;
+  std::list<foo_with_ID> b;
   constexpr static std::size_t struct_pack_id = 0;
 };
 
 struct bar_with_ID {
   std::vector<int> a;
-  std::map<int, bar> b;
+  std::map<int, bar_with_ID> b;
   constexpr static std::size_t struct_pack_id = 0;
 };
 
 struct foo_with_ID1 {
   std::vector<int> a;
-  std::list<foo> b;
+  std::list<foo_with_ID1> b;
   constexpr static std::size_t struct_pack_id = 1;
 };
 
 struct bar_with_ID1 {
   std::vector<int> a;
-  std::deque<bar> b;
+  std::vector<bar_with_ID1> b;
   constexpr static std::size_t struct_pack_id = 1;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Allow user add type id to distinct different c++ type with same struct_pack type by different hash.

## What is changing

Now user can defined a public static member `struct_pack_id`, this ID will be recorded in struct_pack type string to change hash code. This help user distinct different c++ type with same struct_pack type. User can also use this to avoid hash collision.

## Example

```cpp
struct foo_with_ID {
  std::vector<int> a;
  std::list<foo_with_ID> b;
  constexpr static std::size_t struct_pack_id = 0;
};

struct foo {
  std::vector<int> a;
  std::list<foo> b;
};

static_assert(struct_pack::get_type_literal<foo_with_ID>()!=struct_pack::get_type_literal<foo>());
```