### PR TITLE
[struct_paack][fix] fix size_info operator + & namespace

### DIFF
--- a/include/ylt/struct_pack/size_info.hpp
+++ b/include/ylt/struct_pack/size_info.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include <algorithm>
+namespace struct_pack::detail {
 struct size_info {
   std::size_t total;
   std::size_t size_cnt;
@@ -26,7 +27,8 @@ struct size_info {
     return *this;
   }
   constexpr size_info operator+(const size_info &other) {
-    return {this->total + other.total, this->size_cnt += other.size_cnt,
+    return {this->total + other.total, this->size_cnt + other.size_cnt,
             (std::max)(this->max_size, other.max_size)};
   }
 };
+}  // namespace struct_pack::detail

--- a/include/ylt/struct_pack/user_helper.hpp
+++ b/include/ylt/struct_pack/user_helper.hpp
@@ -75,7 +75,7 @@ STRUCT_PACK_INLINE constexpr std::size_t get_write_size(const T* t,
     return sizeof(T) * len;
   }
   else {
-    size_info sz{};
+    detail::size_info sz{};
     for (std::size_t i = 0; i < len; ++i) {
       sz += struct_pack::detail::calculate_one_size(t[i]);
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Closes #557 

## What is changing

1. fix size_info operator +
2. size_info now is in namespace struct_pack::detail

## Example