### PR TITLE
[coro_http_client][bug]fix ssl

### DIFF
--- a/include/ylt/thirdparty/cinatra/coro_http_client.hpp
+++ b/include/ylt/thirdparty/cinatra/coro_http_client.hpp
@@ -1045,7 +1045,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
             else {
               host = std::string{u.host};
             }
-            bool r = init_ssl(asio::ssl::verify_peer, "", host);
+            bool r = init_ssl(asio::ssl::verify_none, "", host);
             if (!r) {
               data.net_err = std::make_error_code(std::errc::invalid_argument);
               co_return data;
@@ -1102,21 +1102,23 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
   async_simple::coro::Lazy<std::error_code> handle_shake() {
 #ifdef CINATRA_ENABLE_SSL
-    if (has_init_ssl_) {
-      if (socket_->ssl_stream_ == nullptr) {
-        co_return std::make_error_code(std::errc::not_a_stream);
+    if (!has_init_ssl_) {
+      bool r = init_ssl(asio::ssl::verify_none, "", host_);
+      if (!r) {
+        co_return std::make_error_code(std::errc::invalid_argument);
       }
+    }
 
-      auto ec = co_await coro_io::async_handshake(
-          socket_->ssl_stream_, asio::ssl::stream_base::client);
-      if (ec) {
-        CINATRA_LOG_ERROR << "handle failed " << ec.message();
-      }
-      co_return ec;
+    if (socket_->ssl_stream_ == nullptr) {
+      co_return std::make_error_code(std::errc::not_a_stream);
     }
-    else {
-      co_return std::error_code{};
+
+    auto ec = co_await coro_io::async_handshake(socket_->ssl_stream_,
+                                                asio::ssl::stream_base::client);
+    if (ec) {
+      CINATRA_LOG_ERROR << "handle failed " << ec.message();
     }
+    co_return ec;
 #else
     // please open CINATRA_ENABLE_SSL before request https!
     co_return std::make_error_code(std::errc::protocol_error);

--- a/src/coro_http/examples/example.cpp
+++ b/src/coro_http/examples/example.cpp
@@ -400,7 +400,12 @@ async_simple::coro::Lazy<void> basic_usage() {
   // make sure you have install openssl and enable CINATRA_ENABLE_SSL
 #ifdef CINATRA_ENABLE_SSL
   coro_http_client client2{};
-  result = co_await client2.async_get("https://baidu.com");
+  result = co_await client2.async_get("https://www.baidu.com");
+  assert(result.status == 200);
+
+  coro_http_client client2{};
+  co_await client2.connect("https://www.baidu.com");
+  result = co_await client2.async_get("/");
   assert(result.status == 200);
 #endif
 }

--- a/src/coro_http/examples/example.cpp
+++ b/src/coro_http/examples/example.cpp
@@ -403,9 +403,9 @@ async_simple::coro::Lazy<void> basic_usage() {
   result = co_await client2.async_get("https://www.baidu.com");
   assert(result.status == 200);
 
-  coro_http_client client2{};
-  co_await client2.connect("https://www.baidu.com");
-  result = co_await client2.async_get("/");
+  coro_http_client client3{};
+  co_await client3.connect("https://www.baidu.com");
+  result = co_await client3.async_get("/");
   assert(result.status == 200);
 #endif
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

add missed init_ssl logic when connect.

## What is changing

## Example

```c++
  coro_http_client client{};
  co_await client.connect("https://www.baidu.com");
  result = co_await client.async_get("/");
  assert(result.status == 200);
```