### PR TITLE
fix code error

### DIFF
--- a/include/ylt/struct_pack/endian_wrapper.hpp
+++ b/include/ylt/struct_pack/endian_wrapper.hpp
@@ -277,7 +277,8 @@ STRUCT_PACK_INLINE void write(Writer& writer, const T& t) {
   }
   else if constexpr (detail::array<T>) {
     if constexpr (detail::is_little_endian_copyable<sizeof(t[0])> &&
-                  std::is_fundamental_v<std::remove_reference_t<decltype(t[0])>>) {
+                  std::is_fundamental_v<
+                      std::remove_reference_t<decltype(t[0])>>) {
       write_bytes_array(writer, (const char*)t.data(), sizeof(T));
     }
     else {
@@ -319,7 +320,8 @@ STRUCT_PACK_INLINE constexpr std::size_t get_write_size(const T& t) {
     return sizeof(T);
   }
   else if constexpr (detail::array<T>) {
-    if constexpr (std::is_fundamental_v<std::remove_reference_t<decltype(t[0])>>) {
+    if constexpr (std::is_fundamental_v<
+                      std::remove_reference_t<decltype(t[0])>>) {
       return sizeof(T);
     }
     else {
@@ -359,7 +361,8 @@ STRUCT_PACK_INLINE struct_pack::errc read(Reader& reader, T& t) {
     }
   }
   else if constexpr (detail::array<T>) {
-    if constexpr (std::is_fundamental_v<std::remove_reference_t<decltype(t[0])>> &&
+    if constexpr (std::is_fundamental_v<
+                      std::remove_reference_t<decltype(t[0])>> &&
                   detail::is_little_endian_copyable<sizeof(t[0])>) {
       return read_bytes_array(reader, (char*)t.data(), sizeof(T));
     }
@@ -381,7 +384,8 @@ STRUCT_PACK_INLINE struct_pack::errc read(Reader& reader, T& t) {
       return ec;
     }
     if constexpr (detail::continuous_container<T> &&
-                  std::is_fundamental_v<std::remove_reference_t<decltype(t[0])>> &&
+                  std::is_fundamental_v<
+                      std::remove_reference_t<decltype(t[0])>> &&
                   detail::is_little_endian_copyable<sizeof(t[0])> &&
                   checkable_reader_t<Reader>) {
       if SP_UNLIKELY (sz > UINT64_MAX / sizeof(t[0]) || sz > SIZE_MAX) {
@@ -392,7 +396,7 @@ STRUCT_PACK_INLINE struct_pack::errc read(Reader& reader, T& t) {
         return struct_pack::errc::no_buffer_space;
       }
       detail::resize(t, mem_size);
-      if(!read_bytes_array(reader, (char*)t.data(), mem_size)) {
+      if (!read_bytes_array(reader, (char*)t.data(), mem_size)) {
         return struct_pack::errc::no_buffer_space;
       }
       return struct_pack::errc{};


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

writer_bytes_array: function name error
decltype(t[0]) :t[0] may be return reference 

<!-- For example: "Closes #1234" -->

writer_bytes_array==>write_bytes_array
decltype(t[0]) ==>std::remove_reference_t<decltype(t[0])>

```
#include <iostream>
#include <random>
#include <string>
#include <type_traits>
#include <vector>

int main() {
  std::string sz = "sss";

  std::cout
      << std::is_same_v<
             char,
             std::remove_reference_t<decltype(
                 sz[0])>> << std::is_same_v<char, decltype(sz[0])> << std::endl;

  std::vector<int> arr{1, 2};
  std::cout
      << std::is_same_v<
             int,
             std::remove_reference_t<decltype(
                 arr[0])>> << std::is_same_v<int, decltype(arr[0])> << std::endl;

  return 0;
}

10
10
```

<!-- Please give a short summary of the change and the problem this solves. -->



## What is changing
## Example