### PR TITLE
[struct_pack][breakchange] use struct_pack::err_code instead of struct_pack::errc as return value

### DIFF
--- a/include/ylt/coro_rpc/impl/context.hpp
+++ b/include/ylt/coro_rpc/impl/context.hpp
@@ -83,7 +83,7 @@ class context_base {
         error_code, error_msg, self_->req_head_, self_->is_delay_);
   }
   void response_error(coro_rpc::err_code error_code) {
-    response_error(error_code, make_error_message(error_code));
+    response_error(error_code, error_code.message());
   }
   /*!
    * Send response message

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -744,12 +744,12 @@ class coro_rpc_client {
                                                           uint8_t rpc_errc,
                                                           bool &error_happen) {
     rpc_return_type_t<T> ret;
-    struct_pack::errc ec;
+    struct_pack::err_code ec;
     coro_rpc_protocol::rpc_error err;
     if (rpc_errc == 0)
       AS_LIKELY {
         ec = struct_pack::deserialize_to(ret, buffer);
-        if (ec == struct_pack::errc::ok) {
+        if SP_LIKELY (!ec) {
           if constexpr (std::is_same_v<T, void>) {
             return {};
           }
@@ -759,17 +759,17 @@ class coro_rpc_client {
         }
       }
     else {
-      err.code = rpc_errc;
+      err.val() = rpc_errc;
       if (rpc_errc != UINT8_MAX) {
         ec = struct_pack::deserialize_to(err.msg, buffer);
-        if (ec == struct_pack::errc::ok) {
+        if SP_LIKELY (!ec) {
           error_happen = true;
           return rpc_result<T, coro_rpc_protocol>{unexpect_t{}, std::move(err)};
         }
       }
       else {
         ec = struct_pack::deserialize_to(err, buffer);
-        if (ec == struct_pack::errc::ok) {
+        if SP_LIKELY (!ec) {
           return rpc_result<T, coro_rpc_protocol>{unexpect_t{}, std::move(err)};
         }
       }

--- a/include/ylt/coro_rpc/impl/errno.h
+++ b/include/ylt/coro_rpc/impl/errno.h
@@ -33,7 +33,7 @@ enum class errc : uint16_t {
   message_too_large,
   server_has_ran,
 };
-inline std::string_view make_error_message(errc ec) noexcept {
+inline constexpr std::string_view make_error_message(errc ec) noexcept {
   switch (ec) {
     case errc::ok:
       return "ok";
@@ -66,24 +66,27 @@ inline std::string_view make_error_message(errc ec) noexcept {
 struct err_code {
  public:
   errc ec;
-  err_code() noexcept : ec(errc::ok) {}
-  explicit err_code(uint16_t ec) noexcept : ec{ec} {};
-  err_code(errc ec) noexcept : ec(ec){};
-  err_code& operator=(errc ec) noexcept {
+  constexpr err_code() noexcept : ec(errc::ok) {}
+  explicit constexpr err_code(uint16_t ec) noexcept : ec{ec} {};
+  constexpr err_code(errc ec) noexcept : ec(ec){};
+  constexpr err_code& operator=(errc ec) noexcept {
     this->ec = ec;
     return *this;
   }
-  err_code(const err_code& err_code) noexcept = default;
-  err_code& operator=(const err_code& o) noexcept = default;
-  operator errc() const noexcept { return ec; }
-  operator bool() const noexcept { return static_cast<uint16_t>(ec); }
-  explicit operator uint16_t() const noexcept {
+  constexpr err_code(const err_code& err_code) noexcept = default;
+  constexpr err_code& operator=(const err_code& o) noexcept = default;
+  constexpr operator errc() const noexcept { return ec; }
+  constexpr operator bool() const noexcept { return static_cast<uint16_t>(ec); }
+  constexpr explicit operator uint16_t() const noexcept {
     return static_cast<uint16_t>(ec);
   }
-  uint16_t val() const noexcept { return static_cast<uint16_t>(ec); }
-  std::string_view message() const noexcept { return make_error_message(ec); }
+  constexpr uint16_t val() const noexcept { return static_cast<uint16_t>(ec); }
+  constexpr std::string_view message() const noexcept {
+    return make_error_message(ec);
+  }
 };
 
+inline bool operator!(err_code ec) noexcept { return ec == errc::ok; }
 inline bool operator!(errc ec) noexcept { return ec == errc::ok; }
 
 };  // namespace coro_rpc

--- a/include/ylt/coro_rpc/impl/errno.h
+++ b/include/ylt/coro_rpc/impl/errno.h
@@ -33,30 +33,7 @@ enum class errc : uint16_t {
   message_too_large,
   server_has_ran,
 };
-struct err_code {
- public:
-  errc ec;
-  err_code() : ec(errc::ok) {}
-  explicit err_code(uint16_t ec) : ec{ec} {};
-  err_code(errc ec) : ec(ec){};
-  err_code& operator=(errc ec) {
-    this->ec = ec;
-    return *this;
-  }
-  err_code& operator=(uint16_t ec) {
-    this->ec = errc{ec};
-    return *this;
-  }
-  err_code(const err_code& err_code) = default;
-  err_code& operator=(const err_code& o) = default;
-  bool operator!() const { return ec == errc::ok; }
-  operator errc() const { return ec; }
-  operator bool() const { return static_cast<uint16_t>(ec); }
-  explicit operator uint16_t() const { return static_cast<uint16_t>(ec); }
-  uint16_t val() const { return static_cast<uint16_t>(ec); }
-};
-inline bool operator!(errc ec) { return ec == errc::ok; }
-inline std::string_view make_error_message(errc ec) {
+inline std::string_view make_error_message(errc ec) noexcept {
   switch (ec) {
     case errc::ok:
       return "ok";
@@ -86,4 +63,27 @@ inline std::string_view make_error_message(errc ec) {
       return "unknown_user-defined_error";
   }
 }
+struct err_code {
+ public:
+  errc ec;
+  err_code() noexcept : ec(errc::ok) {}
+  explicit err_code(uint16_t ec) noexcept : ec{ec} {};
+  err_code(errc ec) noexcept : ec(ec){};
+  err_code& operator=(errc ec) noexcept {
+    this->ec = ec;
+    return *this;
+  }
+  err_code(const err_code& err_code) noexcept = default;
+  err_code& operator=(const err_code& o) noexcept = default;
+  operator errc() const noexcept { return ec; }
+  operator bool() const noexcept { return static_cast<uint16_t>(ec); }
+  explicit operator uint16_t() const noexcept {
+    return static_cast<uint16_t>(ec);
+  }
+  uint16_t val() const noexcept { return static_cast<uint16_t>(ec); }
+  std::string_view message() const noexcept { return make_error_message(ec); }
+};
+
+inline bool operator!(errc ec) noexcept { return ec == errc::ok; }
+
 };  // namespace coro_rpc

--- a/include/ylt/coro_rpc/impl/protocol/struct_pack_protocol.hpp
+++ b/include/ylt/coro_rpc/impl/protocol/struct_pack_protocol.hpp
@@ -20,15 +20,12 @@ namespace coro_rpc::protocol {
 struct struct_pack_protocol {
   template <typename T>
   static bool deserialize_to(T& t, std::string_view buffer) {
-    struct_pack::err_code ok{};
     if constexpr (std::tuple_size_v<T> == 1) {
-      ok = struct_pack::deserialize_to(std::get<0>(t), buffer);
+      return !struct_pack::deserialize_to(std::get<0>(t), buffer);
     }
     else {
-      ok = struct_pack::deserialize_to(t, buffer);
+      return !struct_pack::deserialize_to(t, buffer);
     }
-
-    return !ok;
   }
   template <typename T>
   static std::string serialize(const T& t) {

--- a/include/ylt/coro_rpc/impl/protocol/struct_pack_protocol.hpp
+++ b/include/ylt/coro_rpc/impl/protocol/struct_pack_protocol.hpp
@@ -20,7 +20,7 @@ namespace coro_rpc::protocol {
 struct struct_pack_protocol {
   template <typename T>
   static bool deserialize_to(T& t, std::string_view buffer) {
-    struct_pack::errc ok{};
+    struct_pack::err_code ok{};
     if constexpr (std::tuple_size_v<T> == 1) {
       ok = struct_pack::deserialize_to(std::get<0>(t), buffer);
     }
@@ -28,7 +28,7 @@ struct struct_pack_protocol {
       ok = struct_pack::deserialize_to(t, buffer);
     }
 
-    return ok == struct_pack::errc::ok;
+    return !ok;
   }
   template <typename T>
   static std::string serialize(const T& t) {

--- a/include/ylt/struct_pack.hpp
+++ b/include/ylt/struct_pack.hpp
@@ -88,8 +88,8 @@ inline std::error_code make_error_code(struct_pack::errc err) {
  * @param err error code.
  * @return error message.
  */
-inline std::string error_message(struct_pack::errc err) {
-  return struct_pack::make_error_code(err).message();
+inline std::string_view error_message(struct_pack::errc err) noexcept {
+  return struct_pack::detail::make_error_message(err);
 }
 
 template <typename... Args>
@@ -278,8 +278,8 @@ template <
     typename View,
     typename = std::enable_if_t<struct_pack::detail::deserialize_view<View>>>
 #endif
-[[nodiscard]] struct_pack::errc deserialize_to(T &t, const View &v,
-                                               Args &...args) {
+[[nodiscard]] struct_pack::err_code deserialize_to(T &t, const View &v,
+                                                   Args &...args) {
   detail::memory_reader reader{(const char *)v.data(),
                                (const char *)v.data() + v.size()};
   detail::unpacker<detail::memory_reader, conf> in(reader);
@@ -287,8 +287,8 @@ template <
 }
 
 template <uint64_t conf = sp_config::DEFAULT, typename T, typename... Args>
-[[nodiscard]] struct_pack::errc deserialize_to(T &t, const char *data,
-                                               size_t size, Args &...args) {
+[[nodiscard]] struct_pack::err_code deserialize_to(T &t, const char *data,
+                                                   size_t size, Args &...args) {
   detail::memory_reader reader{data, data + size};
   detail::unpacker<detail::memory_reader, conf> in(reader);
   return in.deserialize(t, args...);
@@ -302,8 +302,8 @@ template <uint64_t conf = sp_config::DEFAULT, typename T, typename... Args,
           typename Reader,
           typename = std::enable_if_t<struct_pack::reader_t<Reader>>>
 #endif
-[[nodiscard]] struct_pack::errc deserialize_to(T &t, Reader &reader,
-                                               Args &...args) {
+[[nodiscard]] struct_pack::err_code deserialize_to(T &t, Reader &reader,
+                                                   Args &...args) {
   detail::unpacker<Reader, conf> in(reader);
   std::size_t consume_len;
   auto old_pos = reader.tellg();
@@ -330,14 +330,14 @@ template <
     typename View,
     typename = std::enable_if_t<struct_pack::detail::deserialize_view<View>>>
 #endif
-[[nodiscard]] struct_pack::errc deserialize_to(T &t, const View &v,
-                                               size_t &consume_len,
-                                               Args &...args) {
+[[nodiscard]] struct_pack::err_code deserialize_to(T &t, const View &v,
+                                                   size_t &consume_len,
+                                                   Args &...args) {
   detail::memory_reader reader{(const char *)v.data(),
                                (const char *)v.data() + v.size()};
   detail::unpacker<detail::memory_reader, conf> in(reader);
   auto ret = in.deserialize_with_len(consume_len, t, args...);
-  if SP_LIKELY (ret == errc{}) {
+  if SP_LIKELY (!ret) {
     consume_len = (std::max)((size_t)(reader.now - v.data()), consume_len);
   }
   else {
@@ -347,13 +347,14 @@ template <
 }
 
 template <uint64_t conf = sp_config::DEFAULT, typename T, typename... Args>
-[[nodiscard]] struct_pack::errc deserialize_to(T &t, const char *data,
-                                               size_t size, size_t &consume_len,
-                                               Args &...args) {
+[[nodiscard]] struct_pack::err_code deserialize_to(T &t, const char *data,
+                                                   size_t size,
+                                                   size_t &consume_len,
+                                                   Args &...args) {
   detail::memory_reader reader{data, data + size};
   detail::unpacker<detail::memory_reader, conf> in(reader);
   auto ret = in.deserialize_with_len(consume_len, t, args...);
-  if SP_LIKELY (ret == errc{}) {
+  if SP_LIKELY (!ret) {
     consume_len = (std::max)((size_t)(reader.now - data), consume_len);
   }
   else {
@@ -369,9 +370,10 @@ template <uint64_t conf = sp_config::DEFAULT, typename T, typename... Args,
 template <uint64_t conf = sp_config::DEFAULT, typename T, typename... Args,
           typename View>
 #endif
-[[nodiscard]] struct_pack::errc deserialize_to_with_offset(T &t, const View &v,
-                                                           size_t &offset,
-                                                           Args &...args) {
+[[nodiscard]] struct_pack::err_code deserialize_to_with_offset(T &t,
+                                                               const View &v,
+                                                               size_t &offset,
+                                                               Args &...args) {
   size_t sz;
   auto ret =
       deserialize_to(t, v.data() + offset, v.size() - offset, sz, args...);
@@ -380,7 +382,7 @@ template <uint64_t conf = sp_config::DEFAULT, typename T, typename... Args,
 }
 
 template <uint64_t conf = sp_config::DEFAULT, typename T, typename... Args>
-[[nodiscard]] struct_pack::errc deserialize_to_with_offset(
+[[nodiscard]] struct_pack::err_code deserialize_to_with_offset(
     T &t, const char *data, size_t size, size_t &offset, Args &...args) {
   size_t sz;
   auto ret = deserialize_to(t, data + offset, size - offset, sz, args...);
@@ -396,20 +398,19 @@ template <
     typename = std::enable_if_t<struct_pack::detail::deserialize_view<View>>>
 #endif
 [[nodiscard]] auto deserialize(const View &v) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to(ret.value(), v);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
 
 template <typename... Args>
 [[nodiscard]] auto deserialize(const char *data, size_t size) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
-  if (auto errc = deserialize_to(ret.value(), data, size);
-      errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
+  if (auto errc = deserialize_to(ret.value(), data, size); errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -420,10 +421,10 @@ template <typename... Args, typename Reader,
           typename = std::enable_if_t<struct_pack::reader_t<Reader>>>
 #endif
 [[nodiscard]] auto deserialize(Reader &v) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to(ret.value(), v);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -434,10 +435,10 @@ template <typename... Args, struct_pack::detail::deserialize_view View>
 template <typename... Args, typename View>
 #endif
 [[nodiscard]] auto deserialize(const View &v, size_t &consume_len) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to(ret.value(), v, consume_len);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -445,10 +446,10 @@ template <typename... Args, typename View>
 template <typename... Args>
 [[nodiscard]] auto deserialize(const char *data, size_t size,
                                size_t &consume_len) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to(ret.value(), data, size, consume_len);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -462,20 +463,19 @@ template <
     typename = std::enable_if_t<struct_pack::detail::deserialize_view<View>>>
 #endif
 [[nodiscard]] auto deserialize(const View &v) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to<conf>(ret.value(), v);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
 
 template <uint64_t conf, typename... Args>
 [[nodiscard]] auto deserialize(const char *data, size_t size) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
-  if (auto errc = deserialize_to<conf>(ret.value(), data, size);
-      errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
+  if (auto errc = deserialize_to<conf>(ret.value(), data, size); errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -487,10 +487,10 @@ template <uint64_t conf, typename... Args, typename Reader,
           typename = std::enable_if_t<struct_pack::reader_t<Reader>>>
 #endif
 [[nodiscard]] auto deserialize(Reader &v) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to<conf>(ret.value(), v);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -502,10 +502,10 @@ template <uint64_t conf, typename... Args,
 template <uint64_t conf, typename... Args, typename View>
 #endif
 [[nodiscard]] auto deserialize(const View &v, size_t &consume_len) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to<conf>(ret.value(), v, consume_len);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -513,10 +513,10 @@ template <uint64_t conf, typename... Args, typename View>
 template <uint64_t conf, typename... Args>
 [[nodiscard]] auto deserialize(const char *data, size_t size,
                                size_t &consume_len) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to<conf>(ret.value(), data, size, consume_len);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -527,10 +527,10 @@ template <typename... Args, struct_pack::detail::deserialize_view View>
 template <typename... Args, typename View>
 #endif
 [[nodiscard]] auto deserialize_with_offset(const View &v, size_t &offset) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to_with_offset(ret.value(), v, offset);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -538,10 +538,10 @@ template <typename... Args, typename View>
 template <typename... Args>
 [[nodiscard]] auto deserialize_with_offset(const char *data, size_t size,
                                            size_t &offset) {
-  expected<detail::get_args_type<Args...>, struct_pack::errc> ret;
+  expected<detail::get_args_type<Args...>, struct_pack::err_code> ret;
   auto errc = deserialize_to_with_offset(ret.value(), data, size, offset);
-  if SP_UNLIKELY (errc != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{errc};
+  if SP_UNLIKELY (errc) {
+    ret = unexpected<struct_pack::err_code>{errc};
   }
   return ret;
 }
@@ -555,7 +555,7 @@ template <
     typename View,
     typename = std::enable_if_t<struct_pack::detail::deserialize_view<View>>>
 #endif
-[[nodiscard]] struct_pack::errc get_field_to(Field &dst, const View &v) {
+[[nodiscard]] struct_pack::err_code get_field_to(Field &dst, const View &v) {
   using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   static_assert(std::is_same_v<Field, T_Field>,
                 "The dst's type is not correct. It should be as same as the "
@@ -568,8 +568,8 @@ template <
 
 template <typename T, size_t I, uint64_t conf = sp_config::DEFAULT,
           typename Field>
-[[nodiscard]] struct_pack::errc get_field_to(Field &dst, const char *data,
-                                             size_t size) {
+[[nodiscard]] struct_pack::err_code get_field_to(Field &dst, const char *data,
+                                                 size_t size) {
   using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   static_assert(std::is_same_v<Field, T_Field>,
                 "The dst's type is not correct. It should be as same as the "
@@ -587,7 +587,7 @@ template <typename T, size_t I, uint64_t conf = sp_config::DEFAULT,
           typename Field, typename Reader,
           typename = std::enable_if_t<struct_pack::reader_t<Reader>>>
 #endif
-[[nodiscard]] struct_pack::errc get_field_to(Field &dst, Reader &reader) {
+[[nodiscard]] struct_pack::err_code get_field_to(Field &dst, Reader &reader) {
   using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
   static_assert(std::is_same_v<Field, T_Field>,
                 "The dst's type is not correct. It should be as same as the "
@@ -606,10 +606,10 @@ template <
 #endif
 [[nodiscard]] auto get_field(const View &v) {
   using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
-  expected<T_Field, struct_pack::errc> ret;
+  expected<T_Field, struct_pack::err_code> ret;
   auto ec = get_field_to<T, I, conf>(ret.value(), v);
-  if SP_UNLIKELY (ec != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{ec};
+  if SP_UNLIKELY (ec) {
+    ret = unexpected<struct_pack::err_code>{ec};
   }
   return ret;
 }
@@ -617,10 +617,10 @@ template <
 template <typename T, size_t I, uint64_t conf = sp_config::DEFAULT>
 [[nodiscard]] auto get_field(const char *data, size_t size) {
   using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
-  expected<T_Field, struct_pack::errc> ret;
+  expected<T_Field, struct_pack::err_code> ret;
   auto ec = get_field_to<T, I, conf>(ret.value(), data, size);
-  if SP_UNLIKELY (ec != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{ec};
+  if SP_UNLIKELY (ec) {
+    ret = unexpected<struct_pack::err_code>{ec};
   }
   return ret;
 }
@@ -634,10 +634,10 @@ template <typename T, size_t I, uint64_t conf = sp_config::DEFAULT,
 #endif
 [[nodiscard]] auto get_field(Reader &reader) {
   using T_Field = std::tuple_element_t<I, decltype(detail::get_types<T>())>;
-  expected<T_Field, struct_pack::errc> ret;
+  expected<T_Field, struct_pack::err_code> ret;
   auto ec = get_field_to<T, I, conf>(ret.value(), reader);
-  if SP_UNLIKELY (ec != struct_pack::errc{}) {
-    ret = unexpected<struct_pack::errc>{ec};
+  if SP_UNLIKELY (ec) {
+    ret = unexpected<struct_pack::err_code>{ec};
   }
   return ret;
 }
@@ -649,7 +649,7 @@ template <typename BaseClass, typename... DerivedClasses, typename Reader,
           typename = std::enable_if_t<struct_pack::reader_t<Reader>>>
 #endif
 [[nodiscard]] struct_pack::expected<std::unique_ptr<BaseClass>,
-                                    struct_pack::errc>
+                                    struct_pack::err_code>
 deserialize_derived_class(Reader &reader) {
   static_assert(sizeof...(DerivedClasses) > 0,
                 "There must have a least one derived class");
@@ -666,12 +666,13 @@ deserialize_derived_class(Reader &reader) {
                   "constexpr uint64_t struct_pack_id` for collision type. ");
   }
   else {
-    struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::errc> ret;
+    struct_pack::expected<std::unique_ptr<BaseClass>, struct_pack::err_code>
+        ret;
     auto ec = struct_pack::detail::deserialize_derived_class<BaseClass,
                                                              DerivedClasses...>(
         ret.value(), reader);
-    if SP_UNLIKELY (ec != struct_pack::errc{}) {
-      ret = unexpected<struct_pack::errc>{ec};
+    if SP_UNLIKELY (ec) {
+      ret = unexpected<struct_pack::err_code>{ec};
     }
     return ret;
   }
@@ -685,7 +686,7 @@ template <
     typename = std::enable_if_t<struct_pack::detail::deserialize_view<View>>>
 #endif
 [[nodiscard]] struct_pack::expected<std::unique_ptr<BaseClass>,
-                                    struct_pack::errc>
+                                    struct_pack::err_code>
 deserialize_derived_class(const View &v) {
   detail::memory_reader reader{v.data(), v.data() + v.size()};
   if constexpr (std::is_abstract_v<BaseClass>) {
@@ -698,7 +699,7 @@ deserialize_derived_class(const View &v) {
 }
 template <typename BaseClass, typename... DerivedClasses>
 [[nodiscard]] struct_pack::expected<std::unique_ptr<BaseClass>,
-                                    struct_pack::errc>
+                                    struct_pack::err_code>
 deserialize_derived_class(const char *data, size_t size) {
   detail::memory_reader reader{data, data + size};
   if constexpr (std::is_abstract_v<BaseClass>) {

--- a/include/ylt/struct_pack/derived_helper.hpp
+++ b/include/ylt/struct_pack/derived_helper.hpp
@@ -102,7 +102,6 @@ struct deserialize_derived_class_helper {
       std::unique_ptr<BaseClass> &base, unpack &unpacker) {
     if constexpr (index >= std::tuple_size_v<DerivedClasses>) {
       unreachable();
-      return struct_pack::err_code{};
     }
     else {
       using derived_class = std::tuple_element_t<index, DerivedClasses>;

--- a/include/ylt/struct_pack/derived_helper.hpp
+++ b/include/ylt/struct_pack/derived_helper.hpp
@@ -98,11 +98,11 @@ struct public_base_class_checker {
 template <typename DerivedClasses>
 struct deserialize_derived_class_helper {
   template <size_t index, typename BaseClass, typename unpack>
-  static STRUCT_PACK_INLINE constexpr struct_pack::errc run(
+  static STRUCT_PACK_INLINE constexpr struct_pack::err_code run(
       std::unique_ptr<BaseClass> &base, unpack &unpacker) {
     if constexpr (index >= std::tuple_size_v<DerivedClasses>) {
       unreachable();
-      return struct_pack::errc{};
+      return struct_pack::err_code{};
     }
     else {
       using derived_class = std::tuple_element_t<index, DerivedClasses>;
@@ -154,8 +154,8 @@ template <typename DerivedClasses, typename size_type, typename version,
           typename NotSkip>
 struct deserialize_one_derived_class_helper {
   template <size_t index, typename unpacker, typename Pointer>
-  static STRUCT_PACK_INLINE constexpr struct_pack::errc run(unpacker *self,
-                                                            Pointer &base) {
+  static STRUCT_PACK_INLINE constexpr struct_pack::err_code run(unpacker *self,
+                                                                Pointer &base) {
     if constexpr (index >= std::tuple_size_v<DerivedClasses>) {
       unreachable();
     }

--- a/include/ylt/struct_pack/error_code.hpp
+++ b/include/ylt/struct_pack/error_code.hpp
@@ -55,12 +55,7 @@ struct err_code {
   }
   constexpr err_code(const err_code& err_code) noexcept = default;
   constexpr err_code& operator=(const err_code& o) noexcept = default;
-  constexpr bool operator==(const err_code& o) const noexcept {
-    return ec == o.ec;
-  }
-  constexpr bool operator!=(const err_code& o) const noexcept {
-    return ec != o.ec;
-  }
+  constexpr operator errc() const noexcept { return ec; }
   constexpr operator bool() const noexcept { return ec != errc::ok; }
   constexpr int val() const noexcept { return static_cast<int>(ec); }
   constexpr std::string_view message() const noexcept {

--- a/include/ylt/struct_pack/error_code.hpp
+++ b/include/ylt/struct_pack/error_code.hpp
@@ -26,7 +26,7 @@ enum class errc {
   invalid_width_of_container_length,
 };
 namespace detail {
-inline std::string_view make_error_message(errc ec) noexcept {
+inline constexpr std::string_view make_error_message(errc ec) noexcept {
   switch (ec) {
     case errc::ok:
       return "ok";
@@ -47,19 +47,23 @@ inline std::string_view make_error_message(errc ec) noexcept {
 struct err_code {
  public:
   errc ec;
-  err_code() noexcept : ec(errc::ok) {}
-  err_code(errc ec) noexcept : ec(ec){};
-  err_code& operator=(errc ec) noexcept {
+  constexpr err_code() noexcept : ec(errc::ok) {}
+  constexpr err_code(errc ec) noexcept : ec(ec){};
+  constexpr err_code& operator=(errc ec) noexcept {
     this->ec = ec;
     return *this;
   }
-  err_code(const err_code& err_code) noexcept = default;
-  err_code& operator=(const err_code& o) noexcept = default;
-  bool operator==(const err_code& o) const noexcept { return ec == o.ec; }
-  bool operator!=(const err_code& o) const noexcept { return ec != o.ec; }
-  operator bool() const noexcept { return ec != errc::ok; }
-  int val() const noexcept { return static_cast<int>(ec); }
-  std::string_view message() const noexcept {
+  constexpr err_code(const err_code& err_code) noexcept = default;
+  constexpr err_code& operator=(const err_code& o) noexcept = default;
+  constexpr bool operator==(const err_code& o) const noexcept {
+    return ec == o.ec;
+  }
+  constexpr bool operator!=(const err_code& o) const noexcept {
+    return ec != o.ec;
+  }
+  constexpr operator bool() const noexcept { return ec != errc::ok; }
+  constexpr int val() const noexcept { return static_cast<int>(ec); }
+  constexpr std::string_view message() const noexcept {
     return detail::make_error_message(ec);
   }
 };

--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -608,7 +608,7 @@ struct memory_reader;
   template <typename Type>
   concept user_defined_serialization = requires (Type& t) {
     sp_serialize_to(std::declval<struct_pack::detail::memory_writer&>(),(const Type&)t);
-    {sp_deserialize_to(std::declval<struct_pack::detail::memory_reader&>(),t)} -> std::same_as<struct_pack::errc>;
+    {sp_deserialize_to(std::declval<struct_pack::detail::memory_reader&>(),t)} -> std::same_as<struct_pack::err_code>;
     {sp_get_needed_size((const Type&)t)}->std::same_as<std::size_t>;
   };
   template <typename Type>
@@ -623,7 +623,7 @@ struct memory_reader;
   template <typename T>
   struct user_defined_serialization_impl<T, std::void_t<
     decltype(sp_serialize_to(std::declval<struct_pack::detail::memory_writer&>(),std::declval<const T&>())),
-    std::enable_if<std::is_same_v<decltype(sp_deserialize_to(std::declval<struct_pack::detail::memory_reader&>(),std::declval<T&>())), struct_pack::errc>,
+    std::enable_if<std::is_same_v<decltype(sp_deserialize_to(std::declval<struct_pack::detail::memory_reader&>(),std::declval<T&>())), struct_pack::err_code>,
     std::enable_if<std::is_same_v<decltype(sp_get_needed_size(std::declval<const T&>())), std::string_view>>>>>
       : std::true_type {};
 

--- a/include/ylt/struct_pack/unpacker.hpp
+++ b/include/ylt/struct_pack/unpacker.hpp
@@ -107,7 +107,7 @@ class unpacker {
       data_len_ = reader_.tellg();
     }
     auto &&[err_code, buffer_len] = deserialize_metainfo<Type>();
-    if SP_UNLIKELY (err_code != struct_pack::err_code{}) {
+    if SP_UNLIKELY (err_code) {
       return err_code;
     }
     if constexpr (has_compatible) {
@@ -168,7 +168,7 @@ class unpacker {
     }
     auto &&[err_code, buffer_len] = deserialize_metainfo<Type>();
     len = buffer_len;
-    if SP_UNLIKELY (err_code != struct_pack::err_code{}) {
+    if SP_UNLIKELY (err_code) {
       return err_code;
     }
     if constexpr (has_compatible) {
@@ -230,7 +230,7 @@ class unpacker {
     }
 
     auto &&[err_code, buffer_len] = deserialize_metainfo<T>();
-    if SP_UNLIKELY (err_code != struct_pack::err_code{}) {
+    if SP_UNLIKELY (err_code) {
       return err_code;
     }
     if constexpr (has_compatible) {
@@ -621,7 +621,7 @@ class unpacker {
   deserialize_many(First &&first_item, Args &&...items) {
     auto code =
         deserialize_one<size_type, version, NotSkip, parent_tag>(first_item);
-    if SP_UNLIKELY (code != struct_pack::err_code{}) {
+    if SP_UNLIKELY (code) {
       return code;
     }
     if constexpr (sizeof...(items) > 0) {
@@ -867,7 +867,7 @@ class unpacker {
         else {
           for (auto &i : item) {
             code = deserialize_one<size_type, version, NotSkip>(i);
-            if SP_UNLIKELY (code != struct_pack::err_code{}) {
+            if SP_UNLIKELY (code) {
               return code;
             }
           }
@@ -970,7 +970,7 @@ class unpacker {
             item.clear();
             for (uint64_t i = 0; i < size; ++i) {
               code = deserialize_one<size_type, version, NotSkip>(value);
-              if SP_UNLIKELY (code != struct_pack::err_code{}) {
+              if SP_UNLIKELY (code) {
                 return code;
               }
               if constexpr (NotSkip) {
@@ -996,7 +996,7 @@ class unpacker {
             item.clear();
             for (uint64_t i = 0; i < size; ++i) {
               code = deserialize_one<size_type, version, NotSkip>(value);
-              if SP_UNLIKELY (code != struct_pack::err_code{}) {
+              if SP_UNLIKELY (code) {
                 return code;
               }
               if constexpr (NotSkip) {
@@ -1043,7 +1043,7 @@ class unpacker {
                   else {
                     for (auto &i : item) {
                       code = deserialize_one<size_type, version, NotSkip>(i);
-                      if SP_UNLIKELY (code != struct_pack::err_code{}) {
+                      if SP_UNLIKELY (code) {
                         return code;
                       }
                     }
@@ -1072,7 +1072,7 @@ class unpacker {
                       for (size_t j = i; j < i + len; ++j) {
                         code = deserialize_one<size_type, version, NotSkip>(
                             item[j]);
-                        if SP_UNLIKELY (code != struct_pack::err_code{}) {
+                        if SP_UNLIKELY (code) {
                           return code;
                         }
                       }
@@ -1100,7 +1100,7 @@ class unpacker {
                 item.emplace_back();
                 code =
                     deserialize_one<size_type, version, NotSkip>(item.back());
-                if SP_UNLIKELY (code != struct_pack::err_code{}) {
+                if SP_UNLIKELY (code) {
                   if constexpr (can_reserve<type>) {
                     if constexpr (can_shrink_to_fit<type>) {
                       item.shrink_to_fit();  // release reserve memory
@@ -1114,7 +1114,7 @@ class unpacker {
               value_type useless;
               for (size_t i = 0; i < size; ++i) {
                 code = deserialize_one<size_type, version, NotSkip>(useless);
-                if SP_UNLIKELY (code != struct_pack::err_code{}) {
+                if SP_UNLIKELY (code) {
                   return code;
                 }
               }
@@ -1284,7 +1284,7 @@ class unpacker {
       else if constexpr (id == type_id::array_t) {
         for (auto &i : item) {
           code = deserialize_one<size_type, version, NotSkip>(i);
-          if SP_UNLIKELY (code != struct_pack::err_code{}) {
+          if SP_UNLIKELY (code) {
             return code;
           }
         }
@@ -1302,7 +1302,7 @@ class unpacker {
           if constexpr (NotSkip) {
             for (auto &e : item) {
               code = deserialize_one<size_type, version, NotSkip>(e.second);
-              if SP_UNLIKELY (code != struct_pack::err_code{}) {
+              if SP_UNLIKELY (code) {
                 return code;
               }
             }
@@ -1319,7 +1319,7 @@ class unpacker {
           if constexpr (NotSkip) {
             for (auto &i : item) {
               code = deserialize_one<size_type, version, NotSkip>(i);
-              if SP_UNLIKELY (code != struct_pack::err_code{}) {
+              if SP_UNLIKELY (code) {
                 return code;
               }
             }

--- a/include/ylt/struct_pack/user_helper.hpp
+++ b/include/ylt/struct_pack/user_helper.hpp
@@ -29,15 +29,15 @@ STRUCT_PACK_INLINE void write(Writer& writer, const T* t, std::size_t len) {
 };
 template <std::size_t size_width = sizeof(uint64_t), bool ifSkip = false,
           typename Reader, typename T>
-STRUCT_PACK_INLINE struct_pack::errc read(Reader& reader, T& t) {
+STRUCT_PACK_INLINE struct_pack::err_code read(Reader& reader, T& t) {
   struct_pack::detail::unpacker<Reader, sp_config::DEFAULT, true> unpacker{
       reader};
   return unpacker.template deserialize_one<size_width, UINT64_MAX, !ifSkip>(t);
 };
 template <std::size_t size_width = sizeof(uint64_t), bool ifSkip = false,
           typename Reader, typename T>
-STRUCT_PACK_INLINE struct_pack::errc read(Reader& reader, T* t,
-                                          std::size_t len) {
+STRUCT_PACK_INLINE struct_pack::err_code read(Reader& reader, T* t,
+                                              std::size_t len) {
   if constexpr (detail::is_trivial_serializable<T>::value &&
                 detail::is_little_endian_copyable<sizeof(T)>) {
     if constexpr (!ifSkip) {
@@ -56,7 +56,7 @@ STRUCT_PACK_INLINE struct_pack::errc read(Reader& reader, T* t,
       auto code =
           unpacker.template deserialize_one<size_width, UINT64_MAX, !ifSkip>(
               t[i]);
-      if SP_UNLIKELY (code != struct_pack::errc{}) {
+      if SP_UNLIKELY (code != struct_pack::err_code{}) {
         return code;
       }
     }

--- a/include/ylt/struct_pack/user_helper.hpp
+++ b/include/ylt/struct_pack/user_helper.hpp
@@ -56,7 +56,7 @@ STRUCT_PACK_INLINE struct_pack::err_code read(Reader& reader, T* t,
       auto code =
           unpacker.template deserialize_one<size_width, UINT64_MAX, !ifSkip>(
               t[i]);
-      if SP_UNLIKELY (code != struct_pack::err_code{}) {
+      if SP_UNLIKELY (code) {
         return code;
       }
     }

--- a/include/ylt/struct_pack/varint.hpp
+++ b/include/ylt/struct_pack/varint.hpp
@@ -275,7 +275,7 @@ template <reader_t Reader>
 #else
 template <typename Reader>
 #endif
-[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_varint_impl(
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::err_code deserialize_varint_impl(
     Reader& reader, uint64_t& v) {
 #if __cpp_concepts < 201907L
   static_assert(reader_t<Reader>, "The writer type must satisfy requirements!");
@@ -300,7 +300,7 @@ template <bool NotSkip = true,
           typename Reader,
 #endif
           typename T>
-[[nodiscard]] STRUCT_PACK_INLINE struct_pack::errc deserialize_varint(
+[[nodiscard]] STRUCT_PACK_INLINE struct_pack::err_code deserialize_varint(
     Reader& reader, T& t) {
 #if __cpp_concepts < 201907L
   static_assert(reader_t<Reader>, "The writer type must satisfy requirements!");
@@ -308,7 +308,7 @@ template <bool NotSkip = true,
   uint64_t v = 0;
   auto ec = deserialize_varint_impl(reader, v);
   if constexpr (NotSkip) {
-    if SP_LIKELY (ec == struct_pack::errc{}) {
+    if SP_LIKELY (!ec) {
       if constexpr (sintable_t<T>) {
         t = decode_zigzag<int64_t>(v);
       }

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -61,7 +61,7 @@ Lazy<void> show_rpc_call() {
   assert(ret.value() == "HelloService::hello_with_delay"s);
 
   ret = co_await client.call<return_error>();
-  assert(ret.error().code = 404);
+  assert(ret.error().code == 404);
   assert(ret.error().msg == "404 Not Found.");
 
   ret = co_await client.call<rpc_with_state_by_tag>();

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -64,7 +64,7 @@ Lazy<void> show_rpc_call() {
 
   ret = co_await client.call<return_error>();
 
-  assert(ret.error().value() == 404);
+  assert(ret.error().code == 404);
   assert(ret.error().msg == "404 Not Found.");
 
   ret = co_await client.call<rpc_with_state_by_tag>();

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -16,6 +16,8 @@
 #include <ylt/coro_rpc/coro_rpc_client.hpp>
 
 #include "rpc_service.h"
+#include "ylt/coro_rpc/impl/errno.h"
+#include "ylt/coro_rpc/impl/protocol/coro_rpc_protocol.hpp"
 using namespace coro_rpc;
 using namespace async_simple::coro;
 using namespace std::string_literals;
@@ -61,7 +63,8 @@ Lazy<void> show_rpc_call() {
   assert(ret.value() == "HelloService::hello_with_delay"s);
 
   ret = co_await client.call<return_error>();
-  assert(ret.error().code == 404);
+
+  assert(ret.error().value() == 404);
   assert(ret.error().msg == "404 Not Found.");
 
   ret = co_await client.call<rpc_with_state_by_tag>();

--- a/src/coro_rpc/tests/ServerTester.hpp
+++ b/src/coro_rpc/tests/ServerTester.hpp
@@ -368,14 +368,13 @@ struct ServerTester : TesterConfig {
     };
     auto client = init_client();
     ELOGV(INFO, "run %s, client_id %d", __func__, client->get_client_id());
-    coro_rpc::errc ec;
+    coro_rpc::err_code ec;
     // ec = syncAwait(client->connect("127.0.0.1", port, 0ms));
     // CHECK_MESSAGE(ec == std::errc::timed_out, make_error_code(ec).message());
     auto client2 = init_client();
     ec = syncAwait(client2->connect("10.255.255.1", port_, 5ms));
-    CHECK_MESSAGE(
-        ec,
-        std::to_string(client->get_client_id()).append(make_error_message(ec)));
+    CHECK_MESSAGE(ec,
+                  std::to_string(client->get_client_id()).append(ec.message()));
   }
 
   template <auto func, typename... Args>

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -278,8 +278,7 @@ class SSLClientTester {
     if (client_crt == ssl_type::fake || client_crt == ssl_type::no) {
       REQUIRE(ok == false);
       auto ec = syncAwait(client->connect("127.0.0.1", port_));
-      REQUIRE_MESSAGE(ec == coro_rpc::errc::not_connected,
-                      make_error_message(ec));
+      REQUIRE_MESSAGE(ec == coro_rpc::errc::not_connected, ec.message());
       auto ret = syncAwait(client->template call<hi>());
       REQUIRE_MESSAGE(ret.error().code == coro_rpc::errc::not_connected,
                       ret.error().msg);
@@ -292,13 +291,12 @@ class SSLClientTester {
           if (ec) {
             ELOGV(INFO, "%s", gen_err().data());
           }
-          REQUIRE_MESSAGE(!ec, make_error_message(ec));
+          REQUIRE_MESSAGE(!ec, ec.message());
           auto ret = co_await client->template call<hi>();
           CHECK(ret.has_value());
         }
         else {
-          REQUIRE_MESSAGE(ec == coro_rpc::errc::not_connected,
-                          make_error_message(ec));
+          REQUIRE_MESSAGE(ec == coro_rpc::errc::not_connected, ec.message());
         }
       };
       syncAwait(f());
@@ -371,7 +369,7 @@ TEST_CASE("testing client with eof") {
   REQUIRE_MESSAGE(res, "server start failed");
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto ec = client.sync_connect("127.0.0.1", "8801");
-  REQUIRE_MESSAGE(!ec, make_error_message(ec));
+  REQUIRE_MESSAGE(!ec, ec.message());
 
   server.register_handler<hello, client_hello>();
   auto ret = client.sync_call<hello>();
@@ -393,7 +391,7 @@ TEST_CASE("testing client with attachment") {
   REQUIRE_MESSAGE(res, "server start failed");
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto ec = client.sync_connect("127.0.0.1", "8801");
-  REQUIRE_MESSAGE(!ec, make_error_message(ec));
+  REQUIRE_MESSAGE(!ec, ec.message());
 
   server.register_handler<echo_with_attachment>();
 
@@ -437,7 +435,7 @@ TEST_CASE("testing client with shutdown") {
   CHECK_MESSAGE(res, "server start timeout");
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto ec = client.sync_connect("127.0.0.1", "8801");
-  REQUIRE_MESSAGE(!ec, make_error_message(ec));
+  REQUIRE_MESSAGE(!ec, ec.message());
   server.register_handler<hello, client_hello>();
 
   g_action = inject_action::nothing;
@@ -469,7 +467,7 @@ TEST_CASE("testing client timeout") {
     coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
     auto ret = client.connect("10.255.255.1", "8801", 5ms);
     auto val = syncAwait(ret);
-    CHECK_MESSAGE(val == coro_rpc::errc::timed_out, make_error_message(val));
+    CHECK_MESSAGE(val == coro_rpc::errc::timed_out, val.message());
   }
   // SUBCASE("call, 0ms timeout") {
   //   coro_rpc_server server(2, 8801);
@@ -487,13 +485,13 @@ TEST_CASE("testing client timeout") {
 TEST_CASE("testing client connect err") {
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto val = syncAwait(client.connect("127.0.0.1", "8801"));
-  CHECK_MESSAGE(val == coro_rpc::errc::not_connected, make_error_message(val));
+  CHECK_MESSAGE(val == coro_rpc::errc::not_connected, val.message());
 }
 #ifdef UNIT_TEST_INJECT
 TEST_CASE("testing client sync connect, unit test inject only") {
   coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
   auto val = client.sync_connect("127.0.0.1", "8801");
-  CHECK_MESSAGE(val == coro_rpc::errc::not_connected, make_error_message(val));
+  CHECK_MESSAGE(val == coro_rpc::errc::not_connected, val.message());
 #ifdef YLT_ENABLE_SSL
   SUBCASE("client use ssl but server don't use ssl") {
     g_action = {};
@@ -504,8 +502,7 @@ TEST_CASE("testing client sync connect, unit test inject only") {
     bool ok = client2.init_ssl("../openssl_files", "server.crt");
     CHECK(ok == true);
     val = client2.sync_connect("127.0.0.1", "8801");
-    CHECK_MESSAGE(val == coro_rpc::errc::not_connected,
-                  make_error_message(val));
+    CHECK_MESSAGE(val == coro_rpc::errc::not_connected, val.message());
   }
 #endif
 }

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -120,7 +120,7 @@ struct CoroServerTester : ServerTester {
     ELOGV(INFO, "run %s", __func__);
 
     auto ec = server.start();
-    REQUIRE_MESSAGE(ec == coro_rpc::errc::io_error, make_error_message(ec));
+    REQUIRE_MESSAGE(ec == coro_rpc::errc::io_error, ec.message());
   }
 
   void test_start_new_server_with_same_port() {
@@ -130,7 +130,7 @@ struct CoroServerTester : ServerTester {
       auto ec = new_server.async_start();
       REQUIRE(!ec);
       REQUIRE_MESSAGE(ec.error() == coro_rpc::errc::address_in_use,
-                      make_error_message(ec.error()));
+                      ec.error().message());
     }
     ELOGV(INFO, "OH NO");
   }
@@ -251,18 +251,16 @@ TEST_CASE("test server accept error") {
   ELOGV(INFO, "run test server accept error, client_id %d",
         client.get_client_id());
   auto ec = syncAwait(client.connect("127.0.0.1", "8810"));
-  REQUIRE_MESSAGE(
-      !ec,
-      std::to_string(client.get_client_id()).append(make_error_message(ec)));
+  REQUIRE_MESSAGE(!ec,
+                  std::to_string(client.get_client_id()).append(ec.message()));
   auto ret = syncAwait(client.call<hi>());
   REQUIRE_MESSAGE(ret.error().code == coro_rpc::errc::io_error,
                   ret.error().msg);
   REQUIRE(client.has_closed() == true);
 
   ec = syncAwait(client.connect("127.0.0.1", "8810"));
-  REQUIRE_MESSAGE(
-      ec == coro_rpc::errc::io_error,
-      std::to_string(client.get_client_id()).append(make_error_message(ec)));
+  REQUIRE_MESSAGE(ec == coro_rpc::errc::io_error,
+                  std::to_string(client.get_client_id()).append(ec.message()));
   ret = syncAwait(client.call<hi>());
   CHECK(!ret);
   REQUIRE(client.has_closed() == true);
@@ -320,7 +318,7 @@ TEST_CASE("test server write queue") {
     std::size_t sz;
     auto ret =
         struct_pack::deserialize_to(r2, buffer_read.data(), body_len, sz);
-    CHECK(ret == struct_pack::errc::ok);
+    CHECK(!ret);
     CHECK(sz == body_len);
     CHECK(r2 == r);
   }
@@ -345,9 +343,8 @@ TEST_CASE("testing coro rpc write error") {
   ELOGV(INFO, "run testing coro rpc write error, client_id %d",
         client.get_client_id());
   auto ec = syncAwait(client.connect("127.0.0.1", "8810"));
-  REQUIRE_MESSAGE(
-      !ec,
-      std::to_string(client.get_client_id()).append(make_error_message(ec)));
+  REQUIRE_MESSAGE(!ec,
+                  std::to_string(client.get_client_id()).append(ec.message()));
   auto ret = syncAwait(client.call<hi>());
   REQUIRE_MESSAGE(
       ret.error().code == coro_rpc::errc::io_error,

--- a/src/struct_pack/examples/basic_usage.cpp
+++ b/src/struct_pack/examples/basic_usage.cpp
@@ -113,7 +113,7 @@ void basic_usage() {
   {
     person p2;
     [[maybe_unused]] auto ec = struct_pack::deserialize_to(p2, buffer);
-    assert(ec == struct_pack::errc{});
+    assert(!ec);
     assert(p == p2);
   }
   // api 3. partial deserialize
@@ -137,7 +137,7 @@ void basic_usage() {
     auto buffer = struct_pack::serialize(p.age, p2.name);
     [[maybe_unused]] auto result =
         struct_pack::deserialize_to(p3.age, buffer, p3.name);
-    assert(result == struct_pack::errc{});
+    assert(!result);
     assert(p3.age == p.age);
     assert(p3.name == p2.name);
   }

--- a/src/struct_pack/examples/user_defined_serialization.cpp
+++ b/src/struct_pack/examples/user_defined_serialization.cpp
@@ -62,11 +62,11 @@ void sp_serialize_to(Writer& writer, const array2D& ar) {
 }
 // 3. sp_deserialize_to: deserilize object from reader
 template </*struct_pack::reader_t*/ typename Reader>
-struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
-  if (auto ec = struct_pack::read(reader, ar.x); ec != struct_pack::errc{}) {
+struct_pack::err_code sp_deserialize_to(Reader& reader, array2D& ar) {
+  if (auto ec = struct_pack::read(reader, ar.x); ec) {
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.y); ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.y); ec) {
     return ec;
   }
   auto length = 1ull * ar.x * ar.y * sizeof(float);
@@ -78,7 +78,7 @@ struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
   }
   ar.p = (float*)malloc(length);
   auto ec = struct_pack::read(reader, ar.p, 1ull * ar.x * ar.y);
-  if (ec != struct_pack::errc{}) {
+  if (ec) {
     free(ar.p);
   }
   return ec;

--- a/src/struct_pack/tests/test_alignas.cpp
+++ b/src/struct_pack/tests/test_alignas.cpp
@@ -52,7 +52,7 @@ TEST_CASE("testing no alignas") {
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   auto ret = struct_pack::deserialize<T>(buf);
-  REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+  REQUIRE_MESSAGE(ret, ret.error().message());
   T d_t = ret.value();
   CHECK(t == d_t);
 }
@@ -81,14 +81,14 @@ TEST_CASE("testing alignas(2)") {
   SUBCASE("deserialize to dummy") {
     using DT = test_alignas::dummy;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
     DT d_t = ret.value();
     CHECK(t == d_t);
   }
   SUBCASE("deserialize to dummy_2") {
     using DT = test_alignas::dummy_2;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
     DT d_t = ret.value();
     CHECK(t == d_t);
   }
@@ -128,7 +128,7 @@ TEST_CASE("testing alignas(4)") {
   SUBCASE("deserialize to dummy_4") {
     using DT = test_alignas::dummy_4;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
     DT d_t = ret.value();
     CHECK(t == d_t);
   }
@@ -173,7 +173,7 @@ TEST_CASE("testing alignas(8)") {
   SUBCASE("deserialize to dummy_8") {
     using DT = test_alignas::dummy_8;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
     DT d_t = ret.value();
     CHECK(t == d_t);
   }

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -145,7 +145,7 @@ TEST_CASE("test compatible") {
 
     person p;
     auto res = deserialize_to(p, buffer.data(), buffer.size());
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(p.name == p1.name);
     CHECK(p.age == p1.age);
 
@@ -171,7 +171,7 @@ TEST_CASE("test compatible") {
 
     person1 p1, p0 = {20, "tom"};
     auto ec = struct_pack::deserialize_to(p1, buffer);
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(p1 == p0);
   }
   SUBCASE("big compatible metainfo") {

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -158,8 +158,7 @@ TEST_CASE("test compatible") {
     serialize_to(buffer.data(), size2, p);
 
     person1 p2;
-    CHECK(deserialize_to(p2, buffer.data(), buffer.size()) ==
-          struct_pack::errc{});
+    CHECK(!deserialize_to(p2, buffer.data(), buffer.size()));
     CHECK((p2.age == p.age && p2.name == p.name));
   }
   SUBCASE("serialize person 2 person1") {

--- a/src/struct_pack/tests/test_compile_time_calculate.cpp
+++ b/src/struct_pack/tests/test_compile_time_calculate.cpp
@@ -169,14 +169,14 @@ TEST_CASE("type calculate") {
                   "T[sz] with different T should get different MD5");
     int ar[5] = {};
     float ar2[5] = {};
-    CHECK(deserialize_to(ar2, serialize(ar)) != struct_pack::errc{});
+    CHECK(deserialize_to(ar2, serialize(ar)));
   }
   {
     static_assert(get_type_code<int[5]>() != get_type_code<int[6]>(),
                   "T[sz] with different sz should get different MD5");
     int ar[5] = {};
     int ar2[6] = {};
-    CHECK(deserialize_to(ar2, serialize(ar)) != struct_pack::errc{});
+    CHECK(deserialize_to(ar2, serialize(ar)));
   }
   {
     static_assert(get_type_code<std::optional<int>>() !=

--- a/src/struct_pack/tests/test_data_struct.cpp
+++ b/src/struct_pack/tests/test_data_struct.cpp
@@ -11,14 +11,14 @@ void test_container(T &v) {
   auto ret = serialize(v);
   T v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(v == v1);
 
   v.clear();
   v1.clear();
   ret = serialize(v);
   ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(v1.empty());
   CHECK(v == v1);
 }
@@ -162,7 +162,7 @@ void test_tuple_like(T &v) {
 
   T v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(v == v1);
 }
 
@@ -225,11 +225,11 @@ TEST_CASE("test_trivial_copy_tuple") {
 
   std::tuple<int, int> v{};
   auto ec = deserialize_to(v, buf);
-  CHECK(ec != struct_pack::errc{});
+  CHECK(ec);
 
   decltype(tp) tp1;
   auto ec2 = deserialize_to(tp1, buf);
-  CHECK(ec2 == struct_pack::errc{});
+  CHECK(!ec2);
   CHECK(tp == tp1);
 }
 
@@ -246,7 +246,7 @@ TEST_CASE("test_trivial_copy_tuple in an object") {
 
   test_obj obj1;
   auto ec = deserialize_to(obj1, buf);
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(obj.tp == obj1.tp);
 }
 #endif
@@ -256,7 +256,7 @@ void test_c_array(T &v) {
 
   T v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  REQUIRE(ec == struct_pack::errc{});
+  REQUIRE(!ec);
 
   auto size = std::extent_v<T>;
   for (decltype(size) i = 0; i < size; ++i) {
@@ -286,7 +286,7 @@ TEST_CASE("testing enum") {
     auto ret = serialize(e);
     std::size_t sz;
     auto ec = deserialize_to(e2, ret.data(), ret.size(), sz);
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(sz == ret.size());
     CHECK(e == e2);
   }
@@ -347,14 +347,14 @@ TEST_CASE("test variant") {
     std::variant<int, double> var = 1.4, var2;
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(var2 == var);
   }
   {
     std::variant<int, std::monostate> var = std::monostate{}, var2;
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(var2 == var);
   }
   {
@@ -363,7 +363,7 @@ TEST_CASE("test variant") {
         var2;
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(var2 == var);
     CHECK(var2.index() == 1);
   }
@@ -371,7 +371,7 @@ TEST_CASE("test variant") {
     std::variant<std::monostate, std::string> var{"hello"}, var2;
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(var2 == var);
   }
   {
@@ -398,7 +398,7 @@ TEST_CASE("test variant") {
         big_variant2;
     auto ret = struct_pack::serialize(big_variant);
     auto ec = struct_pack::deserialize_to(big_variant2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(big_variant2 == big_variant);
   }
 }

--- a/src/struct_pack/tests/test_data_struct2.cpp
+++ b/src/struct_pack/tests/test_data_struct2.cpp
@@ -16,7 +16,7 @@ TEST_CASE("test monostate") {
 #endif
     auto ret = struct_pack::serialize(var);
     auto ec = struct_pack::deserialize_to(var2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(var2 == var);
   }
 }
@@ -26,7 +26,7 @@ TEST_CASE("test expected") {
     tl::expected<int, struct_pack::errc> exp{42}, exp2;
     auto ret = serialize(exp);
     auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(exp2 == exp);
   }
   {
@@ -35,7 +35,7 @@ TEST_CASE("test expected") {
         exp2;
     auto ret = serialize(exp);
     auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(exp2 == exp);
   }
   {
@@ -45,7 +45,7 @@ TEST_CASE("test expected") {
 
     auto ret = serialize(exp);
     auto res = deserialize_to(exp2, ret.data(), ret.size());
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(exp2 == exp);
   }
 }
@@ -56,7 +56,7 @@ TEST_CASE("testing object with containers, enum, tuple array, and pair") {
 
   complicated_object v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(v.a == v1.a);
 
   CHECK(v == v1);
@@ -67,7 +67,7 @@ TEST_CASE("testing object with containers, enum, tuple array, and pair") {
 
     nested_object nested1{};
     auto ec = deserialize_to(nested1, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(nested == nested1);
   }
 
@@ -76,7 +76,7 @@ TEST_CASE("testing object with containers, enum, tuple array, and pair") {
     complicated_object v1{};
     auto ec = deserialize_to(v1, ret.data(), ret.size());
     auto pair = get_field<complicated_object, 2>(ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(pair);
     CHECK(pair.value() == "hello");
     pair = get_field<complicated_object, 2>(ret);
@@ -98,17 +98,17 @@ TEST_CASE("testing object with containers, enum, tuple array, and pair") {
   SUBCASE("test get_field_to") {
     std::string res1;
     auto ec = get_field_to<complicated_object, 2>(res1, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(res1 == "hello");
     ec = get_field_to<complicated_object, 2>(res1, ret);
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(res1 == "hello");
     std::pair<std::string, person> res2;
     ec = get_field_to<complicated_object, 14>(res2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(res2 == v.o);
     ec = get_field_to<complicated_object, 14>(res2, ret);
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(res2 == v.o);
 
     auto res = get_field_to<complicated_object, 14>(res2, ret.data(), 24);
@@ -131,7 +131,7 @@ TEST_CASE("testing string_view deserialize") {
     auto ret = serialize(sv);
     std::wstring str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(str == sv);
   }
   {
@@ -167,7 +167,7 @@ TEST_CASE("test wide string") {
     auto ret = serialize(sv);
     std::wstring str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(str == sv);
   }
 #if __cpp_char8_t >= 201811L
@@ -176,7 +176,7 @@ TEST_CASE("test wide string") {
     auto ret = serialize(sv);
     std::u8string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(str == sv);
   }
 #endif
@@ -185,7 +185,7 @@ TEST_CASE("test wide string") {
     auto ret = serialize(sv);
     std::u16string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(str == sv);
   }
   {
@@ -193,7 +193,7 @@ TEST_CASE("test wide string") {
     auto ret = serialize(sv);
     std::u32string str;
     auto ec = deserialize_to(str, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(str == sv);
   }
 }
@@ -203,28 +203,28 @@ TEST_CASE("char test") {
     char ch = '1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(ch == ch2);
   }
   {
     signed char ch = '1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(ch == ch2);
   }
   {
     unsigned char ch = '1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(ch == ch2);
   }
   {
     wchar_t ch = L'1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(ch == ch2);
   }
 #ifdef __cpp_lib_char8_t
@@ -232,7 +232,7 @@ TEST_CASE("char test") {
     char8_t ch = u8'1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(ch == ch2);
   }
 #endif
@@ -240,14 +240,14 @@ TEST_CASE("char test") {
     char16_t ch = u'1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(ch == ch2);
   }
   {
     char32_t ch = U'1', ch2;
     auto ret = serialize(ch);
     auto ec = deserialize_to(ch2, ret.data(), ret.size());
-    REQUIRE(ec == struct_pack::errc{});
+    REQUIRE(!ec);
     CHECK(ch == ch2);
   }
 }
@@ -257,7 +257,7 @@ TEST_CASE("test deque") {
   auto ret = struct_pack::serialize(raw);
   std::deque<int> res;
   auto ec = struct_pack::deserialize_to(res, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(raw == res);
 }
 

--- a/src/struct_pack/tests/test_derived.cpp
+++ b/src/struct_pack/tests/test_derived.cpp
@@ -3,7 +3,7 @@ namespace test1 {
 struct Base {
   int id = 17;
   Base(){};
-  static struct_pack::expected<std::unique_ptr<Base>, struct_pack::errc>
+  static struct_pack::expected<std::unique_ptr<Base>, struct_pack::err_code>
   deserialize(std::string_view sv);
   virtual std::string get_name() const { return "Base"; };
   friend bool operator==(const Base& a, const Base& b) { return a.id == b.id; }
@@ -67,7 +67,7 @@ struct gua : Base {
 };
 STRUCT_PACK_REFL(gua, id, a, b);
 
-struct_pack::expected<std::unique_ptr<Base>, struct_pack::errc>
+struct_pack::expected<std::unique_ptr<Base>, struct_pack::err_code>
 Base::deserialize(std::string_view sv) {
   return struct_pack::deserialize_derived_class<Base, bar, foo, gua, foo2,
                                                 foo4>(sv);

--- a/src/struct_pack/tests/test_disable_meta_info.cpp
+++ b/src/struct_pack/tests/test_disable_meta_info.cpp
@@ -15,7 +15,7 @@ TEST_CASE("test serialize/deserialize rect") {
     CHECK(buffer.size() == sizeof(rect));
     auto ec = struct_pack::deserialize_to<
         struct_pack::sp_config::DISABLE_ALL_META_INFO>(r2, buffer);
-    CHECK(ec == struct_pack::errc::ok);
+    CHECK(!ec);
     CHECK(r == r2);
   }
   {
@@ -39,7 +39,7 @@ TEST_CASE("test serialize/deserialize rect") {
     auto ec = struct_pack::deserialize_to<
         struct_pack::sp_config::DISABLE_ALL_META_INFO>(r2, buffer.data(),
                                                        buffer.size());
-    CHECK(ec == struct_pack::errc::ok);
+    CHECK(!ec);
     CHECK(r == r2);
   }
   {
@@ -66,7 +66,7 @@ TEST_CASE("test serialize/deserialize rect by ADL") {
     auto buffer = struct_pack::serialize(r);
     CHECK(buffer.size() == sizeof(rect));
     auto ec = struct_pack::deserialize_to(r2, buffer);
-    CHECK(ec == struct_pack::errc::ok);
+    CHECK(!ec);
     CHECK(r == r2);
   }
   {
@@ -83,7 +83,7 @@ TEST_CASE("test serialize/deserialize rect by ADL") {
     auto buffer = struct_pack::serialize(r);
     CHECK(buffer.size() == sizeof(rect));
     auto ec = struct_pack::deserialize_to(r2, buffer.data(), buffer.size());
-    CHECK(ec == struct_pack::errc::ok);
+    CHECK(!ec);
     CHECK(r == r2);
   }
   {
@@ -106,7 +106,7 @@ TEST_CASE("test serialize/deserialize person") {
     CHECK(buffer.size() == 11);
     auto ec = struct_pack::deserialize_to<
         struct_pack::sp_config::DISABLE_ALL_META_INFO>(r2, buffer);
-    CHECK(ec == struct_pack::errc::ok);
+    CHECK(!ec);
     CHECK(r == r2);
   }
   {
@@ -130,7 +130,7 @@ TEST_CASE("test serialize/deserialize person") {
     auto ec = struct_pack::deserialize_to<
         struct_pack::sp_config::DISABLE_ALL_META_INFO>(r2, buffer.data(),
                                                        buffer.size());
-    CHECK(ec == struct_pack::errc::ok);
+    CHECK(!ec);
     CHECK(r == r2);
   }
   {

--- a/src/struct_pack/tests/test_pragma_pack.cpp
+++ b/src/struct_pack/tests/test_pragma_pack.cpp
@@ -73,7 +73,7 @@ TEST_CASE("testing no #pragam pack") {
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   auto ret = struct_pack::deserialize<T>(buf);
-  REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+  REQUIRE_MESSAGE(ret, ret.error().message());
   T d_t = ret.value();
   CHECK(t == d_t);
 }
@@ -113,7 +113,7 @@ TEST_CASE("testing #pragma pack(1)") {
   SUBCASE("deserialize to dummy_1") {
     using DT = test_pragma_pack::dummy_1;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
     DT d_t = ret.value();
     CHECK(t == d_t);
   }
@@ -149,7 +149,7 @@ TEST_CASE("testing #pragma pack(2)") {
   SUBCASE("deserialize to dummy") {
     using DT = test_pragma_pack::dummy;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
   }
   SUBCASE("deserialize to dummy_1") {
     using DT = test_pragma_pack::dummy_1;
@@ -159,7 +159,7 @@ TEST_CASE("testing #pragma pack(2)") {
   SUBCASE("deserialize to dummy_2") {
     using DT = test_pragma_pack::dummy_2;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
     DT d_t = ret.value();
     CHECK(t == d_t);
   }

--- a/src/struct_pack/tests/test_pragma_pack_and_alignas_mix.cpp
+++ b/src/struct_pack/tests/test_pragma_pack_and_alignas_mix.cpp
@@ -52,7 +52,7 @@ TEST_CASE("testing no one") {
   REQUIRE(literal == val);
   auto buf = struct_pack::serialize(t);
   auto ret = struct_pack::deserialize<T>(buf);
-  REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+  REQUIRE_MESSAGE(ret, ret.error().message());
   T d_t = ret.value();
   CHECK(t == d_t);
 }
@@ -100,7 +100,7 @@ TEST_CASE("testing #pragam pack(1), alignas(2)") {
   SUBCASE("deserialize to dummy_1_2") {
     using DT = test_pragma_pack_and_alignas_mix::dummy_1_2;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
     DT d_t = ret.value();
     CHECK(t == d_t);
   }
@@ -164,7 +164,7 @@ TEST_CASE("testing #pragam pack(1), alignas(2)") {
   SUBCASE("deserialize to dummy_1_4") {
     using DT = test_pragma_pack_and_alignas_mix::dummy_1_4;
     auto ret = struct_pack::deserialize<DT>(buf);
-    REQUIRE_MESSAGE(ret, struct_pack::error_message(ret.error()));
+    REQUIRE_MESSAGE(ret, ret.error().message());
     DT d_t = ret.value();
     CHECK(t == d_t);
   }

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -64,14 +64,14 @@ TEST_CASE("testing deserialize") {
   {
     person p2;
     auto res = deserialize_to(p2, ret);
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(p2 == p);
   }
   {
     size_t len = 114514;
     person p2;
     auto res = deserialize_to(p2, ret, len);
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(p2 == p);
     CHECK(len == ret.size());
   }
@@ -79,7 +79,7 @@ TEST_CASE("testing deserialize") {
     size_t offset = 0;
     person p2;
     auto res = deserialize_to(p2, ret, offset);
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(p2 == p);
     CHECK(offset == ret.size());
   }
@@ -115,10 +115,10 @@ TEST_CASE("testing api") {
     serialize_to((char *)my_buffer2.data() + offset, size, p);
     person p1, p2;
     auto ec1 = deserialize_to(p1, my_buffer);
-    CHECK(ec1 == struct_pack::errc{});
+    CHECK(!ec1);
     auto ec2 = deserialize_to(p2, (const char *)my_buffer2.data() + offset,
                               my_buffer2.size() - offset);
-    CHECK(ec2 == struct_pack::errc{});
+    CHECK(!ec2);
     CHECK(p == p1);
     CHECK(p == p2);
   }
@@ -150,7 +150,7 @@ TEST_CASE("testing pack object") {
 
   person p1{};
   auto ec = deserialize_to(p1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(p == p1);
 
   CHECK(deserialize_to(p1, ret.data(), 4) ==
@@ -161,7 +161,7 @@ TEST_CASE("testing pack object") {
     ret = serialize(p);
     person p2{};
     ec = deserialize_to(p2, ret.data(), ret.size());
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(p == p2);
   }
 }
@@ -172,14 +172,14 @@ void test_container(T &v) {
 
   T v1{};
   auto ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(v == v1);
 
   v.clear();
   v1.clear();
   ret = serialize(v);
   ec = deserialize_to(v1, ret.data(), ret.size());
-  CHECK(ec == struct_pack::errc{});
+  CHECK(!ec);
   CHECK(v1.empty());
   CHECK(v == v1);
 }
@@ -295,7 +295,7 @@ TEST_CASE("testing serialize/deserialize variadic params") {
     int a[5];
     auto res = struct_pack::deserialize_to(a[0], ret.data(), ret.size(), a[1],
                                            a[2], a[3], a[4]);
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(a[0] == 1);
     CHECK(a[1] == 2);
     CHECK(a[2] == 3);
@@ -306,7 +306,7 @@ TEST_CASE("testing serialize/deserialize variadic params") {
     auto ret = struct_pack::serialize(1, 2, 3, 4, 5);
     int a[5];
     auto res = struct_pack::deserialize_to(a[0], ret, a[1], a[2], a[3], a[4]);
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(a[0] == 1);
     CHECK(a[1] == 2);
     CHECK(a[2] == 3);
@@ -477,7 +477,7 @@ TEST_CASE("testing serialize/deserialize variadic params") {
         std::get<0>(t), ret.data(), ret.size(), std::get<1>(t), std::get<2>(t),
         std::get<3>(t), std::get<4>(t), std::get<5>(t), std::get<6>(t),
         std::get<7>(t));
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(std::get<0>(t) == 42);
     CHECK(std::get<1>(t) == 2.71828f);
     CHECK(std::get<2>(t) == 3.1415926);
@@ -504,7 +504,7 @@ TEST_CASE("testing serialize/deserialize variadic params") {
     auto res = struct_pack::deserialize_to(
         std::get<0>(t), ret, std::get<1>(t), std::get<2>(t), std::get<3>(t),
         std::get<4>(t), std::get<5>(t), std::get<6>(t), std::get<7>(t));
-    CHECK(res == struct_pack::errc{});
+    CHECK(!res);
     CHECK(std::get<0>(t) == 42);
     CHECK(std::get<1>(t) == 2.71828f);
     CHECK(std::get<2>(t) == 3.1415926);
@@ -657,13 +657,13 @@ TEST_CASE("array test") {
   {
     ar3[117] = test_str;
     [[maybe_unused]] auto ret = deserialize_to(ar3_1, serialize(ar3));
-    CHECK(ret == struct_pack::errc{});
+    CHECK(!ret);
     CHECK(ar3_1[117] == test_str);
   }
   {
     ar4[15472] = test_str;
     auto ret = deserialize_to(ar4_1, serialize(ar4));
-    CHECK(ret == struct_pack::errc{});
+    CHECK(!ret);
     CHECK(ar4_1[15472] == test_str);
   }
 }
@@ -849,7 +849,7 @@ TEST_CASE("test set_value") {
   detail::memory_reader reader(ret.data(), ret.data() + ret.size());
   detail::unpacker in(reader);
   person p2;
-  struct_pack::errc ec;
+  struct_pack::err_code ec;
   std::string s;
   int v;
   int v2 = -1;
@@ -871,12 +871,12 @@ TEST_CASE("test free functions") {
   std::optional<int> op1{};
   auto buf1 = serialize(op1);
   std::optional<int> op2{};
-  CHECK(deserialize_to(op2, buf1.data(), buf1.size()) == struct_pack::errc{});
+  CHECK(!deserialize_to(op2, buf1.data(), buf1.size()));
   CHECK(!op2.has_value());
 
   op1 = 42;
   auto buf2 = serialize(op1);
-  CHECK(deserialize_to(op2, buf2.data(), buf2.size()) == struct_pack::errc{});
+  CHECK(!deserialize_to(op2, buf2.data(), buf2.size()));
   CHECK(op2.has_value());
   CHECK(op2.value() == 42);
 
@@ -1003,14 +1003,14 @@ TEST_CASE("test de_serialize offset") {
     std::string res;
     auto ec = struct_pack::deserialize_to_with_offset(res, ho.data(), ho.size(),
                                                       offset);
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(res == hi + std::to_string(i));
     CHECK(offset == sizes[i]);
   }
   for (size_t i = 0, offset = 0; i < 100; ++i) {
     std::string res;
     auto ec = struct_pack::deserialize_to_with_offset(res, ho, offset);
-    CHECK(ec == struct_pack::errc{});
+    CHECK(!ec);
     CHECK(res == hi + std::to_string(i));
     CHECK(offset == sizes[i]);
   }
@@ -1099,7 +1099,7 @@ TEST_CASE("test static span") {
       auto buffer = struct_pack::serialize(s);
       span_test s2 = {"", ar2};
       auto ec = struct_pack::deserialize_to(s2, buffer);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(s.hello == s2.hello);
       CHECK(ar == ar2);
     }
@@ -1109,7 +1109,7 @@ TEST_CASE("test static span") {
       auto buffer = struct_pack::serialize(s);
       span_test s2 = {"", ar2};
       auto ec = struct_pack::deserialize_to(s2, buffer);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(s.hello == s2.hello);
       CHECK(s.ar == ar2);
     }
@@ -1130,7 +1130,7 @@ TEST_CASE("test static span") {
       auto buffer = struct_pack::serialize(s);
       span_test3 s2 = {"", ar2};
       auto ec = struct_pack::deserialize_to(s2, buffer);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(s.hello == s2.hello);
       CHECK(ar == ar2);
     }
@@ -1140,7 +1140,7 @@ TEST_CASE("test static span") {
       auto buffer = struct_pack::serialize(s);
       span_test3 s2 = {"", ar2};
       auto ec = struct_pack::deserialize_to(s2, buffer);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(s.hello == s2.hello);
       CHECK(s.ar == ar2);
     }
@@ -1166,7 +1166,7 @@ TEST_CASE("test static span") {
       auto buffer = struct_pack::serialize(s);
       span_test5 s2 = {"", ar2};
       auto ec = struct_pack::deserialize_to(s2, buffer);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(s.hello == s2.hello);
       CHECK(ar == ar2);
     }
@@ -1178,7 +1178,7 @@ TEST_CASE("test static span") {
       auto buffer = struct_pack::serialize(s);
       span_test5 s2 = {"", ar2};
       auto ec = struct_pack::deserialize_to(s2, buffer);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(s.hello == s2.hello);
       CHECK(s.ar == ar2);
     }
@@ -1233,7 +1233,7 @@ TEST_CASE("test dynamic span") {
       auto buffer = struct_pack::serialize(s);
       dspan_test s2;
       auto ec = struct_pack::deserialize_to(s2, buffer);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(s.hello == s2.hello);
       CHECK(std::equal(ar.begin(), ar.end(), s2.sp.begin()));
     }
@@ -1242,7 +1242,7 @@ TEST_CASE("test dynamic span") {
       auto buffer = struct_pack::serialize(s);
       dspan_test s2;
       auto ec = struct_pack::deserialize_to(s2, buffer);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(s.hello == s2.hello);
       CHECK(std::equal(s.ar.begin(), s.ar.end(), s2.sp.begin()));
     }

--- a/src/struct_pack/tests/test_serialize.cpp
+++ b/src/struct_pack/tests/test_serialize.cpp
@@ -523,7 +523,7 @@ TEST_CASE("testing deserialization") {
   auto ret = serialize(p);
 
   person p1{};
-  CHECK(deserialize_to(p1, ret.data(), ret.size()) == struct_pack::errc{});
+  CHECK(!deserialize_to(p1, ret.data(), ret.size()));
 }
 
 TEST_CASE("testing deserialization with invalid data") {
@@ -865,8 +865,7 @@ TEST_CASE("test free functions") {
   CHECK(!buffer.empty());
 
   person p1{};
-  CHECK(deserialize_to(p1, buffer.data(), buffer.size()) ==
-        struct_pack::errc{});
+  CHECK(!deserialize_to(p1, buffer.data(), buffer.size()));
 
   std::optional<int> op1{};
   auto buf1 = serialize(op1);
@@ -962,8 +961,7 @@ TEST_CASE("test serialize offset") {
   buffer.resize(info.size() + offset);
   serialize_to(buffer.data() + offset, info, p);
   person p2;
-  CHECK(deserialize_to(p2, buffer.data() + offset, info.size()) ==
-        struct_pack::errc{});
+  CHECK(!deserialize_to(p2, buffer.data() + offset, info.size()));
   CHECK(p2 == p);
 
   std::vector<char> buffer2;
@@ -973,8 +971,7 @@ TEST_CASE("test serialize offset") {
   serialize_to_with_offset(buffer2, offset, p);
   CHECK(data_offset + info.size() == buffer2.size());
   person p3;
-  CHECK(deserialize_to(p3, buffer2.data() + data_offset, info.size()) ==
-        struct_pack::errc{});
+  CHECK(!deserialize_to(p3, buffer2.data() + data_offset, info.size()));
   CHECK(p3 == p);
 }
 

--- a/src/struct_pack/tests/test_stream.cpp
+++ b/src/struct_pack/tests/test_stream.cpp
@@ -68,21 +68,21 @@ TEST_CASE("test serialize_to/deserialize file") {
     for (int i = 0; i < 100; ++i) {
       person person1;
       auto ec = struct_pack::deserialize_to(person1, ifs);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(person1 == p1);
       nested_object nested1;
       ec = struct_pack::deserialize_to(nested1, ifs);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(nested1 == nested);
     }
     for (int i = 0; i < 100; ++i) {
       person person2;
       auto ec = struct_pack::deserialize_to(person2, ifs);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(person2 == p2);
       nested_object nested1;
       ec = struct_pack::deserialize_to(nested1, ifs);
-      CHECK(ec == struct_pack::errc{});
+      CHECK(!ec);
       CHECK(nested1 == nested);
     }
   }
@@ -130,7 +130,7 @@ TEST_CASE("test get_field file") {
         CHECK(ifs.read((char *)&sz, 4));
         std::string name;
         auto ec = struct_pack::get_field_to<person, 1>(name, ifs);
-        CHECK(ec == struct_pack::errc{});
+        CHECK(!ec);
         CHECK(name == p1.name);
         CHECK(ifs.seekg(pos + sz));
       }

--- a/src/struct_pack/tests/test_user_defined_type.cpp
+++ b/src/struct_pack/tests/test_user_defined_type.cpp
@@ -66,22 +66,20 @@ void sp_serialize_to(Writer& writer, const array2D& ar) {
 }
 
 template <typename Reader>
-struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
-  if (auto ec = struct_pack::read(reader, ar.name); ec != struct_pack::errc{}) {
+struct_pack::err_code sp_deserialize_to(Reader& reader, array2D& ar) {
+  if (auto ec = struct_pack::read(reader, ar.name); ec) {
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.values);
-      ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.values); ec) {
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.values2);
-      ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.values2); ec) {
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.x); ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.x); ec) {
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.y); ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.y); ec) {
     return ec;
   }
   if constexpr (struct_pack::checkable_reader_t<Reader>) {
@@ -93,37 +91,37 @@ struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
   }
   ar.p = (float*)malloc(1ull * ar.x * ar.y * sizeof(float));
   auto ec = struct_pack::read(reader, ar.p, 1ull * ar.x * ar.y);
-  if (ec != struct_pack::errc{}) {
+  if (ec) {
     free(ar.p);
   }
   return ec;
 }
 
 template <typename Reader>
-struct_pack::errc sp_deserialize_to_with_skip(Reader& reader, array2D& ar) {
+struct_pack::err_code sp_deserialize_to_with_skip(Reader& reader, array2D& ar) {
   if (auto ec = struct_pack::read<sizeof(uint64_t), true>(
           reader, ar.name);  // skip this field
-      ec != struct_pack::errc{}) {
+      ec) {
     return ec;
   }
   if (auto ec = struct_pack::read<sizeof(uint64_t), true>(reader, ar.values);
-      ec != struct_pack::errc{}) {  // skip this field
+      ec) {  // skip this field
     return ec;
   }
   if (auto ec = struct_pack::read<sizeof(uint64_t), true>(reader, ar.values2);
-      ec != struct_pack::errc{}) {  // skip this field
+      ec) {  // skip this field
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.x); ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.x); ec) {
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.y); ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.y); ec) {
     return ec;
   }
 
   if (auto ec = struct_pack::read<sizeof(uint64_t), true>(reader, ar.p,
                                                           1ull * ar.x * ar.y);
-      ec != struct_pack::errc{}) {
+      ec) {
     return ec;
   }
   return {};
@@ -233,7 +231,7 @@ void sp_serialize_to(Writer& writer, const test& t) {
 }
 
 template <typename Reader>
-struct_pack::errc sp_deserialize_to(Reader& reader, test& ar) {
+struct_pack::err_code sp_deserialize_to(Reader& reader, test& ar) {
   return struct_pack::read(reader, ar.x);
 }
 constexpr std::string_view sp_set_type_name(test*) { return "myint"; }

--- a/website/docs/en/struct_pack/struct_pack_intro.md
+++ b/website/docs/en/struct_pack/struct_pack_intro.md
@@ -92,8 +92,8 @@ assert(person2.value()==person1);
 ```cpp
 // deserialize to an existing object
 person person2;
-std::errc ec = deserialize_to(person2, buffer);
-assert(ec==std::errc{}); // person2.has_value() == true
+auto ec = deserialize_to(person2, buffer);
+assert(!ec); // no error
 assert(person2==person1);
 ```
 
@@ -327,11 +327,11 @@ void sp_serialize_to(Writer& writer, const array2D& ar) {
 }
 // 3. sp_deserialize_to: deserilize object from reader
 template </*struct_pack::reader_t*/ typename Reader>
-struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
-  if (auto ec = struct_pack::read(reader, ar.x); ec != struct_pack::errc{}) {
+struct_pack::err_code sp_deserialize_to(Reader& reader, array2D& ar) {
+  if (auto ec = struct_pack::read(reader, ar.x); ec) {
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.y); ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.y); ec) {
     return ec;
   }
   auto length = 1ull * ar.x * ar.y * sizeof(float);
@@ -343,7 +343,7 @@ struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
   }
   ar.p = (float*)malloc(length);
   auto ec = struct_pack::read(reader, ar.p, 1ull * ar.x * ar.y);
-  if (ec != struct_pack::errc{}) {
+  if (ec) {
     free(ar.p);
   }
   return ec;
@@ -357,7 +357,7 @@ struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
 // need also define this function to skip deserialization of your type:
 
 // template <typename Reader>
-// struct_pack::errc sp_deserialize_to_with_skip(Reader& reader, array2D& ar);
+// struct_pack::err_code sp_deserialize_to_with_skip(Reader& reader, array2D& ar);
 
 }
 

--- a/website/docs/zh/coro_rpc/coro_rpc_doc.hpp
+++ b/website/docs/zh/coro_rpc/coro_rpc_doc.hpp
@@ -65,13 +65,13 @@ class coro_rpc_server {
    *
    * @return 正常启动返回空，否则返回错误码
    */
-  async_simple::coro::Lazy<coro_rpc::errc> async_start() noexcept;
+  async_simple::coro::Lazy<coro_rpc::err_code> async_start() noexcept;
   /*!
    * 阻塞方式启动server, 如果端口被占用将会返回非空的错误码
    *
    * @return 正常启动返回空，否则返回错误码
    */
-  coro_rpc::errc start();
+  coro_rpc::err_code start();
   /*!
    * 停止server，阻塞等待直到server停止；
    */
@@ -159,7 +159,7 @@ class coro_rpc_server {
  *
  */
 struct rpc_error {
-  coro_rpc::errc code;
+  coro_rpc::err_code code;
   std::string msg;
 };
 
@@ -215,7 +215,7 @@ class coro_rpc_client {
    * @param timeout_duration rpc调用超时时间
    * @return 连接错误码，为空表示连接失败
    */
-  async_simple::coro::Lazy<coro_rpc::errc> connect(
+  async_simple::coro::Lazy<coro_rpc::err_code> connect(
       const std::string &host, const std::string &port,
       std::chrono::steady_clock::duration timeout_duration =
           std::chrono::seconds(5));

--- a/website/docs/zh/struct_pack/struct_pack_intro.md
+++ b/website/docs/zh/struct_pack/struct_pack_intro.md
@@ -87,8 +87,8 @@ assert(person2.value()==person1);
 ```cpp
 // 将结果保存到已有的对象中
 person person2;
-std::errc ec = deserialize_to(person2, buffer);
-assert(ec==std::errc{}); // person2.has_value() == true
+auto ec = deserialize_to(person2, buffer);
+assert(!ec); // no error
 assert(person2==person1);
 ```
 
@@ -336,11 +336,11 @@ void sp_serialize_to(Writer& writer, const array2D& ar) {
 }
 // 3. sp_deserialize_to: 从reader反序列化对象
 template </*struct_pack::reader_t*/ typename Reader>
-struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
-  if (auto ec = struct_pack::read(reader, ar.x); ec != struct_pack::errc{}) {
+struct_pack::err_code sp_deserialize_to(Reader& reader, array2D& ar) {
+  if (auto ec = struct_pack::read(reader, ar.x); ec) {
     return ec;
   }
-  if (auto ec = struct_pack::read(reader, ar.y); ec != struct_pack::errc{}) {
+  if (auto ec = struct_pack::read(reader, ar.y); ec) {
     return ec;
   }
   auto length = 1ull * ar.x * ar.y * sizeof(float);
@@ -352,7 +352,7 @@ struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
   }
   ar.p = (float*)malloc(length);
   auto ec = struct_pack::read(reader, ar.p, 1ull * ar.x * ar.y);
-  if (ec != struct_pack::errc{}) {
+  if (ec) {
     free(ar.p);
   }
   return ec;
@@ -364,7 +364,7 @@ struct_pack::errc sp_deserialize_to(Reader& reader, array2D& ar) {
 // 5. 如果你想使用 struct_pack::get_field/struct_pack::get_field_to, 还需要定义下面的函数以跳过自定义类型的反序列化。
 
 // template <typename Reader>
-// struct_pack::errc sp_deserialize_to_with_skip(Reader& reader, array2D& ar);
+// struct_pack::err_code sp_deserialize_to_with_skip(Reader& reader, array2D& ar);
 
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Closes #284 

Now the return type of error code is a enum class. Which is hard to use when error handling.

```cpp
struct_pack::errc ec = struct_pack::deserialize_to(...);
if (ec == struct_pack::errc{})
{
   // ok branch
}
else 
{
  // error branch
}
```

## What is changing

The type of error now is changed to struct `struct_pack::err_code`(contain a value of `struct_pack::errc`) not the enum class `struct_pack::errc`.

Now we can simply the error handling.

```cpp
struct_pack::err_code ec = struct_pack::deserialize_to(...);
if (!ec)
{
   // ok branch
}
else 
{
  // error branch
}
```

It's easy for user to update,  the old error-handling code-style is still work. and we dont remove the enum class `struct_pack::err_code`. It's easy to convert each other.

## Example

See document.