### PR TITLE
[coro_io]fix: std::move used on a local var as return value

### DIFF
--- a/include/ylt/coro_io/channel.hpp
+++ b/include/ylt/coro_io/channel.hpp
@@ -103,7 +103,7 @@ class channel {
                             g_clients_pool<client_t, io_context_pool_t>()) {
     channel ch;
     ch.init(hosts, config, client_pools);
-    return std::move(ch);
+    return ch;
   }
 
  private:


### PR DESCRIPTION
## Why 

Moving local variables as return value interferes with RVO.

This is a common bad practice.

