### PR TITLE
[struct_json, struct_yaml][feat]support escape during serialization

### DIFF
--- a/include/ylt/thirdparty/iguana/util.hpp
+++ b/include/ylt/thirdparty/iguana/util.hpp
@@ -13,6 +13,7 @@
 
 #include "define.h"
 #include "detail/charconv.h"
+#include "detail/utf.hpp"
 #include "enum_reflection.hpp"
 #include "error_code.h"
 #include "reflection.hpp"
@@ -71,7 +72,7 @@ constexpr inline bool map_container_v =
     is_map_container<std::remove_cvref_t<T>>::value;
 
 template <class T>
-constexpr inline bool c_array_v = std::is_array_v<std::remove_cvref_t<T>> &&
+constexpr inline bool c_array_v = std::is_array_v<std::remove_cvref_t<T>>&&
                                       std::extent_v<std::remove_cvref_t<T>> > 0;
 
 template <typename Type, typename = void>
@@ -175,7 +176,7 @@ template <typename T>
 using underline_type_t = typename underline_type<std::remove_cvref_t<T>>::type;
 
 template <char... C, typename It>
-IGUANA_INLINE void match(It &&it, It &&end) {
+IGUANA_INLINE void match(It&& it, It&& end) {
   const auto n = static_cast<size_t>(std::distance(it, end));
   if (n < sizeof...(C))
     IGUANA_UNLIKELY {
@@ -202,5 +203,85 @@ inline constexpr auto has_qoute = [](uint64_t chunk) IGUANA__INLINE_LAMBDA {
       chunk ^
       0b0010001000100010001000100010001000100010001000100010001000100010);
 };
+
+// https://github.com/Tencent/rapidjson/blob/master/include/rapidjson/writer.h
+template <typename Ch, typename SizeType, typename Stream>
+inline void write_string_with_escape(const Ch* it, SizeType length,
+                                     Stream& ss) {
+  static const char hexDigits[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                                     '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+  static const char escape[256] = {
+#define Z16 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+      // 0    1    2    3    4    5    6    7    8    9    A    B    C    D    E
+      // F
+      'u', 'u', 'u',  'u', 'u', 'u', 'u', 'u', 'b', 't',
+      'n', 'u', 'f',  'r', 'u', 'u',  // 00
+      'u', 'u', 'u',  'u', 'u', 'u', 'u', 'u', 'u', 'u',
+      'u', 'u', 'u',  'u', 'u', 'u',  // 10
+      0,   0,   '"',  0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,    0,   0,   0,  // 20
+      Z16, Z16,                     // 30~4F
+      0,   0,   0,    0,   0,   0,   0,   0,   0,   0,
+      0,   0,   '\\', 0,   0,   0,                       // 50
+      Z16, Z16, Z16,  Z16, Z16, Z16, Z16, Z16, Z16, Z16  // 60~FF
+#undef Z16
+  };
+  auto end = it;
+  std::advance(end, length);
+  while (it < end) {
+    if (static_cast<unsigned>(*it) >= 0x80)
+      IGUANA_UNLIKELY {
+        unsigned codepoint = 0;
+        if (!decode_utf8(it, codepoint))
+          IGUANA_UNLIKELY {
+            throw std::runtime_error("illegal unicode character");
+          }
+        ss.push_back('\\');
+        ss.push_back('u');
+        if (codepoint <= 0xD7FF ||
+            (codepoint >= 0xE000 && codepoint <= 0xFFFF)) {
+          ss.push_back(hexDigits[(codepoint >> 12) & 15]);
+          ss.push_back(hexDigits[(codepoint >> 8) & 15]);
+          ss.push_back(hexDigits[(codepoint >> 4) & 15]);
+          ss.push_back(hexDigits[(codepoint)&15]);
+        }
+        else {
+          if (codepoint < 0x010000 || codepoint > 0x10FFFF)
+            IGUANA_UNLIKELY { throw std::runtime_error("illegal codepoint"); }
+          // Surrogate pair
+          unsigned s = codepoint - 0x010000;
+          unsigned lead = (s >> 10) + 0xD800;
+          unsigned trail = (s & 0x3FF) + 0xDC00;
+          ss.push_back(hexDigits[(lead >> 12) & 15]);
+          ss.push_back(hexDigits[(lead >> 8) & 15]);
+          ss.push_back(hexDigits[(lead >> 4) & 15]);
+          ss.push_back(hexDigits[(lead)&15]);
+          ss.push_back('\\');
+          ss.push_back('u');
+          ss.push_back(hexDigits[(trail >> 12) & 15]);
+          ss.push_back(hexDigits[(trail >> 8) & 15]);
+          ss.push_back(hexDigits[(trail >> 4) & 15]);
+          ss.push_back(hexDigits[(trail)&15]);
+        }
+      }
+    else if (escape[static_cast<unsigned char>(*it)])
+      IGUANA_UNLIKELY {
+        ss.push_back('\\');
+        ss.push_back(escape[static_cast<unsigned char>(*it)]);
+
+        if (escape[static_cast<unsigned char>(*it)] == 'u') {
+          // escape other control characters
+          ss.push_back('0');
+          ss.push_back('0');
+          ss.push_back(hexDigits[static_cast<unsigned char>(*it) >> 4]);
+          ss.push_back(hexDigits[static_cast<unsigned char>(*it) & 0xF]);
+        }
+        ++it;
+      }
+    else {
+      ss.push_back(*(it++));
+    }
+  }
+}
 
 }  // namespace iguana

--- a/src/struct_json/examples/main.cpp
+++ b/src/struct_json/examples/main.cpp
@@ -58,6 +58,16 @@ void use_smart_pointer() {
   assert(*p1.age == 42);
 }
 
+void test_escape_serialize() {
+  person p{"老\t人", 20};
+  std::string ss;
+  struct_json::to_json(p, ss);
+  std::cout << ss << std::endl;
+  person p1;
+  struct_json::from_json(p1, ss);
+  assert(p1.name == p.name);
+}
+
 int main() {
   person p{"tom", 20};
   std::string str;
@@ -79,4 +89,5 @@ int main() {
 
   test_inner_object();
   use_smart_pointer();
+  test_escape_serialize();
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

#577 

support escape during serialization
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example
```c++
#include <cassert>
#include <iostream>
#include "ylt/struct_json/json_reader.h"
#include "ylt/struct_json/json_writer.h"

struct person {
  std::string name;
  int age;
};
REFLECTION(person, name, age);
void test_escape_serialize() {
  person p{"小\t强", 20};
  std::string ss;
  struct_json::to_json(p, ss);
  std::cout << ss << std::endl;   \\ output:  {"name":"\u5C0F\t\u5F3A","age":20}
  person p1;
  struct_json::from_json(p1, ss);
  assert(p1.name == p.name);
}
```