### PR TITLE
[CMake][feat] Support FetchContent use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,21 +9,24 @@ project(yaLanTingLibs
 # load pack finder
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Find/)
 
-# add include path
-include_directories(include)
-include_directories(include/ylt/thirdparty)
-include_directories(src/include)
-
 find_package(Threads REQUIRED)
 link_libraries(Threads::Threads)
 
-include(cmake/utils.cmake)
-include(cmake/struct_pb.cmake)
-include(cmake/build.cmake)
-include(cmake/develop.cmake)
 include(cmake/install.cmake)
-# add project config, such as enable_ssl.
-include(cmake/config.cmake)
-# add project's source such as unit test, example & benchmark
-include(cmake/subdir.cmake)
+
+if(CMAKE_PROJECT_NAME STREQUAL "yaLanTingLibs") # if ylt is top-level project
+        # add include path
+        include_directories(include)
+        include_directories(include/ylt/thirdparty)
+        include_directories(src/include)
+
+        include(cmake/utils.cmake)
+        include(cmake/struct_pb.cmake)
+        include(cmake/build.cmake)
+        include(cmake/develop.cmake)
+        # add project config, such as enable_ssl.
+        include(cmake/config.cmake)
+        # add project's source such as unit test, example & benchmark
+        include(cmake/subdir.cmake)
+endif()
 

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -11,8 +11,14 @@ write_basic_package_version_file(
 )
 set(ConfigPackageLocation lib/cmake/yalantinglibs)
 
-
 add_library(yalantinglibs INTERFACE)
+add_library(yalantinglibs::yalantinglibs ALIAS yalantinglibs)
+
+target_include_directories(yalantinglibs INTERFACE 
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../include/ylt/thirdparty>
+)
 install(TARGETS yalantinglibs
        EXPORT yalantinglibsTargets
        LIBRARY DESTINATION lib


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

related to issue : #505 

Make FetchContent available without any test or example target built

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

~~1. CMake version requirement is up ( 3.15 => 3.21)~~
2. Subdirectories will not add into project unless project is top-level .
3. Add some ```$<INSTALL_INTERFACE>``` and ```$<BUILD_INTERFACE>``` to avoid explicit call ```include_directories``` outside 

## Example

Simple testing used 

```
cmake_minimum_required(VERSION 3.21)
project(ylt_test)

include(FetchContent)

FetchContent_Declare(
    yalantinglibs
    GIT_REPOSITORY https://github.com/JYLeeLYJ/yalantinglibs.git
    GIT_TAG feat/fetch # optional ( default master / main )
    GIT_SHALLOW 1 # optional ( --depth=1 )
)

FetchContent_MakeAvailable(yalantinglibs)
add_executable(main main.cpp)

target_link_libraries(main yalantinglibs::yalantinglibs)
target_compile_features(main PRIVATE cxx_std_20)
```