### PR TITLE
[struct_pack][feat] support deserialize derived class

### DIFF
--- a/include/ylt/struct_pack.hpp
+++ b/include/ylt/struct_pack.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -512,48 +513,50 @@ template <typename T, size_t I, typename Reader,
   }
   return ret;
 }
-
+template <typename BaseClass, typename... DerivedClasses,
+          struct_pack::reader_t Reader>
+[[nodiscard]] STRUCT_PACK_INLINE
+    struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::errc>
+    deserialize_derived_class(Reader &reader) {
+  static_assert(sizeof...(DerivedClasses) > 0,
+                "There must have a least one derived class");
+  static_assert(
+      struct_pack::detail::public_base_class_checker<
+          BaseClass, std::tuple<DerivedClasses...>>::value,
+      "the First type should be the base class of all derived class ");
+  constexpr auto has_hash_collision =
+      struct_pack::detail::MD5_set<DerivedClasses...>::has_hash_collision;
+  if constexpr (has_hash_collision != 0) {
+    static_assert(!sizeof(std::tuple_element_t<has_hash_collision,
+                                               std::tuple<DerivedClasses...>>),
+                  "hash collision happened, consider add member `static "
+                  "constexpr uint64_t struct_pack_id` for collision type. ");
+  }
+  else {
+    struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::errc> ret;
+    auto ec = struct_pack::detail::deserialize_derived_class<BaseClass,
+                                                             DerivedClasses...>(
+        ret.value(), reader);
+    if SP_UNLIKELY (ec != struct_pack::errc{}) {
+      ret = unexpected<struct_pack::errc>{ec};
+    }
+    return ret;
+  }
+}
 template <typename BaseClass, typename... DerivedClasses,
           detail::deserialize_view View>
 [[nodiscard]] STRUCT_PACK_INLINE
-    struct_pack::expected<std::shared_ptr<BaseClass>, struct_pack::errc>
+    struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::errc>
     deserialize_derived_class(const View &v) {
-  static_assert(sizeof...(DerivedClasses) > 0);
-  static_assert(struct_pack::detail::public_base_class_checker<
-                    BaseClass, std::tuple<DerivedClasses...>>::value,
-                "The First template argument is not the public");
-  static_assert(!struct_pack::detail::MD5_set<
-                std::tuple<DerivedClasses...>>::has_hash_collision);
-  detail::memory_reader reader{v.data(), v.size()};
+  detail::memory_reader reader{v.data(), v.data() + v.size()};
   return deserialize_derived_class<BaseClass, DerivedClasses...>(reader);
 }
 template <typename BaseClass, typename... DerivedClasses>
 [[nodiscard]] STRUCT_PACK_INLINE
-    struct_pack::expected<std::shared_ptr<BaseClass>, struct_pack::errc>
+    struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::errc>
     deserialize_derived_class(const char *data, size_t size) {
-  static_assert(sizeof...(DerivedClasses) > 0);
-  static_assert(struct_pack::detail::public_base_class_checker<
-                BaseClass, std::tuple<DerivedClasses...>>::value);
-  static_assert(!struct_pack::detail::MD5_set<
-                std::tuple<DerivedClasses...>>::has_hash_collision);
   detail::memory_reader reader{data, data + size};
   return deserialize_derived_class<BaseClass, DerivedClasses...>(reader);
-}
-template <typename BaseClass, typename... DerivedClasses,
-          struct_pack::reader_t Reader>
-[[nodiscard]] STRUCT_PACK_INLINE
-    struct_pack::expected<std::shared_ptr<BaseClass>, struct_pack::errc>
-    deserialize_derived_class(Reader &reader) {
-  static_assert(sizeof...(DerivedClasses) > 0);
-  static_assert(struct_pack::detail::public_base_class_checker<
-                BaseClass, std::tuple<DerivedClasses...>>::value);
-  static_assert(!struct_pack::detail::MD5_set<
-                std::tuple<DerivedClasses...>>::has_hash_collision);
-  struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::errc> ret;
-  auto ec = struct_pack::detail::deserialize_derived_class(ret.value(), reader);
-  if SP_UNLIKELY (ec != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{ec};
-  }
 }
 
 }  // namespace struct_pack

--- a/include/ylt/struct_pack.hpp
+++ b/include/ylt/struct_pack.hpp
@@ -513,8 +513,13 @@ template <typename T, size_t I, typename Reader,
   }
   return ret;
 }
+#if __cpp_concepts >= 201907L
 template <typename BaseClass, typename... DerivedClasses,
           struct_pack::reader_t Reader>
+#else
+template <typename BaseClass, typename... DerivedClasses, typename Reader,
+          typename = std::enable_if_t<struct_pack::reader_t<Reader>>>
+#endif
 [[nodiscard]] STRUCT_PACK_INLINE
     struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::errc>
     deserialize_derived_class(Reader &reader) {
@@ -543,8 +548,14 @@ template <typename BaseClass, typename... DerivedClasses,
     return ret;
   }
 }
+#if __cpp_concepts >= 201907L
 template <typename BaseClass, typename... DerivedClasses,
           detail::deserialize_view View>
+#else
+template <
+    typename BaseClass, typename... DerivedClasses, typename View,
+    typename = std::enable_if_t<struct_pack::detail::deserialize_view<View>>>
+#endif
 [[nodiscard]] STRUCT_PACK_INLINE
     struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::errc>
     deserialize_derived_class(const View &v) {

--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -193,12 +193,15 @@ struct has_user_defined_id_impl<
 template <typename T>
 constexpr bool has_user_defined_id = has_user_defined_id_impl<T>::value;
 
+template <std::size_t sz>
+struct constant_checker{};
+
 template <typename T, typename = void>
 struct has_user_defined_id_ADL_impl : std::false_type {};
 
 template <typename T>
 struct has_user_defined_id_ADL_impl<
-    T, std::void_t<std::integral_constant<std::size_t, struct_pack_id((T*)nullptr)>>>
+    T, std::void_t<decltype(constant_checker<struct_pack_id((T*)nullptr)>)>>
     : std::true_type {};
 
 template <typename T>

--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -201,7 +201,7 @@ struct has_user_defined_id_ADL_impl : std::false_type {};
 
 template <typename T>
 struct has_user_defined_id_ADL_impl<
-    T, std::void_t<decltype(constant_checker<struct_pack_id((T*)nullptr)>)>>
+    T, std::void_t<constant_checker<struct_pack_id((T*)nullptr)>>>
     : std::true_type {};
 
 template <typename T>

--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -199,10 +199,20 @@ struct constant_checker{};
 template <typename T, typename = void>
 struct has_user_defined_id_ADL_impl : std::false_type {};
 
+#ifdef _MSC_VER
+// FIXME: we can't check if it's compile-time calculated in msvc with C++17
+template <typename T>
+struct has_user_defined_id_ADL_impl<
+    T, std::void_t<decltype(struct_pack_id((T*)nullptr))>>
+    : std::true_type {};
+#else
+
 template <typename T>
 struct has_user_defined_id_ADL_impl<
     T, std::void_t<constant_checker<struct_pack_id((T*)nullptr)>>>
     : std::true_type {};
+
+#endif
 
 template <typename T>
 constexpr bool has_user_defined_id_ADL = has_user_defined_id_ADL_impl<T>::value;

--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -90,28 +90,6 @@ constexpr std::size_t alignment_v = 0;
 #if __cpp_concepts >= 201907L
 
 template <typename T>
-concept has_user_defined_id = requires {
-  typename std::integral_constant<std::size_t, T::struct_pack_id>;
-};
-
-#else
-
-template <typename T, typename = void>
-struct has_user_defined_id_impl : std::false_type {};
-
-template <typename T>
-struct has_user_defined_id_impl<
-    T, std::void_t<std::integral_constant<std::size_t, T::struct_pack_id>>>
-    : std::true_type {};
-
-template <typename T>
-constexpr bool has_user_defined_id = has_user_defined_id_impl<T>::value;
-
-#endif
-
-#if __cpp_concepts >= 201907L
-
-template <typename T>
 concept writer_t = requires(T t) {
   t.write((const char *)nullptr, std::size_t{});
 };
@@ -188,6 +166,45 @@ struct compatible;
 
 // clang-format off
 namespace detail {
+
+#if __cpp_concepts >= 201907L
+
+template <typename T>
+concept has_user_defined_id = requires {
+  typename std::integral_constant<std::size_t, T::struct_pack_id>;
+};
+
+template <typename T>
+concept has_user_defined_id_ADL = requires {
+  typename std::integral_constant<std::size_t,
+                                  struct_pack_id((T*)nullptr)>;
+};
+
+#else
+
+template <typename T, typename = void>
+struct has_user_defined_id_impl : std::false_type {};
+
+template <typename T>
+struct has_user_defined_id_impl<
+    T, std::void_t<std::integral_constant<std::size_t, T::struct_pack_id>>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool has_user_defined_id = has_user_defined_id_impl<T>::value;
+
+template <typename T, typename = void>
+struct has_user_defined_id_ADL_impl : std::false_type {};
+
+template <typename T>
+struct has_user_defined_id_ADL_impl<
+    T, std::void_t<std::integral_constant<std::size_t, struct_pack_id((T*)nullptr)>>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool has_user_defined_id_ADL = has_user_defined_id_ADL_impl<T>::value;
+
+#endif
 
 #if __cpp_concepts >= 201907L
   template <typename Type>

--- a/include/ylt/struct_pack/struct_pack_impl.hpp
+++ b/include/ylt/struct_pack/struct_pack_impl.hpp
@@ -3096,7 +3096,7 @@ struct MD5_reader_wrapper : public Reader {
 };
 
 template <typename BaseClass, typename... DerivedClasses,
-          struct_pack::reader_t Reader>
+          typename Reader>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_derived_class(
     std::unique_ptr<BaseClass> &base, Reader &reader) {
   MD5_reader_wrapper wrapper{std::move(reader)};

--- a/include/ylt/struct_pack/struct_pack_impl.hpp
+++ b/include/ylt/struct_pack/struct_pack_impl.hpp
@@ -3072,7 +3072,7 @@ struct deserialize_derived_class_helper {
     else {
       using derived_class = std::tuple_element_t<index, DerivedClasses>;
       base = std::make_unique<derived_class>();
-      return unpacker.template deserialize(*(derived_class *)base.get());
+      return unpacker.deserialize(*(derived_class *)base.get());
     }
   }
 };
@@ -3095,8 +3095,7 @@ struct MD5_reader_wrapper : public Reader {
   std::size_t read_pos;
 };
 
-template <typename BaseClass, typename... DerivedClasses,
-          typename Reader>
+template <typename BaseClass, typename... DerivedClasses, typename Reader>
 [[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_derived_class(
     std::unique_ptr<BaseClass> &base, Reader &reader) {
   MD5_reader_wrapper wrapper{std::move(reader)};

--- a/src/struct_pack/tests/CMakeLists.txt
+++ b/src/struct_pack/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(struct_pack_test
         test_stream.cpp
         test_compatible.cpp
         test_non_aggregated_type.cpp
+        test_derived.cpp
         main.cpp
         )
 add_test(NAME struct_pack_test COMMAND struct_pack_test)

--- a/src/struct_pack/tests/test_compile_time_calculate.cpp
+++ b/src/struct_pack/tests/test_compile_time_calculate.cpp
@@ -405,9 +405,17 @@ struct bar_with_ID1 {
   constexpr static std::size_t struct_pack_id = 1;
 };
 
+struct bar_with_ID2 {
+  std::vector<int> a;
+  std::vector<bar_with_ID2> b;
+};
+constexpr int struct_pack_id(bar_with_ID2*) { return 11; }
+
 TEST_CASE("test user defined ID") {
+  static_assert(struct_pack::detail::has_user_defined_id_ADL<bar_with_ID2>);
   {
-    static_assert(has_user_defined_id<foo_trivial_with_ID>);
+    static_assert(
+        struct_pack::detail::has_user_defined_id<foo_trivial_with_ID>);
     static_assert(struct_pack::get_type_literal<foo_trivial>() !=
                   struct_pack::get_type_literal<foo_trivial_with_ID>());
     static_assert(struct_pack::get_type_literal<foo_trivial_with_ID2>() !=
@@ -416,7 +424,7 @@ TEST_CASE("test user defined ID") {
                   struct_pack::get_type_literal<bar_trivial_with_ID2>());
   }
   {
-    static_assert(has_user_defined_id<foo_with_ID>);
+    static_assert(struct_pack::detail::has_user_defined_id<foo_with_ID>);
     static_assert(struct_pack::get_type_literal<foo>() !=
                   struct_pack::get_type_literal<foo_with_ID>());
     static_assert(struct_pack::get_type_literal<foo_with_ID>() !=
@@ -427,5 +435,7 @@ TEST_CASE("test user defined ID") {
                   struct_pack::get_type_literal<bar_with_ID1>());
     static_assert(struct_pack::get_type_literal<foo_with_ID>() !=
                   struct_pack::get_type_literal<bar_with_ID>());
+    static_assert(struct_pack::get_type_literal<bar_with_ID2>() !=
+                  struct_pack::get_type_literal<bar_with_ID1>());
   }
 }

--- a/src/struct_pack/tests/test_derived.cpp
+++ b/src/struct_pack/tests/test_derived.cpp
@@ -1,0 +1,51 @@
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "doctest.h"
+#include "ylt/struct_pack.hpp"
+struct Base {
+  static struct_pack::expected<std::shared_ptr<Base>, struct_pack::errc>
+  deserialize(std::string_view sv);
+};
+struct foo : public Base {
+  std::string hello;
+  std::string hi;
+  friend bool operator==(const foo& a, const foo& b) {
+    return a.hello == b.hello && a.hi == b.hi;
+  }
+};
+struct bar : public Base {
+  int oh;
+  int no;
+  friend bool operator==(const bar& a, const bar& b) {
+    return a.oh == b.oh && a.no == b.no;
+  }
+};
+struct gua : Base {
+  std::vector<foo> foos;
+  std::vector<bar> bars;
+  friend bool operator==(const gua& a, const gua& b) {
+    return a.foos == b.foos && a.bars == b.bars;
+  }
+};
+struct_pack::expected<std::shared_ptr<Base>, struct_pack::errc>
+Base::deserialize(std::string_view sv) {
+  return struct_pack::deserialize_derived_class<Base, foo, bar, gua>(sv);
+}
+TEST_CASE("testing derived") {
+  foo f{.hello = "1", .hi = "2"};
+  bar b{.oh = 1, .no = 2};
+  gua g{.foos = {{.hello = "23", .hi = "34"}, {.hello = "45", .hi = "67"}},
+        .bars = {{.oh = 1, .no = 2}, {.oh = 3, .no = 4}}};
+  std::vector vecs{struct_pack::serialize<std::string>(f),
+                   struct_pack::serialize<std::string>(b),
+                   struct_pack::serialize<std::string>(g)};
+  auto f1 = Base::deserialize(vecs[0]);
+  auto b1 = Base::deserialize(vecs[1]);
+  auto g1 = Base::deserialize(vecs[2]);
+  CHECK(*(foo*)(f1->get()) == f);
+  CHECK(*(bar*)(b1->get()) == b);
+  CHECK(*(gua*)(g1->get()) == g);
+}

--- a/src/struct_pack/tests/test_derived.cpp
+++ b/src/struct_pack/tests/test_derived.cpp
@@ -5,47 +5,111 @@
 
 #include "doctest.h"
 #include "ylt/struct_pack.hpp"
+#include "ylt/struct_pack/struct_pack_impl.hpp"
 struct Base {
-  static struct_pack::expected<std::shared_ptr<Base>, struct_pack::errc>
+  Base(){};
+  static struct_pack::expected<std::unique_ptr<Base>, struct_pack::errc>
   deserialize(std::string_view sv);
+  virtual std::string get_name() const = 0;
+  virtual ~Base(){};
 };
 struct foo : public Base {
-  std::string hello;
-  std::string hi;
+  std::string hello = "1";
+  std::string hi = "2";
+  virtual std::string get_name() const override { return "foo"; }
   friend bool operator==(const foo& a, const foo& b) {
     return a.hello == b.hello && a.hi == b.hi;
   }
 };
+STRUCT_PACK_REFL(foo, hello, hi);
+struct foo2 : public Base {
+  std::string hello = "1";
+  std::string hi = "2";
+  virtual std::string get_name() const override { return "foo2"; }
+  friend bool operator==(const foo2& a, const foo2& b) {
+    return a.hello == b.hello && a.hi == b.hi;
+  }
+  static constexpr uint64_t struct_pack_id = 114514;
+};
+STRUCT_PACK_REFL(foo2, hello, hi);
+struct foo3 : public Base {
+  std::string hello = "1";
+  std::string hi = "2";
+  virtual std::string get_name() const override { return "foo3"; }
+  friend bool operator==(const foo3& a, const foo3& b) {
+    return a.hello == b.hello && a.hi == b.hi;
+  }
+};
+STRUCT_PACK_REFL(foo3, hello, hi);
+struct foo4 : public Base {
+  std::string hello = "1";
+  std::string hi = "2";
+  virtual std::string get_name() const override { return "foo4"; }
+  friend bool operator==(const foo4& a, const foo4& b) {
+    return a.hello == b.hello && a.hi == b.hi;
+  }
+};
+constexpr int struct_pack_id(foo4*) { return 112233211; }
+STRUCT_PACK_REFL(foo4, hello, hi);
 struct bar : public Base {
-  int oh;
-  int no;
+  int oh = 1;
+  int no = 2;
+  virtual std::string get_name() const override { return "bar"; }
   friend bool operator==(const bar& a, const bar& b) {
     return a.oh == b.oh && a.no == b.no;
   }
 };
+STRUCT_PACK_REFL(bar, oh, no);
 struct gua : Base {
-  std::vector<foo> foos;
-  std::vector<bar> bars;
+  std::string a = "Hello";
+  int b = 1;
+  virtual std::string get_name() const override { return "gua"; }
   friend bool operator==(const gua& a, const gua& b) {
-    return a.foos == b.foos && a.bars == b.bars;
+    return a.a == b.a && a.b == b.b;
   }
 };
-struct_pack::expected<std::shared_ptr<Base>, struct_pack::errc>
+STRUCT_PACK_REFL(gua, a, b);
+
+struct_pack::expected<std::unique_ptr<Base>, struct_pack::errc>
 Base::deserialize(std::string_view sv) {
-  return struct_pack::deserialize_derived_class<Base, foo, bar, gua>(sv);
+  return struct_pack::deserialize_derived_class<Base, bar, foo, gua, foo2,
+                                                foo4>(sv);
 }
+
 TEST_CASE("testing derived") {
-  foo f{.hello = "1", .hi = "2"};
-  bar b{.oh = 1, .no = 2};
-  gua g{.foos = {{.hello = "23", .hi = "34"}, {.hello = "45", .hi = "67"}},
-        .bars = {{.oh = 1, .no = 2}, {.oh = 3, .no = 4}}};
+  using namespace std::string_literals;
+  static_assert(struct_pack::detail::has_user_defined_id_ADL<foo4>);
+  foo f;
+  foo2 f2;
+  foo4 f4;
+  bar b;
+  gua g;
   std::vector vecs{struct_pack::serialize<std::string>(f),
                    struct_pack::serialize<std::string>(b),
-                   struct_pack::serialize<std::string>(g)};
+                   struct_pack::serialize<std::string>(g),
+                   struct_pack::serialize<std::string>(f2),
+                   struct_pack::serialize<std::string>(f4)};
   auto f1 = Base::deserialize(vecs[0]);
   auto b1 = Base::deserialize(vecs[1]);
   auto g1 = Base::deserialize(vecs[2]);
+  auto f21 = Base::deserialize(vecs[3]);
+  auto f41 = Base::deserialize(vecs[4]);
   CHECK(*(foo*)(f1->get()) == f);
+  CHECK(*(foo2*)(f21->get()) == f2);
   CHECK(*(bar*)(b1->get()) == b);
   CHECK(*(gua*)(g1->get()) == g);
+  std::vector<std::pair<std::unique_ptr<Base>, std::string>> vec;
+  vec.emplace_back(std::move(f1.value()), "foo");
+  vec.emplace_back(std::move(f21.value()), "foo2");
+  vec.emplace_back(std::move(b1.value()), "bar");
+  vec.emplace_back(std::move(g1.value()), "gua");
+  vec.emplace_back(std::move(f41.value()), "foo4");
+  for (const auto& e : vec) {
+    CHECK(e.first->get_name() == e.second);
+  }
+}
+
+TEST_CASE("test hash collision") {
+  static_assert(struct_pack::detail::MD5_set<foo, bar, foo2, gua, foo3,
+                                             foo4>::has_hash_collision != 0);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

See #444 

## What is changing

Add function `struct_pack::deserialize_derived_class(...)`; this function can deserialize derived class to a unique_ptr of base class.

## Example

simple example:
```cpp
struct_pack::expected<std::unique_ptr<Base>,std::errc> ret = struct_pack::deserialize_derived_class<Base, foo, bar, gua>(sv);
```

```cpp
struct Base {
  Base(){};
  static struct_pack::expected<std::unique_ptr<Base>, struct_pack::errc>
  deserialize(std::string_view sv);
  virtual std::string get_name() const = 0;
  virtual ~Base(){};
};
struct foo : public Base {
  std::string hello = "1";
  std::string hi = "2";
  virtual std::string get_name() const override { return "foo"; }
  friend bool operator==(const foo& a, const foo& b) {
    return a.hello == b.hello && a.hi == b.hi;
  }
};
STRUCT_PACK_REFL(foo, hello, hi);
struct foo2 : public Base {
  std::string hello = "1";
  std::string hi = "2";
  virtual std::string get_name() const override { return "foo2"; }
  friend bool operator==(const foo2& a, const foo2& b) {
    return a.hello == b.hello && a.hi == b.hi;
  }
  static constexpr uint64_t struct_pack_id = 114514;
};
STRUCT_PACK_REFL(foo2, hello, hi);
struct foo4 : public Base {
  std::string hello = "1";
  std::string hi = "2";
  virtual std::string get_name() const override { return "foo4"; }
  friend bool operator==(const foo4& a, const foo4& b) {
    return a.hello == b.hello && a.hi == b.hi;
  }
};
constexpr int struct_pack_id(foo4*) { return 112233211; }
STRUCT_PACK_REFL(foo4, hello, hi);
struct bar : public Base {
  int oh = 1;
  int no = 2;
  virtual std::string get_name() const override { return "bar"; }
  friend bool operator==(const bar& a, const bar& b) {
    return a.oh == b.oh && a.no == b.no;
  }
};
STRUCT_PACK_REFL(bar, oh, no);
struct gua : Base {
  std::string a = "Hello";
  int b = 1;
  virtual std::string get_name() const override { return "gua"; }
  friend bool operator==(const gua& a, const gua& b) {
    return a.a == b.a && a.b == b.b;
  }
};
STRUCT_PACK_REFL(gua, a, b);

struct_pack::expected<std::unique_ptr<Base>, struct_pack::errc>
Base::deserialize(std::string_view sv) {
  return struct_pack::deserialize_derived_class<Base, bar, foo, gua, foo2,
                                                foo4>(sv);
}

int test(){
  using namespace std::string_literals;
  foo f;
  foo2 f2;
  foo4 f4;
  bar b;
  gua g;
  std::vector vecs{struct_pack::serialize<std::string>(f),
                   struct_pack::serialize<std::string>(b),
                   struct_pack::serialize<std::string>(g),
                   struct_pack::serialize<std::string>(f2),
                   struct_pack::serialize<std::string>(f4)};
  auto f1 = Base::deserialize(vecs[0]);
  auto b1 = Base::deserialize(vecs[1]);
  auto g1 = Base::deserialize(vecs[2]);
  auto f21 = Base::deserialize(vecs[3]);
  auto f41 = Base::deserialize(vecs[4]);
  CHECK(*(foo*)(f1->get()) == f);
  CHECK(*(foo2*)(f21->get()) == f2);
  CHECK(*(bar*)(b1->get()) == b);
  CHECK(*(gua*)(g1->get()) == g);
  std::vector<std::pair<std::unique_ptr<Base>, std::string>> vec;
  vec.emplace_back(std::move(f1.value()), "foo");
  vec.emplace_back(std::move(f21.value()), "foo2");
  vec.emplace_back(std::move(b1.value()), "bar");
  vec.emplace_back(std::move(g1.value()), "gua");
  vec.emplace_back(std::move(f41.value()), "foo4");
  for (const auto& e : vec) {
    CHECK(e.first->get_name() == e.second);
  }
}
```