### PR TITLE
[struct_pack][fix] set std::bitset as unportable type

### DIFF
--- a/include/ylt/struct_pack/type_id.hpp
+++ b/include/ylt/struct_pack/type_id.hpp
@@ -303,9 +303,11 @@ constexpr type_id get_type_id() {
                      std::is_same_v<T, void> || std::is_abstract_v<T>) {
     return type_id::monostate_t;
   }
+#ifdef STRUCT_PACK_ENABLE_UNPORTABLE_TYPE
   else if constexpr (bitset<T>) {
     return type_id::bitset_t;
   }
+#endif
   else if constexpr (string<T>) {
     return type_id::string_t;
   }

--- a/website/docs/en/struct_pack/struct_pack_tips.md
+++ b/website/docs/en/struct_pack/struct_pack_tips.md
@@ -22,7 +22,7 @@ struct_pack will save the data as little-endian even if the arch is big-endian. 
 | macro      | description |
 | ----------- | ------------------ |
 | STRUCT_PACK_OPTIMIZE               | Allow more extremed loop unrolling to get better performance, but it cost more compile time.    |
-| STRUCT_PACK_ENABLE_UNPORTABLE_TYPE | Enable serialize unportable type, such as wchar_t and wstring. Deserialize them in other platform is ubdefined bevaior. |
+| STRUCT_PACK_ENABLE_UNPORTABLE_TYPE | Enable serialize unportable type, such as wchar_t/std::wstring/std::bitset. Deserialize them in other platform maybe an undefined bevaior. |
 | STRUCT_PACK_ENABLE_INT128 | Enable serialize __int128 and __uint128. Not all compiler support it.
 ## How to speed up serialization/deserialization
 1. use string_view instead of string, use span instead of vector/array.

--- a/website/docs/zh/struct_pack/struct_pack_tips.md
+++ b/website/docs/zh/struct_pack/struct_pack_tips.md
@@ -23,7 +23,7 @@ struct_pack即使在大端架构下，也会将数据保存为小端格式。当
 | 宏      | 作用 |
 | ----------- | ------------------ |
 | STRUCT_PACK_OPTIMIZE               |增加模板实例化的数量，通过牺牲编译时间和二进制体积来换取更好的性能    |
-|STRUCT_PACK_ENABLE_UNPORTABLE_TYPE |允许序列化unportable的类型，如wchar_t和wstring，请注意，这些类型序列化出的二进制数据可能无法正常的在其他平台下反序列化|
+|STRUCT_PACK_ENABLE_UNPORTABLE_TYPE |允许序列化无法跨平台的类型，如wchar_t/std::wstring/std::bitset，请注意，这些类型序列化出的二进制数据可能无法正常的在其他平台下反序列化|
 | STRUCT_PACK_ENABLE_INT128 | 允许序列化128位整数，包括__uint128和__int128类型。请注意，只有部分编译器在部分架构下支持该类型。
 ## 如何让序列化or反序列化更加高效
 1. 考虑使用string_view代替string, 使用span代替vector/array；


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

std::bitset is hard to cross platform between big-endian & little-endian. 

## What is changing

Set it as unportable type now.

User can define marco STRUCT_PACK_ENABLE_UNPORTABLE_TYPE to enable std::bitset.

## Example
```cpp
#define STRUCT_PACK_ENABLE_UNPORTABLE_TYPE
#include<ylt/struct_pack.hpp>
int main() {
  auto buffer = struct_pack::serialize(std::bitset<114>{});
  return 0;
}
```