### PR TITLE
[strcut_xml][fix] fix parse Chinese text in xml

### DIFF
--- a/include/ylt/thirdparty/iguana/define.h
+++ b/include/ylt/thirdparty/iguana/define.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <array>
-#if __cplusplus >= 202002L
+#if (defined(_MSC_VER) && _MSC_VER >= 1920 && _MSVC_LANG >= 202002L) || \
+    (!defined(_MSC_VER) && defined(__cplusplus) && __cplusplus >= 202002L)
 #include <bit>
 #endif
+#include <array>
 #include <string>
 #include <string_view>
 #include <type_traits>

--- a/include/ylt/thirdparty/iguana/enum_reflection.hpp
+++ b/include/ylt/thirdparty/iguana/enum_reflection.hpp
@@ -6,6 +6,10 @@
 #include "frozen/unordered_map.h"
 
 namespace iguana {
+
+#if defined(__clang__) || defined(_MSC_VER) || \
+    (defined(__GNUC__) && __GNUC__ > 8)
+
 template <typename T>
 constexpr std::string_view get_raw_name() {
 #ifdef _MSC_VER
@@ -39,7 +43,7 @@ inline constexpr std::string_view type_string() {
 #else
   return str.substr(pos, next1 - pos);
 #endif
-}
+  }
 
 template <auto T>
 inline constexpr std::string_view enum_string() {
@@ -136,6 +140,8 @@ constexpr inline auto get_str_to_enum_map(
       {enum_names[Is], enum_values[Is]}...};
 }
 
+#endif
+
 // the default generic enum_value
 // if the user has not defined a specialization template, this will be called
 template <typename T>
@@ -145,6 +151,8 @@ struct enum_value {
 
 template <bool str_to_enum, typename E>
 constexpr inline auto get_enum_map() {
+#if defined(__clang__) || defined(_MSC_VER) || \
+    (defined(__GNUC__) && __GNUC__ > 8)
   constexpr auto &arr = enum_value<E>::value;
   constexpr auto arr_size = arr.size();
   if constexpr (arr_size > 0) {
@@ -166,6 +174,9 @@ constexpr inline auto get_enum_map() {
   else {
     return false;
   }
+#else
+  return false;
+#endif
 }
 
 #if defined(__clang__) && (__clang_major__ >= 17)

--- a/include/ylt/thirdparty/iguana/enum_reflection.hpp
+++ b/include/ylt/thirdparty/iguana/enum_reflection.hpp
@@ -43,7 +43,7 @@ inline constexpr std::string_view type_string() {
 #else
   return str.substr(pos, next1 - pos);
 #endif
-  }
+}
 
 template <auto T>
 inline constexpr std::string_view enum_string() {

--- a/include/ylt/thirdparty/iguana/json_util.hpp
+++ b/include/ylt/thirdparty/iguana/json_util.hpp
@@ -90,16 +90,6 @@ IGUANA_INLINE void skip_ws_no_comments(It &&it, It &&end) {
   }
 }
 
-inline constexpr auto has_zero = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
-  return (((chunk - 0x0101010101010101) & ~chunk) & 0x8080808080808080);
-};
-
-inline constexpr auto has_qoute = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
-  return has_zero(
-      chunk ^
-      0b0010001000100010001000100010001000100010001000100010001000100010);
-};
-
 inline constexpr auto has_escape = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
   return has_zero(
       chunk ^

--- a/include/ylt/thirdparty/iguana/reflection.hpp
+++ b/include/ylt/thirdparty/iguana/reflection.hpp
@@ -611,6 +611,9 @@ constexpr std::array<frozen::string, N> get_alias_arr(Args... pairs) {
       using size_type = std::integral_constant<                               \
           size_t, std::tuple_size_v<decltype(std::make_tuple(__VA_ARGS__))>>; \
       constexpr static std::string_view name() { return ALIAS; }              \
+      constexpr static std::string_view struct_name() {                       \
+        return std::string_view(#STRUCT_NAME, sizeof(#STRUCT_NAME) - 1);      \
+      }                                                                       \
       constexpr static size_t value() { return size_type::value; }            \
       constexpr static std::array<frozen::string, size_type::value> arr() {   \
         return iguana::detail::get_alias_arr<size_type::value>(__VA_ARGS__);  \

--- a/include/ylt/thirdparty/iguana/util.hpp
+++ b/include/ylt/thirdparty/iguana/util.hpp
@@ -193,4 +193,14 @@ IGUANA_INLINE void match(It &&it, It &&end) {
     }
 }
 
+inline constexpr auto has_zero = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
+  return (((chunk - 0x0101010101010101) & ~chunk) & 0x8080808080808080);
+};
+
+inline constexpr auto has_qoute = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
+  return has_zero(
+      chunk ^
+      0b0010001000100010001000100010001000100010001000100010001000100010);
+};
+
 }  // namespace iguana

--- a/include/ylt/thirdparty/iguana/xml_reader.hpp
+++ b/include/ylt/thirdparty/iguana/xml_reader.hpp
@@ -5,7 +5,6 @@
 #include "detail/utf.hpp"
 #include "xml_util.hpp"
 
-
 namespace iguana {
 namespace detail {
 

--- a/include/ylt/thirdparty/iguana/xml_reader.hpp
+++ b/include/ylt/thirdparty/iguana/xml_reader.hpp
@@ -5,6 +5,7 @@
 #include "detail/utf.hpp"
 #include "xml_util.hpp"
 
+
 namespace iguana {
 namespace detail {
 

--- a/include/ylt/thirdparty/iguana/xml_util.hpp
+++ b/include/ylt/thirdparty/iguana/xml_util.hpp
@@ -47,10 +47,6 @@ struct is_cdata_t<xml_cdata_t<T>> : std::true_type {};
 template <typename T>
 constexpr inline bool cdata_v = is_cdata_t<std::remove_cvref_t<T>>::value;
 
-inline constexpr auto has_zero = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
-  return (((chunk - 0x0101010101010101) & ~chunk) & 0x8080808080808080);
-};
-
 inline constexpr auto has_greater = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
   return has_zero(
       chunk ^
@@ -82,15 +78,9 @@ inline constexpr auto has_equal = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
       0b0011110100111101001111010011110100111101001111010011110100111101);
 };
 
-inline constexpr auto has_qoute = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
-  return has_zero(
-      chunk ^
-      0b0010001000100010001000100010001000100010001000100010001000100010);
-};
-
 template <typename It>
 IGUANA_INLINE void skip_sapces_and_newline(It &&it, It &&end) {
-  while (it != end && (*it < 33)) {
+  while (it != end && (static_cast<uint8_t>(*it) < 33)) {
     ++it;
   }
 }

--- a/include/ylt/thirdparty/iguana/xml_writer.hpp
+++ b/include/ylt/thirdparty/iguana/xml_writer.hpp
@@ -167,7 +167,7 @@ IGUANA_INLINE void render_xml_value(Stream &ss, T &&t, std::string_view name) {
              using value_type = underline_type_t<decltype(t.*v)>;
              constexpr auto Idx = decltype(i)::value;
              constexpr auto Count = M::value();
-             constexpr std::string_view tag_name =
+             [[maybe_unused]] constexpr std::string_view tag_name =
                  std::string_view(get_name<std::decay_t<T>, Idx>().data(),
                                   get_name<std::decay_t<T>, Idx>().size());
              static_assert(Idx < Count);

--- a/include/ylt/thirdparty/iguana/yaml_reader.hpp
+++ b/include/ylt/thirdparty/iguana/yaml_reader.hpp
@@ -6,6 +6,7 @@
 #include "detail/utf.hpp"
 #include "yaml_util.hpp"
 
+
 namespace iguana {
 
 template <typename T, typename It, std::enable_if_t<refletable_v<T>, int> = 0>
@@ -337,7 +338,8 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end, size_t min_spaces) {
       using value_type = std::decay_t<decltype(v)>;
       skip_space_and_lines(it, end, spaces);
       match<'-'>(it, end);
-      auto subspaces = skip_space_and_lines(it, end, spaces + 1);
+      [[maybe_unused]] auto subspaces =
+          skip_space_and_lines(it, end, spaces + 1);
       if constexpr (string_v<value_type>) {
         parse_item(v, it, end, spaces + 1);
       }
@@ -361,10 +363,10 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end, size_t min_spaces) {
   using T = std::remove_reference_t<U>;
   using key_type = typename T::key_type;
   using value_type = typename T::mapped_type;
-  auto spaces = skip_space_and_lines(it, end, min_spaces);
+  [[maybe_unused]] auto spaces = skip_space_and_lines(it, end, min_spaces);
   if (*it == '{') {
     ++it;
-    auto subspaces = skip_space_and_lines(it, end, min_spaces);
+    [[maybe_unused]] auto subspaces = skip_space_and_lines(it, end, min_spaces);
     while (it != end) {
       if (*it == '}')
         IGUANA_UNLIKELY {
@@ -470,7 +472,7 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end, size_t min_spaces) {
 
 template <typename It>
 IGUANA_INLINE void skip_object_value(It &&it, It &&end, size_t min_spaces) {
-  int subspace = min_spaces;
+  size_t subspace = min_spaces;
   while (it != end) {
     while (it != end && *it != '\n') {
       ++it;

--- a/include/ylt/thirdparty/iguana/yaml_reader.hpp
+++ b/include/ylt/thirdparty/iguana/yaml_reader.hpp
@@ -6,7 +6,6 @@
 #include "detail/utf.hpp"
 #include "yaml_util.hpp"
 
-
 namespace iguana {
 
 template <typename T, typename It, std::enable_if_t<refletable_v<T>, int> = 0>

--- a/include/ylt/thirdparty/iguana/yaml_util.hpp
+++ b/include/ylt/thirdparty/iguana/yaml_util.hpp
@@ -6,7 +6,7 @@ namespace iguana {
 // return true when it==end
 template <typename It>
 IGUANA_INLINE bool skip_space_till_end(It &&it, It &&end) {
-  while (it != end && *it < 33) ++it;
+  while (it != end && (static_cast<uint8_t>(*it) < 33)) ++it;
   return it == end;
 }
 

--- a/src/struct_xml/examples/main.cpp
+++ b/src/struct_xml/examples/main.cpp
@@ -253,6 +253,12 @@ void test_inner_object() {
   iguana::from_xml(obj1, str);
   assert(obj1.get_id() == 20);
   assert(obj1.get_name() == "tom");
+
+  std::string xml_str = R"(<some_object><id>20</id><name>小强</name></some_object>)";
+  some_object obj2;
+  iguana::from_xml(obj2, xml_str);
+  assert(obj2.get_id() == 20);
+  assert(obj2.get_name() == "小强");
 }
 
 struct shared_object {

--- a/src/struct_xml/examples/main.cpp
+++ b/src/struct_xml/examples/main.cpp
@@ -254,7 +254,8 @@ void test_inner_object() {
   assert(obj1.get_id() == 20);
   assert(obj1.get_name() == "tom");
 
-  std::string xml_str = R"(<some_object><id>20</id><name>小强</name></some_object>)";
+  std::string xml_str =
+      R"(<some_object><id>20</id><name>小强</name></some_object>)";
   some_object obj2;
   iguana::from_xml(obj2, xml_str);
   assert(obj2.get_id() == 20);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Close #520 

## What is changing

## Example
```c++
struct some_object {
  int id;
  std::string name;
};

int main() {
  std::string xml_str = R"(<some_object><id>20</id><name>小强</name></some_object>)";
  some_object obj2;
  iguana::from_xml(obj2, xml_str);
  assert(obj2.id == 20);
  assert(obj2.name == "小强");
}
```