### PR TITLE
[coro_http][feat]coro_http_server support websocket

### DIFF
--- a/include/ylt/thirdparty/cinatra/coro_http_client.hpp
+++ b/include/ylt/thirdparty/cinatra/coro_http_client.hpp
@@ -66,6 +66,17 @@ template <class T>
 constexpr bool is_stream_v = is_stream<T>::value;
 
 template <class, class = void>
+struct is_span : std::false_type {};
+
+template <class T>
+struct is_span<T, std::void_t<decltype(std::declval<T>().data(),
+                                       std::declval<T>().size())>>
+    : std::true_type {};
+
+template <class T>
+constexpr bool is_span_v = is_span<T>::value;
+
+template <class, class = void>
 struct is_smart_ptr : std::false_type {};
 
 template <class T>
@@ -105,7 +116,7 @@ struct multipart_t {
 };
 
 struct read_result {
-  std::string_view buf;
+  std::span<char> buf;
   bool eof;
   std::error_code err;
 };
@@ -330,25 +341,69 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
     co_return !data.net_err;
   }
 
-  async_simple::coro::Lazy<resp_data> async_send_ws(std::string msg,
+  async_simple::coro::Lazy<resp_data> async_send_ws(const char *data,
+                                                    bool need_mask = true,
+                                                    opcode op = opcode::text) {
+    std::string str(data);
+    co_return co_await async_send_ws(std::span<char>(str), need_mask, op);
+  }
+
+  async_simple::coro::Lazy<resp_data> async_send_ws(std::string data,
+                                                    bool need_mask = true,
+                                                    opcode op = opcode::text) {
+    co_return co_await async_send_ws(std::span<char>(data), need_mask, op);
+  }
+
+  template <typename Source>
+  async_simple::coro::Lazy<resp_data> async_send_ws(Source source,
                                                     bool need_mask = true,
                                                     opcode op = opcode::text) {
     resp_data data{};
 
     websocket ws{};
+    std::string close_str;
     if (op == opcode::close) {
-      msg = ws.format_close_payload(close_code::normal, msg.data(), msg.size());
+      if constexpr (is_span_v<Source>) {
+        close_str = ws.format_close_payload(close_code::normal, source.data(),
+                                            source.size());
+        source = {close_str.data(), close_str.size()};
+      }
     }
 
-    std::string encode_header = ws.encode_frame(msg, op, need_mask);
-    std::vector<asio::const_buffer> buffers{
-        asio::buffer(encode_header.data(), encode_header.size()),
-        asio::buffer(msg.data(), msg.size())};
+    if constexpr (is_span_v<Source>) {
+      std::string encode_header = ws.encode_frame(source, op, need_mask);
+      std::vector<asio::const_buffer> buffers{
+          asio::buffer(encode_header.data(), encode_header.size()),
+          asio::buffer(source.data(), source.size())};
 
-    auto [ec, _] = co_await async_write(buffers);
-    if (ec) {
-      data.net_err = ec;
-      data.status = 404;
+      auto [ec, _] = co_await async_write(buffers);
+      if (ec) {
+        data.net_err = ec;
+        data.status = 404;
+      }
+    }
+    else {
+      while (true) {
+        auto result = co_await source();
+
+        std::span<char> msg(result.buf.data(), result.buf.size());
+        std::string encode_header =
+            ws.encode_frame(msg, op, need_mask, result.eof);
+        std::vector<asio::const_buffer> buffers{
+            asio::buffer(encode_header.data(), encode_header.size()),
+            asio::buffer(msg.data(), msg.size())};
+
+        auto [ec, _] = co_await async_write(buffers);
+        if (ec) {
+          data.net_err = ec;
+          data.status = 404;
+          break;
+        }
+
+        if (result.eof) {
+          break;
+        }
+      }
     }
 
     co_return data;
@@ -356,7 +411,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
   async_simple::coro::Lazy<resp_data> async_send_ws_close(
       std::string msg = "") {
-    return async_send_ws(std::move(msg), false, opcode::close);
+    co_return co_await async_send_ws(std::move(msg), false, opcode::close);
   }
 
   void on_ws_msg(std::function<void(resp_data)> on_ws_msg) {
@@ -1654,7 +1709,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
       data_ptr = asio::buffer_cast<const char *>(read_buf_.data());
       if (is_close_frame) {
-        payload_len -= 4;
+        payload_len -= 2;
         data_ptr += sizeof(uint16_t);
       }
 

--- a/include/ylt/thirdparty/cinatra/coro_http_router.hpp
+++ b/include/ylt/thirdparty/cinatra/coro_http_router.hpp
@@ -10,9 +10,9 @@
 
 #include "cinatra/cinatra_log_wrapper.hpp"
 #include "cinatra/coro_http_request.hpp"
-#include "cinatra/function_traits.hpp"
 #include "cinatra/response_cv.hpp"
 #include "coro_http_response.hpp"
+#include "ylt/util/type_traits.h"
 
 namespace cinatra {
 template <template <typename...> class U, typename T>
@@ -42,7 +42,7 @@ class coro_http_router {
 
     // hold keys to make sure map_handles_ key is
     // std::string_view, avoid memcpy when route
-    using return_type = typename timax::function_traits<Func>::result_type;
+    using return_type = typename util::function_traits<Func>::return_type;
     if constexpr (is_lazy_v<return_type>) {
       auto [it, ok] = coro_keys_.emplace(std::move(whole_str));
       if (!ok) {

--- a/include/ylt/thirdparty/cinatra/url_encode_decode.hpp
+++ b/include/ylt/thirdparty/cinatra/url_encode_decode.hpp
@@ -48,6 +48,53 @@ inline static std::string url_decode(const std::string &value) noexcept {
   return result;
 }
 
+// from h2o
+inline const char *MAP =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789+/";
+
+inline const char *MAP_URL_ENCODED =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789-_";
+inline size_t base64_encode(char *_dst, const void *_src, size_t len,
+                            int url_encoded) {
+  char *dst = _dst;
+  const uint8_t *src = reinterpret_cast<const uint8_t *>(_src);
+  const char *map = url_encoded ? MAP_URL_ENCODED : MAP;
+  uint32_t quad;
+
+  for (; len >= 3; src += 3, len -= 3) {
+    quad = ((uint32_t)src[0] << 16) | ((uint32_t)src[1] << 8) | src[2];
+    *dst++ = map[quad >> 18];
+    *dst++ = map[(quad >> 12) & 63];
+    *dst++ = map[(quad >> 6) & 63];
+    *dst++ = map[quad & 63];
+  }
+  if (len != 0) {
+    quad = (uint32_t)src[0] << 16;
+    *dst++ = map[quad >> 18];
+    if (len == 2) {
+      quad |= (uint32_t)src[1] << 8;
+      *dst++ = map[(quad >> 12) & 63];
+      *dst++ = map[(quad >> 6) & 63];
+      if (!url_encoded)
+        *dst++ = '=';
+    }
+    else {
+      *dst++ = map[(quad >> 12) & 63];
+      if (!url_encoded) {
+        *dst++ = '=';
+        *dst++ = '=';
+      }
+    }
+  }
+
+  *dst = '\0';
+  return dst - _dst;
+}
+
 inline static std::string u8wstring_to_string(const std::wstring &wstr) {
   std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
   return conv.to_bytes(wstr);

--- a/include/ylt/thirdparty/cinatra/websocket.hpp
+++ b/include/ylt/thirdparty/cinatra/websocket.hpp
@@ -3,6 +3,11 @@
 #include "ws_define.h"
 
 namespace cinatra {
+enum ws_header_status {
+  error = -1,
+  complete = 0,
+  incomplete = -2,
+};
 class websocket {
  public:
   void sec_ws_key(std::string_view sec_key) { sec_ws_key_ = sec_key; }
@@ -40,7 +45,8 @@ class websocket {
   Payload length:  7 bits, 7+16 bits, or 7+64 bits
   Masking-key:  0 or 4 bytes
   */
-  int parse_header(const char *buf, size_t size, bool is_server = true) {
+  ws_header_status parse_header(const char *buf, size_t size,
+                                bool is_server = true) {
     const unsigned char *inp = (const unsigned char *)(buf);
 
     msg_opcode_ = inp[0] & 0x0F;
@@ -52,10 +58,12 @@ class websocket {
 
     left_header_len_ = 0;
     if (length_field <= 125) {
+      len_bytes_ = SHORT_HEADER;
       payload_length_ = length_field;
     }
     else if (length_field == 126)  // msglen is 16bit!
     {
+      len_bytes_ = MEDIUM_HEADER;
       payload_length_ = ntohs(*(uint16_t *)&inp[2]);  // (inp[2] << 8) + inp[3];
       pos += 2;
       left_header_len_ =
@@ -63,20 +71,54 @@ class websocket {
     }
     else if (length_field == 127)  // msglen is 64bit!
     {
+      len_bytes_ = LONG_HEADER;
       payload_length_ = (size_t)be64toh(*(uint64_t *)&inp[2]);
       pos += 8;
       left_header_len_ =
           is_server ? LONG_HEADER - size : CLIENT_LONG_HEADER - size;
     }
     else {
-      return -1;
+      len_bytes_ = INVALID_HEADER;
+      return ws_header_status::error;
     }
 
     if (msg_masked) {
       std::memcpy(mask_, inp + pos, 4);
     }
 
-    return left_header_len_ == 0 ? 0 : -2;
+    return left_header_len_ == 0 ? ws_header_status::complete
+                                 : ws_header_status::incomplete;
+  }
+
+  int len_bytes() const { return len_bytes_; }
+  void reset_len_bytes() { len_bytes_ = SHORT_HEADER; }
+
+  ws_frame_type parse_payload(std::span<char> buf) {
+    // unmask data:
+    if (*(uint32_t *)mask_ != 0) {
+      for (size_t i = 0; i < payload_length_; i++) {
+        buf[i] = buf[i] ^ mask_[i % 4];
+      }
+    }
+
+    if (msg_opcode_ == 0x0)
+      return (msg_fin_)
+                 ? ws_frame_type::WS_TEXT_FRAME
+                 : ws_frame_type::WS_INCOMPLETE_TEXT_FRAME;  // continuation
+    // frame ?
+    if (msg_opcode_ == 0x1)
+      return (msg_fin_) ? ws_frame_type::WS_TEXT_FRAME
+                        : ws_frame_type::WS_INCOMPLETE_TEXT_FRAME;
+    if (msg_opcode_ == 0x2)
+      return (msg_fin_) ? ws_frame_type::WS_BINARY_FRAME
+                        : ws_frame_type::WS_INCOMPLETE_BINARY_FRAME;
+    if (msg_opcode_ == 0x8)
+      return ws_frame_type::WS_CLOSE_FRAME;
+    if (msg_opcode_ == 0x9)
+      return ws_frame_type::WS_PING_FRAME;
+    if (msg_opcode_ == 0xA)
+      return ws_frame_type::WS_PONG_FRAME;
+    return ws_frame_type::WS_BINARY_FRAME;
   }
 
   ws_frame_type parse_payload(const char *buf, size_t size,
@@ -131,12 +173,12 @@ class websocket {
             asio::buffer(src, length)};
   }
 
-  inline std::string encode_frame(std::string &data, opcode op,
-                                  bool need_mask) {
+  std::string encode_frame(std::span<char> &data, opcode op, bool need_mask,
+                           bool eof = true) {
     std::string header;
     /// Base header.
     frame_header hdr{};
-    hdr.fin = 1;
+    hdr.fin = eof;
     hdr.rsv1 = 0;
     hdr.rsv2 = 0;
     hdr.rsv3 = 0;
@@ -212,6 +254,9 @@ class websocket {
 
   std::string format_close_payload(uint16_t code, char *message,
                                    size_t length) {
+    if (length == 0) {
+      return "";
+    }
     std::string close_payload;
     if (code) {
       close_payload.resize(length + 2);
@@ -267,6 +312,7 @@ class websocket {
   unsigned char msg_fin_ = 0;
 
   char msg_header_[10];
+  ws_head_len len_bytes_ = SHORT_HEADER;
 };
 
 }  // namespace cinatra

--- a/include/ylt/thirdparty/cinatra/ws_define.h
+++ b/include/ylt/thirdparty/cinatra/ws_define.h
@@ -211,6 +211,6 @@ struct frame_header {
 inline constexpr const size_t MAX_CLOSE_PAYLOAD = 123;
 
 inline constexpr const std::string_view WEBSOCKET = "websocket"sv;
-inline constexpr const std::string_view UPGRADE = "upgrade"sv;
+inline constexpr const std::string_view UPGRADE = "Upgrade"sv;
 inline constexpr const char ws_guid[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 }  // namespace cinatra


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
```
  coro_http::coro_http_server server(1, 9001);
  server.set_http_handler<cinatra::GET>(
      "/ws_echo",
      [](coro_http_request &req,
         coro_http_response &resp) -> async_simple::coro::Lazy<void> {
        assert(req.get_content_type() == content_type::websocket);
        std::string out_str;
        websocket_result result{};
        while (!result.eof) {
          result = co_await req.get_conn()->read_websocket();
          if (result.ec) {
            break;
          }

          if (result.type == ws_frame_type::WS_CLOSE_FRAME) {
            std::cout << "close frame\n";
            break;
          }

          out_str.append(result.data);

          auto ec = co_await req.get_conn()->write_websocket(result.data);
          if (ec) {
            continue;
          }
        }

        std::cout << out_str << "\n";
      });

  server.async_start();
```

## What is changing

## Example