### PR TITLE
[coro_rpc][breakchange] enhance error handling

### DIFF
--- a/include/ylt/coro_rpc/impl/context.hpp
+++ b/include/ylt/coro_rpc/impl/context.hpp
@@ -27,6 +27,7 @@
 #include <ylt/easylog.hpp>
 
 #include "coro_connection.hpp"
+#include "ylt/coro_rpc/impl/errno.h"
 #include "ylt/util/type_traits.h"
 
 namespace coro_rpc {
@@ -79,6 +80,10 @@ class context_base {
       AS_UNLIKELY { return; };
     self_->conn_->template response_error<rpc_protocol>(
         error_code, error_msg, self_->req_head_, self_->is_delay_);
+  }
+
+  void response_error(coro_rpc::errc error_code) {
+    response_error(error_code, make_error_message(error_code));
   }
   /*!
    * Send response message

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -297,7 +297,9 @@ class coro_rpc_client {
     if (!ssl_init_ret_) {
       ret = rpc_result<R, coro_rpc_protocol>{
           unexpect_t{},
-          coro_rpc_protocol::rpc_error{not_connected, "not connected"}};
+          coro_rpc_protocol::rpc_error{
+              errc::not_connected,
+              std::string{make_error_message(errc::not_connected)}}};
       co_return ret;
     }
 #endif
@@ -393,7 +395,7 @@ class coro_rpc_client {
 #ifdef YLT_ENABLE_SSL
     if (!ssl_init_ret_) {
       std::cout << "ssl_init_ret_: " << ssl_init_ret_ << std::endl;
-      co_return not_connected;
+      co_return errc::not_connected;
     }
 #endif
     if (!is_reconnect.value && has_closed_)
@@ -440,7 +442,7 @@ class coro_rpc_client {
       if (shake_ec) {
         ELOGV(WARN, "client_id %d handshake failed: %s", config_.client_id,
               shake_ec.message().data());
-        co_return not_connected;
+        co_return errc::not_connected;
       }
     }
 #endif

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -46,6 +46,7 @@
 #include "protocol/coro_rpc_protocol.hpp"
 #include "ylt/coro_io/coro_io.hpp"
 #include "ylt/coro_io/io_context_pool.hpp"
+#include "ylt/coro_rpc/impl/errno.h"
 #include "ylt/struct_pack.hpp"
 #include "ylt/struct_pack/util.h"
 #include "ylt/util/function_name.h"
@@ -90,7 +91,7 @@ using rpc_return_type_t = typename rpc_return_type<T>::type;
  *
  * Lazy<void> show_rpc_call(coro_rpc_client &client) {
  *   auto ec = co_await client.connect("127.0.0.1", "8801");
- *   assert(ec == std::errc{});
+ *   assert(!ec);
  *   auto result = co_await client.call<hello_coro_rpc>();
  *   if (!result) {
  *     std::cout << "err: " << result.error().msg << std::endl;
@@ -109,7 +110,7 @@ class coro_rpc_client {
 
  public:
   const inline static coro_rpc_protocol::rpc_error connect_error = {
-      std::errc::io_error, "client has been closed"};
+      errc::io_error, "client has been closed"};
   struct config {
     uint32_t client_id = 0;
     std::chrono::milliseconds timeout_duration =
@@ -178,7 +179,7 @@ class coro_rpc_client {
    * @param timeout_duration RPC call timeout
    * @return error code
    */
-  [[nodiscard]] async_simple::coro::Lazy<std::errc> reconnect(
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> reconnect(
       std::string host, std::string port,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5)) {
@@ -190,7 +191,7 @@ class coro_rpc_client {
     return connect(is_reconnect_t{true});
   }
 
-  [[nodiscard]] async_simple::coro::Lazy<std::errc> reconnect(
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> reconnect(
       std::string endpoint,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5)) {
@@ -213,7 +214,7 @@ class coro_rpc_client {
    * @param timeout_duration RPC call timeout
    * @return error code
    */
-  [[nodiscard]] async_simple::coro::Lazy<std::errc> connect(
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> connect(
       std::string host, std::string port,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5)) {
@@ -223,7 +224,7 @@ class coro_rpc_client {
         std::chrono::duration_cast<std::chrono::milliseconds>(timeout_duration);
     return connect();
   }
-  [[nodiscard]] async_simple::coro::Lazy<std::errc> connect(
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> connect(
       std::string_view endpoint,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5)) {
@@ -285,9 +286,9 @@ class coro_rpc_client {
       AS_UNLIKELY {
         ELOGV(ERROR, "client has been closed, please re-connect");
         auto ret = rpc_result<R, coro_rpc_protocol>{
-            unexpect_t{}, coro_rpc_protocol::rpc_error{
-                              std::errc::io_error,
-                              "client has been closed, please re-connect"}};
+            unexpect_t{},
+            coro_rpc_protocol::rpc_error{
+                errc::io_error, "client has been closed, please re-connect"}};
         co_return ret;
       }
 
@@ -295,8 +296,8 @@ class coro_rpc_client {
 #ifdef YLT_ENABLE_SSL
     if (!ssl_init_ret_) {
       ret = rpc_result<R, coro_rpc_protocol>{
-          unexpect_t{}, coro_rpc_protocol::rpc_error{std::errc::not_connected,
-                                                     "not connected"}};
+          unexpect_t{},
+          coro_rpc_protocol::rpc_error{not_connected, "not connected"}};
       co_return ret;
     }
 #endif
@@ -326,8 +327,8 @@ class coro_rpc_client {
 
     if (is_timeout_) {
       ret = rpc_result<R, coro_rpc_protocol>{
-          unexpect_t{}, coro_rpc_protocol::rpc_error{std::errc::timed_out,
-                                                     "rpc call timed out"}};
+          unexpect_t{},
+          coro_rpc_protocol::rpc_error{errc::timed_out, "rpc call timed out"}};
     }
 
     co_await promise.getFuture();
@@ -386,14 +387,13 @@ class coro_rpc_client {
     is_timeout_ = false;
     has_closed_ = false;
   }
-
-  static bool is_ok(std::errc ec) noexcept { return ec == std::errc{}; }
-  [[nodiscard]] async_simple::coro::Lazy<std::errc> connect(
+  static bool is_ok(coro_rpc::errc ec) noexcept { return !ec; }
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> connect(
       is_reconnect_t is_reconnect = is_reconnect_t{false}) {
 #ifdef YLT_ENABLE_SSL
     if (!ssl_init_ret_) {
       std::cout << "ssl_init_ret_: " << ssl_init_ret_ << std::endl;
-      co_return std::errc::not_connected;
+      co_return not_connected;
     }
 #endif
     if (!is_reconnect.value && has_closed_)
@@ -402,7 +402,7 @@ class coro_rpc_client {
               "a closed client is not allowed connect again, please use "
               "reconnect function or create a new "
               "client");
-        co_return std::errc::io_error;
+        co_return errc::io_error;
       }
     has_closed_ = false;
 
@@ -422,14 +422,14 @@ class coro_rpc_client {
     co_await promise.getFuture();
     if (ec) {
       if (is_timeout_) {
-        co_return std::errc::timed_out;
+        co_return errc::timed_out;
       }
-      co_return std::errc::not_connected;
+      co_return errc::not_connected;
     }
 
     if (is_timeout_) {
       ELOGV(WARN, "client_id %d connect timeout", config_.client_id);
-      co_return std::errc::timed_out;
+      co_return errc::timed_out;
     }
 
 #ifdef YLT_ENABLE_SSL
@@ -440,12 +440,12 @@ class coro_rpc_client {
       if (shake_ec) {
         ELOGV(WARN, "client_id %d handshake failed: %s", config_.client_id,
               shake_ec.message().data());
-        co_return std::errc::not_connected;
+        co_return not_connected;
       }
     }
 #endif
 
-    co_return std::errc{};
+    co_return coro_rpc::errc{};
   };
 #ifdef YLT_ENABLE_SSL
   [[nodiscard]] bool init_ssl_impl() {
@@ -553,7 +553,7 @@ class coro_rpc_client {
     if (buffer.empty()) {
       r = rpc_result<R, coro_rpc_protocol>{
           unexpect_t{},
-          coro_rpc_protocol::rpc_error{std::errc::message_size,
+          coro_rpc_protocol::rpc_error{errc::message_too_large,
                                        "rpc body serialize size too big"}};
       co_return r;
     }
@@ -575,8 +575,8 @@ class coro_rpc_client {
       ELOGV(INFO, "client_id %d close socket", config_.client_id);
       close();
       r = rpc_result<R, coro_rpc_protocol>{
-          unexpect_t{}, coro_rpc_protocol::rpc_error{std::errc::io_error,
-                                                     ret.first.message()}};
+          unexpect_t{},
+          coro_rpc_protocol::rpc_error{errc::io_error, ret.first.message()}};
       co_return r;
     }
     else if (g_action ==
@@ -587,8 +587,8 @@ class coro_rpc_client {
       ELOGV(INFO, "client_id %d close socket", config_.client_id);
       close();
       r = rpc_result<R, coro_rpc_protocol>{
-          unexpect_t{}, coro_rpc_protocol::rpc_error{std::errc::io_error,
-                                                     ret.first.message()}};
+          unexpect_t{},
+          coro_rpc_protocol::rpc_error{errc::io_error, ret.first.message()}};
       co_return r;
     }
     else if (g_action ==
@@ -598,8 +598,8 @@ class coro_rpc_client {
       ELOGV(INFO, "client_id %d shutdown", config_.client_id);
       socket_->shutdown(asio::ip::tcp::socket::shutdown_send);
       r = rpc_result<R, coro_rpc_protocol>{
-          unexpect_t{}, coro_rpc_protocol::rpc_error{std::errc::io_error,
-                                                     ret.first.message()}};
+          unexpect_t{},
+          coro_rpc_protocol::rpc_error{errc::io_error, ret.first.message()}};
       co_return r;
     }
     else {
@@ -624,8 +624,8 @@ class coro_rpc_client {
         ELOGV(INFO, "client_id %d client_close_socket_after_send_payload",
               config_.client_id);
         r = rpc_result<R, coro_rpc_protocol>{
-            unexpect_t{}, coro_rpc_protocol::rpc_error{std::errc::io_error,
-                                                       ret.first.message()}};
+            unexpect_t{},
+            coro_rpc_protocol::rpc_error{errc::io_error, ret.first.message()}};
         close();
         co_return r;
       }
@@ -662,7 +662,8 @@ class coro_rpc_client {
           file << resp_attachment_buf_;
           file.close();
 #endif
-          r = handle_response_buffer<R>(read_buf_, std::errc{header.err_code});
+          r = handle_response_buffer<R>(read_buf_,
+                                        coro_rpc::errc{header.err_code});
           if (!r) {
             close();
           }
@@ -677,13 +678,13 @@ class coro_rpc_client {
 #endif
     if (is_timeout_) {
       r = rpc_result<R, coro_rpc_protocol>{
-          unexpect_t{}, coro_rpc_protocol::rpc_error{
-                            .code = std::errc::timed_out, .msg = {}}};
+          unexpect_t{},
+          coro_rpc_protocol::rpc_error{.code = errc::timed_out, .msg = {}}};
     }
     else {
       r = rpc_result<R, coro_rpc_protocol>{
           unexpect_t{},
-          coro_rpc_protocol::rpc_error{.code = std::errc::io_error,
+          coro_rpc_protocol::rpc_error{.code = errc::io_error,
                                        .msg = ret.first.message()}};
     }
     close();
@@ -737,12 +738,12 @@ class coro_rpc_client {
   }
 
   template <typename T>
-  rpc_result<T, coro_rpc_protocol> handle_response_buffer(std::string &buffer,
-                                                          std::errc rpc_errc) {
+  rpc_result<T, coro_rpc_protocol> handle_response_buffer(
+      std::string &buffer, coro_rpc::errc rpc_errc) {
     rpc_return_type_t<T> ret;
     struct_pack::errc ec;
     coro_rpc_protocol::rpc_error err;
-    if (rpc_errc == std::errc{}) {
+    if (rpc_errc == coro_rpc::errc{}) {
       ec = struct_pack::deserialize_to(ret, buffer);
       if (ec == struct_pack::errc::ok) {
         if constexpr (std::is_same_v<T, void>) {
@@ -761,8 +762,7 @@ class coro_rpc_client {
       }
     }
     // deserialize failed.
-    err = {std::errc::invalid_argument,
-           "failed to deserialize rpc return value"};
+    err = {errc::invalid_argument, "failed to deserialize rpc return value"};
     return rpc_result<T, coro_rpc_protocol>{unexpect_t{}, std::move(err)};
   }
 
@@ -805,7 +805,8 @@ class coro_rpc_client {
 
 #ifdef UNIT_TEST_INJECT
  public:
-  std::errc sync_connect(const std::string &host, const std::string &port) {
+  coro_rpc::errc sync_connect(const std::string &host,
+                              const std::string &port) {
     return async_simple::coro::syncAwait(connect(host, port));
   }
 

--- a/include/ylt/coro_rpc/impl/errno.h
+++ b/include/ylt/coro_rpc/impl/errno.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <ylt/struct_pack/util.h>
+#pragma once
+namespace coro_rpc {
+enum class errc : uint8_t {
+  ok,
+  io_error,
+  not_connected,
+  timed_out,
+  invalid_argument,
+  address_in_use,
+  operation_canceled,
+  interrupted,
+  function_not_registered,
+  protocol_error,
+  message_too_large,
+  server_has_ran,
+  user_defined_err_min = 100,
+  user_defined_err_max = 255
+};
+inline bool operator!(errc ec) { return ec == errc::ok; }
+inline std::string_view make_error_message(errc ec) {
+  switch (ec) {
+    case errc::ok:
+      return "ok";
+    case errc::io_error:
+      return "io_error";
+    case errc::not_connected:
+      return "not_connected";
+    case errc::timed_out:
+      return "timed_out";
+    case errc::invalid_argument:
+      return "invalid_argument";
+    case errc::address_in_use:
+      return "address_in_use";
+    case errc::operation_canceled:
+      return "operation_canceled";
+    case errc::interrupted:
+      return "interrupted";
+    case errc::function_not_registered:
+      return "function_not_registered";
+    case errc::protocol_error:
+      return "protocol_error";
+    case errc::message_too_large:
+      return "message_too_large";
+    case errc::server_has_ran:
+      return "server_has_ran";
+    default:
+      return "unknown_user-defined_error";
+  }
+}
+};  // namespace coro_rpc

--- a/src/coro_io/tests/test_client_pool.cpp
+++ b/src/coro_io/tests/test_client_pool.cpp
@@ -156,9 +156,10 @@ TEST_CASE("test reconnect") {
 
 struct mock_client : public coro_rpc::coro_rpc_client {
   using coro_rpc::coro_rpc_client::coro_rpc_client;
-  async_simple::coro::Lazy<std::errc> reconnect(const std::string &hostname) {
+  async_simple::coro::Lazy<coro_rpc::errc> reconnect(
+      const std::string &hostname) {
     auto ec = co_await this->coro_rpc::coro_rpc_client::reconnect(hostname);
-    if (ec != std::errc{}) {
+    if (!!ec) {
       co_await coro_io::sleep_for(300ms);
     }
     co_return ec;

--- a/src/coro_rpc/benchmark/server.hpp
+++ b/src/coro_rpc/benchmark/server.hpp
@@ -39,7 +39,7 @@ inline int start_server(coro_rpc::coro_rpc_server& server) {
       pool.run();
     }};
     [[maybe_unused]] auto ec = server.start();
-    assert(ec == std::errc{});
+    assert(!ec);
     pool.stop();
     thrd.join();
   } catch (std::exception& e) {

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -28,7 +28,7 @@ Lazy<void> show_rpc_call() {
   coro_rpc_client client;
 
   [[maybe_unused]] auto ec = co_await client.connect("127.0.0.1", "8801");
-  assert(ec == std::errc{});
+  assert(!ec);
 
   auto ret = co_await client.call<hello_world>();
   if (!ret) {

--- a/src/coro_rpc/examples/base_examples/concurrent_clients.cpp
+++ b/src/coro_rpc/examples/base_examples/concurrent_clients.cpp
@@ -45,12 +45,12 @@ std::atomic<uint64_t> working_echo = 0;
 Lazy<void> call_echo(int cnt) {
   ++working_echo;
   coro_rpc_client client;
-  std::errc ec = co_await client.connect("localhost:8801");
-  for (int i = 0; i < 3 && ec != std::errc{}; ++i) {
+  auto ec = co_await client.connect("localhost:8801");
+  for (int i = 0; i < 3 && !ec; ++i) {
     co_await coro_io::sleep_for(rand() % 10000 * 1ms);
     ec = co_await client.reconnect("localhost:8801");
   }
-  if (ec == std::errc{}) {
+  if (!ec) {
     for (int i = 0; i < cnt; ++i) {
       auto res = co_await client.call<echo>("Hello world!");
       if (!res.has_value()) {

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -76,7 +76,7 @@ async_simple::coro::Lazy<std::string> nested_echo(std::string_view sv) {
   ELOGV(INFO, "start nested echo");
   coro_rpc::coro_rpc_client client(co_await coro_io::get_current_executor());
   [[maybe_unused]] auto ec = co_await client.connect("127.0.0.1", "8802");
-  assert(ec == std::errc{});
+  assert(!ec);
   ELOGV(INFO, "connect another server");
   auto ret = co_await client.call<echo>(sv);
   assert(ret.value() == sv);

--- a/src/coro_rpc/examples/base_examples/server.cpp
+++ b/src/coro_rpc/examples/base_examples/server.cpp
@@ -43,5 +43,5 @@ int main() {
   assert(res.has_value());
 
   // sync start server & sync await server stop
-  return server.start() == std::errc{};
+  return !server.start();
 }

--- a/src/coro_rpc/examples/file_transfer/file_client.cpp
+++ b/src/coro_rpc/examples/file_transfer/file_client.cpp
@@ -7,7 +7,7 @@
 async_simple::coro::Lazy<void> test(coro_rpc::coro_rpc_client &client,
                                     auto filename) {
   [[maybe_unused]] auto ret = co_await client.connect("127.0.0.1", "9000");
-  assert(ret == std::errc{});
+  assert(!ret);
 
   auto result = co_await client.call<echo>("hello lantinglibs");
   if (result) {

--- a/src/coro_rpc/examples/file_transfer/file_server.cpp
+++ b/src/coro_rpc/examples/file_transfer/file_server.cpp
@@ -12,6 +12,6 @@ int main() {
   server.register_handler<&dummy::echo>(&d);
 
   [[maybe_unused]] auto ret = server.start();
-  assert(ret == std::errc{});
+  assert(!ret);
   return 0;
 }

--- a/src/coro_rpc/tests/rpc_api.hpp
+++ b/src/coro_rpc/tests/rpc_api.hpp
@@ -34,6 +34,9 @@ struct my_context {
   using return_type = void;
 };
 void echo_with_attachment(coro_rpc::context<void> conn);
+inline void error_with_context(coro_rpc::context<void> conn) {
+  conn.response_error(coro_rpc::errc{104}, "My Error.");
+}
 void coro_fun_with_user_define_connection_type(my_context conn);
 void coro_fun_with_delay_return_void(coro_rpc::context<void> conn);
 void coro_fun_with_delay_return_string(coro_rpc::context<std::string> conn);

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -29,6 +29,7 @@
 
 #include "doctest.h"
 #include "rpc_api.hpp"
+#include "ylt/coro_rpc/impl/errno.h"
 using namespace coro_rpc;
 using namespace std::chrono_literals;
 using namespace std::string_literals;
@@ -51,7 +52,7 @@ Lazy<std::shared_ptr<coro_rpc_client>> create_client(
   REQUIRE_MESSAGE(ok == true, "init ssl fail, please check ssl config");
 #endif
   auto ec = co_await client->connect("127.0.0.1", port);
-  REQUIRE_MESSAGE(ec == std::errc{}, make_error_code(ec).message());
+  REQUIRE(!ec);
   co_return client;
 }
 
@@ -60,12 +61,12 @@ TEST_CASE("testing client") {
     coro_rpc::coro_rpc_client client;
     auto lazy_ret = client.connect("", "");
     auto ret = syncAwait(lazy_ret);
-    CHECK(ret == std::errc::not_connected);
+    CHECK(ret == coro_rpc::errc::not_connected);
   }
   {
     coro_rpc::coro_rpc_client client;
     auto ret = client.sync_connect("", "");
-    CHECK(ret == std::errc::not_connected);
+    CHECK(ret == coro_rpc::errc::not_connected);
   }
   g_action = {};
   std::string port = std::to_string(coro_rpc_server_port);
@@ -93,7 +94,7 @@ TEST_CASE("testing client") {
     auto f = [&io_context, &port]() -> Lazy<void> {
       auto client = co_await create_client(io_context, port);
       auto ret = co_await client->template call<hello>();
-      CHECK_MESSAGE(ret.error().code == std::errc::function_not_supported,
+      CHECK_MESSAGE(ret.error().code == coro_rpc::errc::function_not_registered,
                     ret.error().msg);
       co_return;
     };
@@ -104,7 +105,7 @@ TEST_CASE("testing client") {
     auto f = [&io_context, &port]() -> Lazy<void> {
       auto client = co_await create_client(io_context, port);
       auto ret = co_await client->template call<hi>();
-      CHECK_MESSAGE(ret.error().code == std::errc::function_not_supported,
+      CHECK_MESSAGE(ret.error().code == coro_rpc::errc::function_not_registered,
                     ret.error().msg);
       co_return;
     };
@@ -116,7 +117,8 @@ TEST_CASE("testing client") {
     auto f = [&io_context, &port]() -> Lazy<void> {
       auto client = co_await create_client(io_context, port);
       auto ret = co_await client->template call_for<hello_timeout>(20ms);
-      CHECK_MESSAGE(ret.error().code == std::errc::timed_out, ret.error().msg);
+      CHECK_MESSAGE(ret.error().code == coro_rpc::errc::timed_out,
+                    ret.error().msg);
       co_return;
     };
     server.register_handler<hello_timeout>();
@@ -192,7 +194,8 @@ TEST_CASE("testing client with inject server") {
       auto client = co_await create_client(io_context, port);
       g_action = inject_action::close_socket_after_read_header;
       auto ret = co_await client->template call<hello>();
-      REQUIRE_MESSAGE(ret.error().code == std::errc::io_error, ret.error().msg);
+      REQUIRE_MESSAGE(ret.error().code == coro_rpc::errc::io_error,
+                      ret.error().msg);
     };
     syncAwait(f());
   }
@@ -202,7 +205,8 @@ TEST_CASE("testing client with inject server") {
       auto client = co_await create_client(io_context, port);
       g_action = inject_action::close_socket_after_send_length;
       auto ret = co_await client->template call<hello>();
-      REQUIRE_MESSAGE(ret.error().code == std::errc::io_error, ret.error().msg);
+      REQUIRE_MESSAGE(ret.error().code == coro_rpc::errc::io_error,
+                      ret.error().msg);
     };
     syncAwait(f());
   }
@@ -367,7 +371,7 @@ TEST_CASE("testing client with eof") {
   REQUIRE_MESSAGE(res, "server start failed");
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto ec = client.sync_connect("127.0.0.1", "8801");
-  REQUIRE_MESSAGE(ec == std::errc{}, make_error_code(ec).message());
+  REQUIRE_MESSAGE(!ec, make_error_message(ec));
 
   server.register_handler<hello, client_hello>();
   auto ret = client.sync_call<hello>();
@@ -378,7 +382,8 @@ TEST_CASE("testing client with eof") {
 
   g_action = inject_action::client_close_socket_after_send_partial_header;
   ret = client.sync_call<hello>();
-  REQUIRE_MESSAGE(ret.error().code == std::errc::io_error, ret.error().msg);
+  REQUIRE_MESSAGE(ret.error().code == coro_rpc::errc::io_error,
+                  ret.error().msg);
 }
 TEST_CASE("testing client with attachment") {
   g_action = {};
@@ -388,7 +393,7 @@ TEST_CASE("testing client with attachment") {
   REQUIRE_MESSAGE(res, "server start failed");
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto ec = client.sync_connect("127.0.0.1", "8801");
-  REQUIRE_MESSAGE(ec == std::errc{}, make_error_code(ec).message());
+  REQUIRE_MESSAGE(!ec, make_error_message(ec));
 
   server.register_handler<echo_with_attachment>();
 
@@ -406,6 +411,21 @@ TEST_CASE("testing client with attachment") {
   CHECK(client.get_resp_attachment() == "");
 }
 
+TEST_CASE("testing client with context response user-defined error") {
+  g_action = {};
+  coro_rpc_server server(2, 8801);
+  auto res = server.async_start();
+  REQUIRE_MESSAGE(res, "server start failed");
+  coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
+  auto ec = client.sync_connect("127.0.0.1", "8801");
+  REQUIRE(!ec);
+  server.register_handler<error_with_context>();
+  auto ret = client.sync_call<error_with_context>();
+  CHECK(!ret.has_value());
+  CHECK(ret.error().code == coro_rpc::errc{104});
+  CHECK(ret.error().msg == "My Error.");
+}
+
 TEST_CASE("testing client with shutdown") {
   g_action = {};
   coro_rpc_server server(2, 8801);
@@ -413,7 +433,7 @@ TEST_CASE("testing client with shutdown") {
   CHECK_MESSAGE(res, "server start timeout");
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto ec = client.sync_connect("127.0.0.1", "8801");
-  REQUIRE_MESSAGE(ec == std::errc{}, make_error_code(ec).message());
+  REQUIRE_MESSAGE(!ec, make_error_message(ec));
   server.register_handler<hello, client_hello>();
 
   g_action = inject_action::nothing;
@@ -425,7 +445,8 @@ TEST_CASE("testing client with shutdown") {
 
   g_action = inject_action::client_shutdown_socket_after_send_header;
   ret = client.sync_call<hello>();
-  REQUIRE_MESSAGE(ret.error().code == std::errc::io_error, ret.error().msg);
+  REQUIRE_MESSAGE(ret.error().code == coro_rpc::errc::io_error,
+                  ret.error().msg);
 
   g_action = {};
 }
@@ -444,7 +465,7 @@ TEST_CASE("testing client timeout") {
     coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
     auto ret = client.connect("10.255.255.1", "8801", 5ms);
     auto val = syncAwait(ret);
-    CHECK_MESSAGE(val == std::errc::timed_out, make_error_code(val).message());
+    CHECK_MESSAGE(val == coro_rpc::errc::timed_out, make_error_message(val));
   }
   // SUBCASE("call, 0ms timeout") {
   //   coro_rpc_server server(2, 8801);
@@ -462,15 +483,13 @@ TEST_CASE("testing client timeout") {
 TEST_CASE("testing client connect err") {
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto val = syncAwait(client.connect("127.0.0.1", "8801"));
-  CHECK_MESSAGE(val == std::errc::not_connected,
-                make_error_code(val).message());
+  CHECK_MESSAGE(val == coro_rpc::errc::not_connected, make_error_message(val));
 }
 #ifdef UNIT_TEST_INJECT
 TEST_CASE("testing client sync connect, unit test inject only") {
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto val = client.sync_connect("127.0.0.1", "8801");
-  CHECK_MESSAGE(val == std::errc::not_connected,
-                make_error_code(val).message());
+  CHECK_MESSAGE(val == coro_rpc::errc::not_connected, make_error_message(val));
 #ifdef YLT_ENABLE_SSL
   SUBCASE("client use ssl but server don't use ssl") {
     g_action = {};
@@ -500,7 +519,8 @@ TEST_CASE("testing client call timeout") {
     //    assert(ec == std::errc{});
     auto ret = client.call<hi>();
     auto val = syncAwait(ret);
-    CHECK_MESSAGE(val.error().code == std::errc::timed_out, val.error().msg);
+    CHECK_MESSAGE(val.error().code == coro_rpc::errc::timed_out,
+                  val.error().msg);
     g_action = inject_action::nothing;
   }
 #ifdef __GNUC__
@@ -515,10 +535,11 @@ TEST_CASE("testing client call timeout") {
     coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
     auto ec_lazy = client.connect("127.0.0.1", "8801");
     auto ec = syncAwait(ec_lazy);
-    REQUIRE(ec == std::errc{});
+    REQUIRE(!ec);
     auto ret = client.call_for<hello_timeout>(10ms);
     auto val = syncAwait(ret);
-    CHECK_MESSAGE(val.error().code == std::errc::timed_out, val.error().msg);
+    CHECK_MESSAGE(val.error().code == coro_rpc::errc::timed_out,
+                  val.error().msg);
   }
 #endif
   g_action = {};

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -278,10 +278,10 @@ class SSLClientTester {
     if (client_crt == ssl_type::fake || client_crt == ssl_type::no) {
       REQUIRE(ok == false);
       auto ec = syncAwait(client->connect("127.0.0.1", port_));
-      REQUIRE_MESSAGE(ec == std::errc::not_connected,
-                      make_error_code(ec).message());
+      REQUIRE_MESSAGE(ec == coro_rpc::errc::not_connected,
+                      make_error_message(ec));
       auto ret = syncAwait(client->template call<hi>());
-      REQUIRE_MESSAGE(ret.error().code == std::errc::not_connected,
+      REQUIRE_MESSAGE(ret.error().code == coro_rpc::errc::not_connected,
                       ret.error().msg);
     }
     else {
@@ -289,16 +289,16 @@ class SSLClientTester {
       auto f = [this, &client]() -> Lazy<void> {
         auto ec = co_await client->connect("127.0.0.1", port_);
         if (server_crt == ssl_type::_ && server_key == ssl_type::_) {
-          if (ec != std::errc{}) {
+          if (!!ec) {
             ELOGV(INFO, "%s", gen_err().data());
           }
-          REQUIRE_MESSAGE(ec == std::errc{}, make_error_code(ec).message());
+          REQUIRE_MESSAGE(!ec, make_error_message(ec));
           auto ret = co_await client->template call<hi>();
           CHECK(ret.has_value());
         }
         else {
-          REQUIRE_MESSAGE(ec == std::errc::not_connected,
-                          make_error_code(ec).message());
+          REQUIRE_MESSAGE(ec == coro_rpc::errc::not_connected,
+                          make_error_message(ec));
         }
       };
       syncAwait(f());
@@ -500,8 +500,8 @@ TEST_CASE("testing client sync connect, unit test inject only") {
     bool ok = client2.init_ssl("../openssl_files", "server.crt");
     CHECK(ok == true);
     val = client2.sync_connect("127.0.0.1", "8801");
-    CHECK_MESSAGE(val == std::errc::not_connected,
-                  make_error_code(val).message());
+    CHECK_MESSAGE(val == coro_rpc::errc::not_connected,
+                  make_error_message(val));
   }
 #endif
 }

--- a/website/docs/zh/coro_rpc/coro_rpc_doc.hpp
+++ b/website/docs/zh/coro_rpc/coro_rpc_doc.hpp
@@ -65,13 +65,13 @@ class coro_rpc_server {
    *
    * @return 正常启动返回空，否则返回错误码
    */
-  async_simple::coro::Lazy<std::errc> async_start() noexcept;
+  async_simple::coro::Lazy<coro_rpc::errc> async_start() noexcept;
   /*!
    * 阻塞方式启动server, 如果端口被占用将会返回非空的错误码
    *
    * @return 正常启动返回空，否则返回错误码
    */
-  std::errc start();
+  coro_rpc::errc start();
   /*!
    * 停止server，阻塞等待直到server停止；
    */
@@ -159,7 +159,7 @@ class coro_rpc_server {
  *
  */
 struct rpc_error {
-  std::errc code;
+  coro_rpc::errc code;
   std::string msg;
 };
 
@@ -175,7 +175,7 @@ struct rpc_error {
  *
  * Lazy<void> show_rpc_call(coro_rpc_client &client) {
  *   auto ec = co_await client.connect("127.0.0.1", "8801");
- *   assert(ec == std::errc{});
+ *   assert(!ec);
  *   auto result = co_await client.call<hello_coro_rpc>();
  *   if (!result) {
  *     std::cout << "err: " << result.error().msg << std::endl;
@@ -215,7 +215,7 @@ class coro_rpc_client {
    * @param timeout_duration rpc调用超时时间
    * @return 连接错误码，为空表示连接失败
    */
-  async_simple::coro::Lazy<std::errc> connect(
+  async_simple::coro::Lazy<coro_rpc::errc> connect(
       const std::string &host, const std::string &port,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5));


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

## What is changing

1. use enum class `coro_rpc::errc : uint8_t` instead of `std::errc` for cross-platform.
2. add support for user set error by coro_rpc::context<T>.
3. add support for user-defined framework error code.(It should between 100-255)

## Example

```cpp
void hello(coro_rpc::context<void> ctx) {
  ctx.response_error(coro_rpc::errc::io_error,"This is io error.");
}
```