### PR TITLE
[coro_rpc] add attachment/close/get_connection_id for coro_rpc::context

### DIFF
--- a/include/ylt/coro_rpc/impl/coro_connection.hpp
+++ b/include/ylt/coro_rpc/impl/coro_connection.hpp
@@ -407,7 +407,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
 #endif
       auto attachment = std::get<2>(msg)();
       if (attachment.empty()) {
-        std::array<asio::const_buffer, 3> buffers{
+        std::array<asio::const_buffer, 2> buffers{
             asio::buffer(std::get<0>(msg)), asio::buffer(std::get<1>(msg))};
 #ifdef YLT_ENABLE_SSL
         if (use_ssl_) {

--- a/include/ylt/coro_rpc/impl/coro_connection.hpp
+++ b/include/ylt/coro_rpc/impl/coro_connection.hpp
@@ -22,6 +22,7 @@
 #include <asio/buffer.hpp>
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <future>
 #include <memory>
 #include <string_view>
@@ -37,12 +38,6 @@
 #endif
 namespace coro_rpc {
 
-template <typename T>
-concept apply_user_buf = requires() {
-  requires std::is_same_v<std::string_view,
-                          typename std::remove_cvref_t<T>::buffer_type>;
-};
-
 class coro_connection;
 using rpc_conn = std::shared_ptr<coro_connection>;
 
@@ -51,7 +46,11 @@ struct context_info_t {
   constexpr static size_t body_default_size_ = 256;
   std::shared_ptr<coro_connection> conn_;
   typename rpc_protocol::req_header req_head_;
-  std::vector<char> body_;
+  std::string body_;
+  std::string req_attachment_;
+  std::function<std::string_view()> resp_attachment_ = [] {
+    return std::string_view{};
+  };
   std::atomic<bool> has_response_ = false;
   bool is_delay_ = false;
   context_info_t(std::shared_ptr<coro_connection> &&conn)
@@ -158,6 +157,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     while (true) {
       auto &req_head = context_info->req_head_;
       auto &body = context_info->body_;
+      auto &req_attachment = context_info->req_attachment_;
       reset_timer();
       auto ec = co_await rpc_protocol::read_head(socket, req_head);
       cancel_timer();
@@ -195,16 +195,12 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
           break;
         }
 
-      std::string_view payload{};
+      std::string_view payload;
       // rpc_protocol::buffer_type maybe from user, default from framework.
-      constexpr bool apply_user_buf_v = apply_user_buf<rpc_protocol>;
-      if constexpr (apply_user_buf_v) {
-        ec = co_await rpc_protocol::read_payload(socket, req_head, payload);
-      }
-      else {
-        ec = co_await rpc_protocol::read_payload(socket, req_head, body);
-        payload = std::string_view{body.data(), body.size()};
-      }
+
+      ec = co_await rpc_protocol::read_payload(socket, req_head, body,
+                                               req_attachment);
+      payload = std::string_view{body};
 
       if (ec)
         AS_UNLIKELY {
@@ -256,7 +252,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
       if (resp_err != std::errc{})
         AS_UNLIKELY { std::swap(resp_buf, resp_error_msg); }
       std::string header_buf = rpc_protocol::prepare_response(
-          resp_buf, req_head, resp_err, resp_error_msg);
+          resp_buf, req_head, 0, resp_err, resp_error_msg);
 
 #ifdef UNIT_TEST_INJECT
       if (g_action == inject_action::close_socket_after_send_length) {
@@ -280,7 +276,10 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
         AS_LIKELY {
           if (resp_err != std::errc{})
             AS_UNLIKELY { resp_err_ = resp_err; }
-          write_queue_.emplace_back(std::move(header_buf), std::move(resp_buf));
+          write_queue_.emplace_back(std::move(header_buf), std::move(resp_buf),
+                                    [] {
+                                      return std::string_view{};
+                                    });
           if (write_queue_.size() == 1) {
             send_data().start([self = shared_from_this()](auto &&) {
             });
@@ -299,11 +298,13 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
 
   template <typename rpc_protocol>
   void response_msg(std::string &&body_buf,
+                    std::function<std::string_view()> &&resp_attachment,
                     const typename rpc_protocol::req_header &req_head,
                     bool is_delay) {
-    std::string header_buf = rpc_protocol::prepare_response(body_buf, req_head);
-    response(std::move(header_buf), std::move(body_buf), shared_from_this(),
-             is_delay)
+    std::string header_buf = rpc_protocol::prepare_response(
+        body_buf, req_head, resp_attachment().size());
+    response(std::move(header_buf), std::move(body_buf),
+             std::move(resp_attachment), shared_from_this(), is_delay)
         .via(executor_)
         .detach();
   }
@@ -351,9 +352,10 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
   auto &get_executor() { return *executor_; }
 
  private:
-  async_simple::coro::Lazy<void> response(std::string header_buf,
-                                          std::string body_buf, rpc_conn self,
-                                          bool is_delay) noexcept {
+  async_simple::coro::Lazy<void> response(
+      std::string header_buf, std::string body_buf,
+      std::function<std::string_view()> resp_attachment, rpc_conn self,
+      bool is_delay) noexcept {
     if (has_closed())
       AS_UNLIKELY {
         ELOGV(DEBUG, "response_msg failed: connection has been closed");
@@ -365,7 +367,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
       body_buf.clear();
     }
 #endif
-    write_queue_.emplace_back(std::move(header_buf), std::move(body_buf));
+    write_queue_.emplace_back(std::move(header_buf), std::move(body_buf),
+                              std::move(resp_attachment));
     if (is_delay) {
       --delay_resp_cnt;
       assert(delay_resp_cnt >= 0);
@@ -402,19 +405,38 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
         co_return;
       }
 #endif
-      std::array<asio::const_buffer, 2> buffers{asio::buffer(msg.first),
-                                                asio::buffer(msg.second)};
+      auto attachment = std::get<2>(msg)();
+      if (attachment.empty()) {
+        std::array<asio::const_buffer, 3> buffers{
+            asio::buffer(std::get<0>(msg)), asio::buffer(std::get<1>(msg))};
 #ifdef YLT_ENABLE_SSL
-      if (use_ssl_) {
-        assert(ssl_stream_);
-        ret = co_await coro_io::async_write(*ssl_stream_, buffers);
+        if (use_ssl_) {
+          assert(ssl_stream_);
+          ret = co_await coro_io::async_write(*ssl_stream_, buffers);
+        }
+        else {
+#endif
+          ret = co_await coro_io::async_write(socket_, buffers);
+#ifdef YLT_ENABLE_SSL
+        }
+#endif
       }
       else {
-#endif
-        ret = co_await coro_io::async_write(socket_, buffers);
+        std::array<asio::const_buffer, 3> buffers{
+            asio::buffer(std::get<0>(msg)), asio::buffer(std::get<1>(msg)),
+            asio::buffer(attachment)};
 #ifdef YLT_ENABLE_SSL
-      }
+        if (use_ssl_) {
+          assert(ssl_stream_);
+          ret = co_await coro_io::async_write(*ssl_stream_, buffers);
+        }
+        else {
 #endif
+          ret = co_await coro_io::async_write(socket_, buffers);
+#ifdef YLT_ENABLE_SSL
+        }
+#endif
+      }
       if (ret.first)
         AS_UNLIKELY {
           ELOGV(ERROR, "%s, %s", ret.first.message().data(),
@@ -449,11 +471,13 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     if (has_closed_) {
       return;
     }
-    close_socket();
+    has_closed_ = true;
+    asio::error_code ignored_ec;
+    socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ignored_ec);
+    socket_.close(ignored_ec);
     if (quit_callback_) {
       quit_callback_(conn_id_);
     }
-    has_closed_ = true;
   }
 
   void reset_timer() {
@@ -472,20 +496,9 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
             ELOGV(INFO, "close timeout client conn_id %d", conn_id_);
 #endif
 
-            close_socket();
+            close();
           }
         });
-  }
-
-  void close_socket() {
-    if (has_closed_) {
-      return;
-    }
-
-    asio::error_code ignored_ec;
-    socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ignored_ec);
-    socket_.close(ignored_ec);
-    has_closed_ = true;
   }
 
   void cancel_timer() {
@@ -502,7 +515,9 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
   async_simple::Executor *executor_;
   asio::ip::tcp::socket socket_;
   // FIXME: queue's performance can be imporved.
-  std::deque<std::pair<std::string, std::string>> write_queue_;
+  std::deque<
+      std::tuple<std::string, std::string, std::function<std::string_view()>>>
+      write_queue_;
   std::errc resp_err_;
   rpc_call_type rpc_call_type_{non_callback};
 

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -19,6 +19,7 @@
 #include <async_simple/coro/Lazy.h>
 #include <async_simple/coro/SyncAwait.h>
 
+#include <array>
 #include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
 #include <chrono>
@@ -36,7 +37,9 @@
 #include <variant>
 #include <ylt/easylog.hpp>
 
+#include "asio/buffer.hpp"
 #include "asio/dispatch.hpp"
+#include "asio/registered_buffer.hpp"
 #include "common_service.hpp"
 #include "context.hpp"
 #include "expected.hpp"
@@ -44,6 +47,7 @@
 #include "ylt/coro_io/coro_io.hpp"
 #include "ylt/coro_io/io_context_pool.hpp"
 #include "ylt/struct_pack.hpp"
+#include "ylt/struct_pack/util.h"
 #include "ylt/util/function_name.h"
 #include "ylt/util/type_traits.h"
 #include "ylt/util/utils.hpp"
@@ -127,7 +131,6 @@ class coro_rpc_client {
       : executor(executor),
         socket_(std::make_shared<asio::ip::tcp::socket>(executor)) {
     config_.client_id = client_id;
-    read_buf_.resize(default_read_buf_size_);
   }
 
   /*!
@@ -141,7 +144,6 @@ class coro_rpc_client {
         socket_(std::make_shared<asio::ip::tcp::socket>(
             executor.get_asio_executor())) {
     config_.client_id = client_id;
-    read_buf_.resize(default_read_buf_size_);
   }
 
   std::string_view get_host() const { return config_.host; }
@@ -347,12 +349,24 @@ class coro_rpc_client {
     if (has_closed_) {
       return;
     }
-
-    ELOGV(INFO, "client_id %d close", config_.client_id);
-
-    close_socket(socket_);
-
     has_closed_ = true;
+    ELOGV(INFO, "client_id %d close", config_.client_id);
+    close_socket(socket_);
+  }
+
+  bool set_req_attachment(std::string_view attachment) {
+    if (attachment.size() > UINT32_MAX) {
+      ELOGV(ERROR, "too large rpc attachment");
+      return false;
+    }
+    req_attachment_ = attachment;
+    return true;
+  }
+
+  std::string_view get_resp_attachment() const { return resp_attachment_buf_; }
+
+  std::string release_resp_attachment() {
+    return std::move(resp_attachment_buf_);
   }
 
   template <typename T, typename U>
@@ -534,7 +548,15 @@ class coro_rpc_client {
     using R = decltype(get_return_type<func>());
 
     auto buffer = prepare_buffer<func>(std::move(args)...);
+
     rpc_result<R, coro_rpc_protocol> r{};
+    if (buffer.empty()) {
+      r = rpc_result<R, coro_rpc_protocol>{
+          unexpect_t{},
+          coro_rpc_protocol::rpc_error{std::errc::message_size,
+                                       "rpc body serialize size too big"}};
+      co_return r;
+    }
 #ifdef GENERATE_BENCHMARK_DATA
     std::ofstream file(
         benchmark_file_path + std::string{get_func_name<func>()} + ".in",
@@ -581,12 +603,19 @@ class coro_rpc_client {
       co_return r;
     }
     else {
-      ret = co_await coro_io::async_write(
-          socket, asio::buffer(buffer.data(), buffer.size()));
+#endif
+      if (req_attachment_.empty())
+        ret = co_await coro_io::async_write(
+            socket, asio::buffer(buffer.data(), buffer.size()));
+      else {
+        std::array<asio::const_buffer, 2> iov{
+            asio::const_buffer{buffer.data(), buffer.size()},
+            asio::const_buffer{req_attachment_.data(), req_attachment_.size()}};
+        ret = co_await coro_io::async_write(socket, iov);
+        req_attachment_ = {};
+      }
+#ifdef UNIT_TEST_INJECT
     }
-#else
-    ret = co_await coro_io::async_write(
-        socket, asio::buffer(buffer.data(), buffer.size()));
 #endif
     if (!ret.first) {
 #ifdef UNIT_TEST_INJECT
@@ -606,11 +635,21 @@ class coro_rpc_client {
           asio::buffer((char *)&header, coro_rpc_protocol::RESP_HEAD_LEN));
       if (!ret.first) {
         uint32_t body_len = header.length;
-        if (body_len > read_buf_.size()) {
-          read_buf_.resize(body_len);
+        struct_pack::detail::resize(read_buf_, body_len);
+        if (header.attach_length == 0) {
+          ret = co_await coro_io::async_read(
+              socket, asio::buffer(read_buf_.data(), body_len));
+          resp_attachment_buf_.clear();
         }
-        ret = co_await coro_io::async_read(
-            socket, asio::buffer(read_buf_.data(), body_len));
+        else {
+          struct_pack::detail::resize(resp_attachment_buf_,
+                                      header.attach_length);
+          std::array<asio::mutable_buffer, 2> iov{
+              asio::mutable_buffer{read_buf_.data(), body_len},
+              asio::mutable_buffer{resp_attachment_buf_.data(),
+                                   resp_attachment_buf_.size()}};
+          ret = co_await coro_io::async_read(socket, iov);
+        }
         if (!ret.first) {
 #ifdef GENERATE_BENCHMARK_DATA
           std::ofstream file(
@@ -618,11 +657,11 @@ class coro_rpc_client {
               std::ofstream::binary | std::ofstream::out);
           file << std::string_view{(char *)&header,
                                    coro_rpc_protocol::RESP_HEAD_LEN};
-          file << std::string_view{(char *)read_buf_.data(), body_len};
+          file << read_buf_;
+          file << resp_attachment_buf_;
           file.close();
 #endif
-          r = handle_response_buffer<R>(read_buf_.data(), ret.second,
-                                        std::errc{header.err_code});
+          r = handle_response_buffer<R>(read_buf_, std::errc{header.err_code});
           if (!r) {
             close();
           }
@@ -673,6 +712,7 @@ class coro_rpc_client {
     header = {};
     header.magic = coro_rpc_protocol::magic_number;
     header.function_id = func_id<func>();
+    header.attach_length = req_attachment_.size();
 #ifdef UNIT_TEST_INJECT
     header.seq_num = config_.client_id;
     if (g_action == inject_action::client_send_bad_magic_num) {
@@ -683,7 +723,12 @@ class coro_rpc_client {
     }
     else {
 #endif
-      header.length = buffer.size() - coro_rpc_protocol::REQ_HEAD_LEN;
+      auto sz = buffer.size() - coro_rpc_protocol::REQ_HEAD_LEN;
+      if (sz > UINT32_MAX) {
+        ELOGV(ERROR, "too large rpc body");
+        return {};
+      }
+      header.length = sz;
 #ifdef UNIT_TEST_INJECT
     }
 #endif
@@ -691,13 +736,13 @@ class coro_rpc_client {
   }
 
   template <typename T>
-  rpc_result<T, coro_rpc_protocol> handle_response_buffer(
-      const std::byte *buffer, std::size_t len, std::errc rpc_errc) {
+  rpc_result<T, coro_rpc_protocol> handle_response_buffer(std::string &buffer,
+                                                          std::errc rpc_errc) {
     rpc_return_type_t<T> ret;
     struct_pack::errc ec;
     coro_rpc_protocol::rpc_error err;
     if (rpc_errc == std::errc{}) {
-      ec = struct_pack::deserialize_to(ret, (const char *)buffer, len);
+      ec = struct_pack::deserialize_to(ret, buffer);
       if (ec == struct_pack::errc::ok) {
         if constexpr (std::is_same_v<T, void>) {
           return {};
@@ -709,7 +754,7 @@ class coro_rpc_client {
     }
     else {
       err.code = rpc_errc;
-      ec = struct_pack::deserialize_to(err.msg, (const char *)buffer, len);
+      ec = struct_pack::deserialize_to(err.msg, buffer);
       if (ec == struct_pack::errc::ok) {
         return rpc_result<T, coro_rpc_protocol>{unexpect_t{}, std::move(err)};
       }
@@ -773,7 +818,8 @@ class coro_rpc_client {
  private:
   coro_io::ExecutorWrapper<> executor;
   std::shared_ptr<asio::ip::tcp::socket> socket_;
-  std::vector<std::byte> read_buf_;
+  std::string read_buf_, resp_attachment_buf_;
+  std::string_view req_attachment_;
   config config_;
   constexpr static std::size_t default_read_buf_size_ = 256;
 #ifdef YLT_ENABLE_SSL

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -604,9 +604,10 @@ class coro_rpc_client {
     }
     else {
 #endif
-      if (req_attachment_.empty())
+      if (req_attachment_.empty()) {
         ret = co_await coro_io::async_write(
             socket, asio::buffer(buffer.data(), buffer.size()));
+      }
       else {
         std::array<asio::const_buffer, 2> iov{
             asio::const_buffer{buffer.data(), buffer.size()},

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -29,11 +29,19 @@ Lazy<void> show_rpc_call() {
 
   [[maybe_unused]] auto ec = co_await client.connect("127.0.0.1", "8801");
   assert(ec == std::errc{});
+
   auto ret = co_await client.call<hello_world>();
   if (!ret) {
     std::cout << "hello_world err: " << ret.error().msg << std::endl;
   }
   assert(ret.value() == "hello_world"s);
+
+  client.set_req_attachment("This is attachment.");
+  auto ret_void = co_await client.call<echo_with_attachment>();
+  if (!ret) {
+    std::cout << "hello_world err: " << ret.error().msg << std::endl;
+  }
+  assert(client.get_resp_attachment() == "This is attachment.");
 
   auto ret_int = co_await client.call<A_add_B>(12, 30);
   if (!ret_int) {

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -43,6 +43,13 @@ Lazy<void> show_rpc_call() {
   }
   assert(client.get_resp_attachment() == "This is attachment.");
 
+  client.set_req_attachment("This is attachment2.");
+  ret_void = co_await client.call<echo_with_attachment2>();
+  if (!ret) {
+    std::cout << "hello_world err: " << ret.error().msg << std::endl;
+  }
+  assert(client.get_resp_attachment() == "This is attachment2.");
+
   auto ret_int = co_await client.call<A_add_B>(12, 30);
   if (!ret_int) {
     std::cout << "A_add_B err: " << ret_int.error().msg << std::endl;

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -33,8 +33,19 @@ int A_add_B(int a, int b) {
 }
 
 void echo_with_attachment(coro_rpc::context<void> conn) {
+  ELOGV(INFO, "call echo_with_attachment");
   std::string str = conn.release_request_attachment();
   conn.set_response_attachment(std::move(str));
+  conn.response_msg();
+}
+
+void echo_with_attachment2(coro_rpc::context<void> conn) {
+  ELOGV(INFO, "call echo_with_attachment2");
+  std::string_view str = conn.get_request_attachment();
+  // The live time of attachment is same as coro_rpc::context
+  conn.set_response_attachment([str, conn] {
+    return str;
+  });
   conn.response_msg();
 }
 

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -32,6 +32,12 @@ int A_add_B(int a, int b) {
   return a + b;
 }
 
+void echo_with_attachment(coro_rpc::context<void> conn) {
+  std::string str = conn.release_request_attachment();
+  conn.set_response_attachment(std::move(str));
+  conn.response_msg();
+}
+
 std::string echo(std::string_view sv) { return std::string{sv}; }
 
 async_simple::coro::Lazy<std::string> coro_echo(std::string_view sv) {

--- a/src/coro_rpc/examples/base_examples/rpc_service.h
+++ b/src/coro_rpc/examples/base_examples/rpc_service.h
@@ -24,6 +24,7 @@ std::string hello_world();
 int A_add_B(int a, int b);
 void hello_with_delay(coro_rpc::context<std::string> conn, std::string hello);
 std::string echo(std::string_view sv);
+void echo_with_attachment(coro_rpc::context<void> conn);
 async_simple::coro::Lazy<std::string> coro_echo(std::string_view sv);
 async_simple::coro::Lazy<std::string> nested_echo(std::string_view sv);
 class HelloService {

--- a/src/coro_rpc/examples/base_examples/rpc_service.h
+++ b/src/coro_rpc/examples/base_examples/rpc_service.h
@@ -25,6 +25,7 @@ int A_add_B(int a, int b);
 void hello_with_delay(coro_rpc::context<std::string> conn, std::string hello);
 std::string echo(std::string_view sv);
 void echo_with_attachment(coro_rpc::context<void> conn);
+void echo_with_attachment2(coro_rpc::context<void> conn);
 async_simple::coro::Lazy<std::string> coro_echo(std::string_view sv);
 async_simple::coro::Lazy<std::string> nested_echo(std::string_view sv);
 class HelloService {

--- a/src/coro_rpc/examples/base_examples/server.cpp
+++ b/src/coro_rpc/examples/base_examples/server.cpp
@@ -28,7 +28,8 @@ int main() {
 
   // regist normal function for rpc
   server.register_handler<hello_world, A_add_B, hello_with_delay, echo,
-                          nested_echo, coro_echo>();
+                          nested_echo, coro_echo, echo_with_attachment,
+                          echo_with_attachment2>();
 
   // regist member function for rpc
   HelloService hello_service;

--- a/src/coro_rpc/tests/rpc_api.cpp
+++ b/src/coro_rpc/tests/rpc_api.cpp
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "rpc_api.hpp"
+
 #include <ylt/coro_rpc/coro_rpc_context.hpp>
 #include <ylt/easylog.hpp>
-
-#include "rpc_api.hpp"
 
 using namespace coro_rpc;
 using namespace std::chrono_literals;
@@ -43,6 +43,12 @@ std::string large_arg_fun(std::string data) {
 int long_run_func(int val) {
   std::this_thread::sleep_for(40ms);
   return val;
+}
+
+void echo_with_attachment(coro_rpc::context<void> conn) {
+  auto str = conn.release_request_attachment();
+  conn.set_response_attachment(std::move(str));
+  conn.response_msg();
 }
 
 void coro_fun_with_user_define_connection_type(my_context conn) {

--- a/src/coro_rpc/tests/rpc_api.hpp
+++ b/src/coro_rpc/tests/rpc_api.hpp
@@ -15,9 +15,9 @@
  */
 #ifndef CORO_RPC_RPC_API_HPP
 #define CORO_RPC_RPC_API_HPP
-#include <ylt/coro_rpc/coro_rpc_context.hpp>
 #include <string>
 #include <thread>
+#include <ylt/coro_rpc/coro_rpc_context.hpp>
 
 void hi();
 std::string hello();
@@ -33,7 +33,7 @@ struct my_context {
   my_context(coro_rpc::context<void>&& ctx) : ctx_(std::move(ctx)) {}
   using return_type = void;
 };
-
+void echo_with_attachment(coro_rpc::context<void> conn);
 void coro_fun_with_user_define_connection_type(my_context conn);
 void coro_fun_with_delay_return_void(coro_rpc::context<void> conn);
 void coro_fun_with_delay_return_string(coro_rpc::context<std::string> conn);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Support attachment/close connection/get_connection_id by coro_rpc::context

## What is changing

## Example

```cpp
void echo_with_attachment(coro_rpc::context<void> conn) {
  auto id=conn.get_connection_id();
  std::cout<<"ID:<<id<<std::endl;
  if (conn.get_request_attachment().empty()) {
       conn.close();
  }
  std::string str = conn.release_request_attachment();
  conn.set_response_attachment(std::move(str));
  conn.response_msg();
}
```