### PR TITLE
[struct_pack] enhance serialize performance by uninitialized resize

### DIFF
--- a/include/ylt/coro_io/rate_limiter.hpp
+++ b/include/ylt/coro_io/rate_limiter.hpp
@@ -101,7 +101,8 @@ class abstract_smooth_rate_limiter : public rate_limiter {
     do_set_rate(permits_per_second, stable_internal_micros);
   }
   std::chrono::steady_clock::time_point reserve_earliest_available(
-      int required_permits, std::chrono::steady_clock::time_point now_micros) {
+      int required_permits,
+      std::chrono::steady_clock::time_point now_micros) override {
     resync(now_micros);
     std::chrono::steady_clock::time_point return_value =
         this->next_free_ticket_micros_;

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -669,6 +669,7 @@ class coro_rpc_client {
     }
 
     auto &header = *(coro_rpc_protocol::req_header *)buffer.data();
+    header = {};
     header.magic = coro_rpc_protocol::magic_number;
     header.function_id = func_id<func>();
 #ifdef UNIT_TEST_INJECT

--- a/include/ylt/struct_pack.hpp
+++ b/include/ylt/struct_pack.hpp
@@ -152,7 +152,7 @@ STRUCT_PACK_INLINE void serialize_to(Writer &writer, const Args &...args) {
     auto data_offset = writer.size();
     auto info = detail::get_serialize_runtime_info<conf>(args...);
     auto total = data_offset + info.size();
-    detail::uninit_resize(writer, total);
+    detail::resize(writer, total);
     auto real_writer =
         struct_pack::detail::memory_writer{(char *)writer.data() + data_offset};
     struct_pack::detail::serialize_to<conf>(real_writer, info, args...);
@@ -189,7 +189,7 @@ void STRUCT_PACK_INLINE serialize_to_with_offset(Buffer &buffer,
   static_assert(sizeof...(args) > 0);
   auto info = detail::get_serialize_runtime_info<conf>(args...);
   auto old_size = buffer.size();
-  detail::uninit_resize(buffer, old_size + offset + info.size());
+  detail::resize(buffer, old_size + offset + info.size());
   auto writer = struct_pack::detail::memory_writer{(char *)buffer.data() +
                                                    old_size + offset};
   struct_pack::detail::serialize_to<conf>(writer, info, args...);

--- a/include/ylt/struct_pack.hpp
+++ b/include/ylt/struct_pack.hpp
@@ -152,7 +152,7 @@ STRUCT_PACK_INLINE void serialize_to(Writer &writer, const Args &...args) {
     auto data_offset = writer.size();
     auto info = detail::get_serialize_runtime_info<conf>(args...);
     auto total = data_offset + info.size();
-    writer.resize(total);
+    detail::uninit_resize(writer, total);
     auto real_writer =
         struct_pack::detail::memory_writer{(char *)writer.data() + data_offset};
     struct_pack::detail::serialize_to<conf>(real_writer, info, args...);
@@ -189,7 +189,7 @@ void STRUCT_PACK_INLINE serialize_to_with_offset(Buffer &buffer,
   static_assert(sizeof...(args) > 0);
   auto info = detail::get_serialize_runtime_info<conf>(args...);
   auto old_size = buffer.size();
-  buffer.resize(old_size + offset + info.size());
+  detail::uninit_resize(buffer, old_size + offset + info.size());
   auto writer = struct_pack::detail::memory_writer{(char *)buffer.data() +
                                                    old_size + offset};
   struct_pack::detail::serialize_to<conf>(writer, info, args...);

--- a/include/ylt/struct_pack/type_trait.hpp
+++ b/include/ylt/struct_pack/type_trait.hpp
@@ -25,7 +25,7 @@ namespace struct_pack::detail {
 template <typename T>
 constexpr bool struct_pack_byte =
     std::is_same_v<char, T> || std::is_same_v<unsigned char, T> ||
-    std::is_same_v<std::byte, T>;
+    std::is_same_v<signed char, T> || std::is_same_v<std::byte, T>;
 
 template <typename T>
 #if __cpp_concepts < 201907L

--- a/src/struct_pack/examples/basic_usage.cpp
+++ b/src/struct_pack/examples/basic_usage.cpp
@@ -83,7 +83,10 @@ void basic_usage() {
   // api 5. serialize with offset
   {
     auto buffer = struct_pack::serialize_with_offset(/* offset = */ 2, p);
-    assert(buffer[0] == '\0' && buffer[1] == '\0');
+    auto buffer2 = struct_pack::serialize(p);
+    bool result = std::string_view{buffer.data() + 2, buffer.size() - 2} ==
+                  std::string_view{buffer2.data(), buffer2.size()};
+    assert(result);
   }
   // api 6. serialize varadic param
   {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

In old version, if struct_pack save binary to a container, it will call member function `resize()`. which cause useless initialization.

## What is changing

Add a helper function `struct_pack::detail::resize()`, which will resize some container(std::basic_string<char/unsigned char/signed char>, std::vector<char/unsigned char/signed char/std::byte>) without initialization.

Now struct_pack::serialize is faster:

old version:
```
struct_pack serialize 1 rect :            3 ns
struct_pack serialize 20 rects :          17 ns
struct_pack serialize 1 person :          11 ns
struct_pack serialize 20 persons :        110 ns
struct_pack serialize 1 monster :         76 ns
struct_pack serialize 20 monsters :       652 ns
```
new version:
```
struct_pack serialize 1 rect :            2 ns
struct_pack serialize 20 rects :          11 ns
struct_pack serialize 1 person :          7 ns
struct_pack serialize 20 persons :        98 ns
struct_pack serialize 1 monster :         76 ns
struct_pack serialize 20 monsters :       618 ns
```

## Example