### PR TITLE
[coro_rpc][fix] keep protocol compatible/use context<T>::tag() instead o…

### DIFF
--- a/include/ylt/coro_rpc/impl/context.hpp
+++ b/include/ylt/coro_rpc/impl/context.hpp
@@ -75,14 +75,14 @@ class context_base {
 
   using return_type = return_msg_type;
 
-  void response_error(coro_rpc::errc error_code, std::string_view error_msg) {
+  void response_error(coro_rpc::err_code error_code,
+                      std::string_view error_msg) {
     if (!check_status())
       AS_UNLIKELY { return; };
     self_->conn_->template response_error<rpc_protocol>(
         error_code, error_msg, self_->req_head_, self_->is_delay_);
   }
-
-  void response_error(coro_rpc::errc error_code) {
+  void response_error(coro_rpc::err_code error_code) {
     response_error(error_code, make_error_message(error_code));
   }
   /*!
@@ -190,13 +190,8 @@ class context_base {
     self_->conn_->set_rpc_call_type(
         coro_connection::rpc_call_type::callback_with_delay);
   }
-
-  template <typename T>
-  void set_tag(T &&tag) {
-    self_->conn_->set_tag(std::forward<T>(tag));
-  }
-
-  std::any get_tag() { return self_->conn_->get_tag(); }
+  std::any &tag() { return self_->conn_->tag(); }
+  const std::any &tag() const { return self_->conn_->tag(); }
 };
 
 template <typename T>

--- a/include/ylt/coro_rpc/impl/coro_connection.hpp
+++ b/include/ylt/coro_rpc/impl/coro_connection.hpp
@@ -315,8 +315,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
       return {};
     };
     std::string body_buf;
-    std::string header_buf =
-        rpc_protocol::prepare_response(body_buf, req_head, 0, ec, error_msg);
+    std::string header_buf = rpc_protocol::prepare_response(
+        body_buf, req_head, 0, ec, error_msg, true);
     response(std::move(header_buf), std::move(body_buf), std::move(attach_ment),
              shared_from_this(), is_delay)
         .via(executor_)
@@ -356,12 +356,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     conn_id_ = conn_id;
   }
 
-  template <typename T>
-  void set_tag(T &&tag) {
-    tag_ = std::forward<T>(tag);
-  }
-
-  std::any get_tag() { return tag_; }
+  std::any &tag() { return tag_; }
+  const std::any &tag() const { return tag_; }
 
   auto &get_executor() { return *executor_; }
 

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -179,7 +179,7 @@ class coro_rpc_client {
    * @param timeout_duration RPC call timeout
    * @return error code
    */
-  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> reconnect(
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::err_code> reconnect(
       std::string host, std::string port,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5)) {
@@ -191,7 +191,7 @@ class coro_rpc_client {
     return connect(is_reconnect_t{true});
   }
 
-  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> reconnect(
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::err_code> reconnect(
       std::string endpoint,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5)) {
@@ -214,7 +214,7 @@ class coro_rpc_client {
    * @param timeout_duration RPC call timeout
    * @return error code
    */
-  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> connect(
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::err_code> connect(
       std::string host, std::string port,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5)) {
@@ -224,7 +224,7 @@ class coro_rpc_client {
         std::chrono::duration_cast<std::chrono::milliseconds>(timeout_duration);
     return connect();
   }
-  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> connect(
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::err_code> connect(
       std::string_view endpoint,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5)) {
@@ -389,8 +389,8 @@ class coro_rpc_client {
     is_timeout_ = false;
     has_closed_ = false;
   }
-  static bool is_ok(coro_rpc::errc ec) noexcept { return !ec; }
-  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::errc> connect(
+  static bool is_ok(coro_rpc::err_code ec) noexcept { return (bool)ec; }
+  [[nodiscard]] async_simple::coro::Lazy<coro_rpc::err_code> connect(
       is_reconnect_t is_reconnect = is_reconnect_t{false}) {
 #ifdef YLT_ENABLE_SSL
     if (!ssl_init_ret_) {
@@ -447,7 +447,7 @@ class coro_rpc_client {
     }
 #endif
 
-    co_return coro_rpc::errc{};
+    co_return coro_rpc::err_code{};
   };
 #ifdef YLT_ENABLE_SSL
   [[nodiscard]] bool init_ssl_impl() {
@@ -664,9 +664,9 @@ class coro_rpc_client {
           file << resp_attachment_buf_;
           file.close();
 #endif
-          r = handle_response_buffer<R>(read_buf_,
-                                        coro_rpc::errc{header.err_code});
-          if (!r) {
+          bool ec = false;
+          r = handle_response_buffer<R>(read_buf_, header.err_code, ec);
+          if (ec) {
             close();
           }
           co_return r;
@@ -740,29 +740,41 @@ class coro_rpc_client {
   }
 
   template <typename T>
-  rpc_result<T, coro_rpc_protocol> handle_response_buffer(
-      std::string &buffer, coro_rpc::errc rpc_errc) {
+  rpc_result<T, coro_rpc_protocol> handle_response_buffer(std::string &buffer,
+                                                          uint8_t rpc_errc,
+                                                          bool &error_happen) {
     rpc_return_type_t<T> ret;
     struct_pack::errc ec;
     coro_rpc_protocol::rpc_error err;
-    if (rpc_errc == coro_rpc::errc{}) {
-      ec = struct_pack::deserialize_to(ret, buffer);
-      if (ec == struct_pack::errc::ok) {
-        if constexpr (std::is_same_v<T, void>) {
-          return {};
-        }
-        else {
-          return std::move(ret);
+    if (rpc_errc == 0)
+      AS_LIKELY {
+        ec = struct_pack::deserialize_to(ret, buffer);
+        if (ec == struct_pack::errc::ok) {
+          if constexpr (std::is_same_v<T, void>) {
+            return {};
+          }
+          else {
+            return std::move(ret);
+          }
         }
       }
-    }
     else {
       err.code = rpc_errc;
-      ec = struct_pack::deserialize_to(err.msg, buffer);
-      if (ec == struct_pack::errc::ok) {
-        return rpc_result<T, coro_rpc_protocol>{unexpect_t{}, std::move(err)};
+      if (rpc_errc != UINT8_MAX) {
+        ec = struct_pack::deserialize_to(err.msg, buffer);
+        if (ec == struct_pack::errc::ok) {
+          error_happen = true;
+          return rpc_result<T, coro_rpc_protocol>{unexpect_t{}, std::move(err)};
+        }
+      }
+      else {
+        ec = struct_pack::deserialize_to(err, buffer);
+        if (ec == struct_pack::errc::ok) {
+          return rpc_result<T, coro_rpc_protocol>{unexpect_t{}, std::move(err)};
+        }
       }
     }
+    error_happen = true;
     // deserialize failed.
     err = {errc::invalid_argument, "failed to deserialize rpc return value"};
     return rpc_result<T, coro_rpc_protocol>{unexpect_t{}, std::move(err)};
@@ -807,7 +819,7 @@ class coro_rpc_client {
 
 #ifdef UNIT_TEST_INJECT
  public:
-  coro_rpc::errc sync_connect(const std::string &host,
+  coro_rpc::err_code sync_connect(const std::string &host,
                               const std::string &port) {
     return async_simple::coro::syncAwait(connect(host, port));
   }

--- a/include/ylt/coro_rpc/impl/errno.h
+++ b/include/ylt/coro_rpc/impl/errno.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include <ylt/struct_pack/util.h>
+
+#include <cstdint>
 #pragma once
 namespace coro_rpc {
 enum class errc : uint16_t {
@@ -27,10 +29,30 @@ enum class errc : uint16_t {
   interrupted,
   function_not_registered,
   protocol_error,
+  unknown_protocol_version,
   message_too_large,
   server_has_ran,
-  user_defined_err_min = 256,
-  user_defined_err_max = 65535
+};
+struct err_code {
+ public:
+  errc ec;
+  err_code() : ec(errc::ok) {}
+  err_code(uint16_t ec) : ec{ec} {};
+  err_code(errc ec) : ec(ec){};
+  err_code& operator=(errc ec) {
+    this->ec = ec;
+    return *this;
+  }
+  err_code& operator=(uint16_t ec) {
+    this->ec = errc{ec};
+    return *this;
+  }
+  err_code(const err_code& err_code) = default;
+  err_code& operator=(const err_code& o) = default;
+  bool operator!() const { return ec == errc::ok; }
+  operator errc() const { return ec; }
+  operator uint16_t() const { return static_cast<uint16_t>(ec); }
+  uint16_t val() const { return static_cast<uint16_t>(ec); }
 };
 inline bool operator!(errc ec) { return ec == errc::ok; }
 inline std::string_view make_error_message(errc ec) {

--- a/src/coro_io/tests/test_client_pool.cpp
+++ b/src/coro_io/tests/test_client_pool.cpp
@@ -159,7 +159,7 @@ struct mock_client : public coro_rpc::coro_rpc_client {
   async_simple::coro::Lazy<coro_rpc::errc> reconnect(
       const std::string &hostname) {
     auto ec = co_await this->coro_rpc::coro_rpc_client::reconnect(hostname);
-    if (!!ec) {
+    if (ec) {
       co_await coro_io::sleep_for(300ms);
     }
     co_return ec;

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <exception>
 #include <ylt/coro_rpc/coro_rpc_client.hpp>
 
 #include "rpc_service.h"
@@ -31,67 +32,45 @@ Lazy<void> show_rpc_call() {
   assert(!ec);
 
   auto ret = co_await client.call<hello_world>();
-  if (!ret) {
-    std::cout << "hello_world err: " << ret.error().msg << std::endl;
-  }
   assert(ret.value() == "hello_world"s);
 
   client.set_req_attachment("This is attachment.");
   auto ret_void = co_await client.call<echo_with_attachment>();
-  if (!ret) {
-    std::cout << "hello_world err: " << ret.error().msg << std::endl;
-  }
   assert(client.get_resp_attachment() == "This is attachment.");
 
   client.set_req_attachment("This is attachment2.");
   ret_void = co_await client.call<echo_with_attachment2>();
-  if (!ret) {
-    std::cout << "hello_world err: " << ret.error().msg << std::endl;
-  }
   assert(client.get_resp_attachment() == "This is attachment2.");
 
   auto ret_int = co_await client.call<A_add_B>(12, 30);
-  if (!ret_int) {
-    std::cout << "A_add_B err: " << ret_int.error().msg << std::endl;
-  }
   assert(ret_int.value() == 42);
 
   ret = co_await client.call<coro_echo>("coro_echo");
-  if (!ret) {
-    std::cout << "coro_echo err: " << ret.error().msg << std::endl;
-  }
   assert(ret.value() == "coro_echo"s);
 
   ret = co_await client.call<hello_with_delay>("hello_with_delay"s);
-  if (!ret) {
-    std::cout << "hello_with_delay err: " << ret.error().msg << std::endl;
-  }
   assert(ret.value() == "hello_with_delay"s);
 
   ret = co_await client.call<nested_echo>("nested_echo"s);
-  if (!ret) {
-    std::cout << "nested_echo err: " << ret.error().msg << std::endl;
-  }
   assert(ret.value() == "nested_echo"s);
 
   ret = co_await client.call<&HelloService::hello>();
-  if (!ret) {
-    std::cout << "HelloService::hello err: " << ret.error().msg << std::endl;
-  }
   assert(ret.value() == "HelloService::hello"s);
 
   ret = co_await client.call<&HelloService::hello_with_delay>(
       "HelloService::hello_with_delay"s);
-  if (!ret) {
-    std::cout << "HelloService::hello_with_delay err: " << ret.error().msg
-              << std::endl;
-  }
   assert(ret.value() == "HelloService::hello_with_delay"s);
+
+  ret = co_await client.call<return_error>();
+  assert(ret.error().code == 404);
 }
 
 int main() {
-  syncAwait(show_rpc_call());
-
-  std::cout << "Done!" << std::endl;
+  try {
+    syncAwait(show_rpc_call());
+    std::cout << "Done!" << std::endl;
+  } catch (const std::exception& e) {
+    std::cout << "Error:" << e.what() << std::endl;
+  }
   return 0;
 }

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -97,3 +97,15 @@ void HelloService::hello_with_delay(
   }).detach();
   return;
 }
+
+void return_error(coro_rpc::context<std::string> conn) {
+  conn.response_error(404, "404 Not Found.");
+}
+void rpc_with_state_by_tag(coro_rpc::context<std::string> conn) {
+  if (!conn.tag().has_value()) {
+    conn.tag() = 0ull;
+  }
+  auto &cnter = std::any_cast<int &>(conn.tag());
+  ELOGV(INFO, "call count: %d", ++cnter);
+  conn.response_msg(std::to_string(cnter));
+}

--- a/src/coro_rpc/examples/base_examples/rpc_service.h
+++ b/src/coro_rpc/examples/base_examples/rpc_service.h
@@ -26,6 +26,8 @@ void hello_with_delay(coro_rpc::context<std::string> conn, std::string hello);
 std::string echo(std::string_view sv);
 void echo_with_attachment(coro_rpc::context<void> conn);
 void echo_with_attachment2(coro_rpc::context<void> conn);
+void return_error(coro_rpc::context<std::string> conn);
+void rpc_with_state_by_tag(coro_rpc::context<std::string> conn);
 async_simple::coro::Lazy<std::string> coro_echo(std::string_view sv);
 async_simple::coro::Lazy<std::string> nested_echo(std::string_view sv);
 class HelloService {

--- a/src/coro_rpc/examples/file_transfer/rpc_service.cpp
+++ b/src/coro_rpc/examples/file_transfer/rpc_service.cpp
@@ -1,28 +1,25 @@
 #include "rpc_service.h"
 
+#include <any>
 #include <filesystem>
+#include <fstream>
+#include <memory>
 
 std::string echo(std::string str) { return str; }
 
 void upload_file(coro_rpc::context<std::errc> conn, file_part part) {
-  std::shared_ptr<std::ofstream> stream = nullptr;
-  if (!conn.get_tag().has_value()) {
-    stream = std::make_shared<std::ofstream>();
+  if (!conn.tag().has_value()) {
     auto filename = std::to_string(std::time(0)) +
                     std::filesystem::path(part.filename).extension().string();
-    stream->open(filename, std::ios::binary | std::ios::app);
-    conn.set_tag(stream);
+    conn.tag() = std::make_shared<std::ofstream>(
+        filename, std::ios::binary | std::ios::app);
   }
-  else {
-    stream = std::any_cast<std::shared_ptr<std::ofstream>>(conn.get_tag());
-  }
-
+  auto stream = std::any_cast<std::shared_ptr<std::ofstream>>(conn.tag());
   std::cout << "file part content size=" << part.content.size() << "\n";
-
   stream->write(part.content.data(), part.content.size());
   if (part.eof) {
     stream->close();
-    conn.set_tag(std::any{});
+    conn.tag().reset();
     std::cout << "file upload finished\n";
   }
 
@@ -31,8 +28,7 @@ void upload_file(coro_rpc::context<std::errc> conn, file_part part) {
 
 void download_file(coro_rpc::context<response_part> conn,
                    std::string filename) {
-  std::shared_ptr<std::ifstream> stream = nullptr;
-  if (!conn.get_tag().has_value()) {
+  if (!conn.tag().has_value()) {
     std::string actual_filename =
         std::filesystem::path(filename).filename().string();
     if (!std::filesystem::is_regular_file(actual_filename) ||
@@ -40,13 +36,10 @@ void download_file(coro_rpc::context<response_part> conn,
       conn.response_msg(response_part{std::errc::invalid_argument});
       return;
     }
-
-    stream = std::make_shared<std::ifstream>(actual_filename, std::ios::binary);
-    conn.set_tag(stream);
+    conn.tag() =
+        std::make_shared<std::ifstream>(actual_filename, std::ios::binary);
   }
-  else {
-    stream = std::any_cast<std::shared_ptr<std::ifstream>>(conn.get_tag());
-  }
+  auto stream = std::any_cast<std::shared_ptr<std::ifstream>>(conn.tag());
 
   char buf[1024];
 
@@ -56,7 +49,7 @@ void download_file(coro_rpc::context<response_part> conn,
 
   if (stream->eof()) {
     stream->close();
-    conn.set_tag(std::any{});
+    conn.tag().reset();
   }
 }
 

--- a/src/coro_rpc/tests/ServerTester.hpp
+++ b/src/coro_rpc/tests/ServerTester.hpp
@@ -374,7 +374,7 @@ struct ServerTester : TesterConfig {
     auto client2 = init_client();
     ec = syncAwait(client2->connect("10.255.255.1", port_, 5ms));
     CHECK_MESSAGE(
-        !!ec,
+        ec,
         std::to_string(client->get_client_id()).append(make_error_message(ec)));
   }
 

--- a/src/coro_rpc/tests/rpc_api.hpp
+++ b/src/coro_rpc/tests/rpc_api.hpp
@@ -19,6 +19,8 @@
 #include <thread>
 #include <ylt/coro_rpc/coro_rpc_context.hpp>
 
+#include "ylt/coro_rpc/impl/errno.h"
+
 void hi();
 std::string hello();
 std::string hello_timeout();
@@ -35,7 +37,7 @@ struct my_context {
 };
 void echo_with_attachment(coro_rpc::context<void> conn);
 inline void error_with_context(coro_rpc::context<void> conn) {
-  conn.response_error(coro_rpc::errc{104}, "My Error.");
+  conn.response_error(104, "My Error.");
 }
 void coro_fun_with_user_define_connection_type(my_context conn);
 void coro_fun_with_delay_return_void(coro_rpc::context<void> conn);

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -289,7 +289,7 @@ class SSLClientTester {
       auto f = [this, &client]() -> Lazy<void> {
         auto ec = co_await client->connect("127.0.0.1", port_);
         if (server_crt == ssl_type::_ && server_key == ssl_type::_) {
-          if (!!ec) {
+          if (ec) {
             ELOGV(INFO, "%s", gen_err().data());
           }
           REQUIRE_MESSAGE(!ec, make_error_message(ec));
@@ -419,11 +419,15 @@ TEST_CASE("testing client with context response user-defined error") {
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto ec = client.sync_connect("127.0.0.1", "8801");
   REQUIRE(!ec);
-  server.register_handler<error_with_context>();
+  server.register_handler<error_with_context,hello>();
   auto ret = client.sync_call<error_with_context>();
-  CHECK(!ret.has_value());
+  REQUIRE(!ret.has_value());
   CHECK(ret.error().code == coro_rpc::errc{104});
   CHECK(ret.error().msg == "My Error.");
+  CHECK(client.has_closed() == false);
+  auto ret2 = client.sync_call<hello>();
+  REQUIRE(ret2.has_value());
+  CHECK(ret2.value() == "hello");
 }
 
 TEST_CASE("testing client with shutdown") {


### PR DESCRIPTION
…f set_tag&get_tag/use coro_rpc::err_code instead of coro_rpc::errc

<!-- Thank you for your contribution! -->

## What is changing

1. Closes #554 to keep compatible of rpc protocol. Now user's error code will be put in payload not in rpc_head.
2. use `std::any& context<T>::tag()` instead of `set_tag/get_tag`
3. the error type now change to `coro_rpc::err_code` to help error handling like:
```cpp
  auto ec= client.connect();
  if (ec) {
     //....
  }
```
4. add example for `context<T>::response_error` & `context<T>::tag`