### PR TITLE
[easylog]if statement can be constexpr

### DIFF
--- a/include/ylt/easylog.hpp
+++ b/include/ylt/easylog.hpp
@@ -213,7 +213,7 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
         easylog::record_t(std::chrono::system_clock::now(), severity, \
                           GET_STRING(__FILE__, __LINE__))             \
             .sprintf(fmt, __VA_ARGS__);                               \
-    if (severity == easylog::Severity::CRITICAL) {                    \
+    if constexpr (severity == easylog::Severity::CRITICAL) {          \
       easylog::flush<Id>();                                           \
       std::exit(EXIT_FAILURE);                                        \
     }                                                                 \
@@ -240,7 +240,7 @@ inline void add_appender(std::function<void(std::string_view)> fn) {
         easylog::record_t(std::chrono::system_clock::now(), severity, \
                           GET_STRING(__FILE__, __LINE__))             \
             .format(prefix::format(format_str, __VA_ARGS__));         \
-    if (severity == easylog::Severity::CRITICAL) {                    \
+    if constexpr (severity == easylog::Severity::CRITICAL) {          \
       easylog::flush<Id>();                                           \
       std::exit(EXIT_FAILURE);                                        \
     }                                                                 \


### PR DESCRIPTION
## Why

if statement within macro `ELOGV_IMPL`. `ELOGFMT_IMPL0` can be evaluated during compile-time.

I'm not 100% sure this change is proper, but it seems to me that `severity` should be compile-time constant as long as `Id` is used as one.

## What is changing

Macro definition `ELOGV_IMPL`. `ELOGFMT_IMPL0`, easylog.hpp