### PR TITLE
[struct_pack][bugfix] base class can't optimized as no container type…

### DIFF
--- a/include/ylt/struct_pack/type_calculate.hpp
+++ b/include/ylt/struct_pack/type_calculate.hpp
@@ -794,8 +794,14 @@ constexpr bool check_if_has_container() {
         return false;
       }
       else if constexpr (unique_ptr<Arg>) {
-        return check_if_has_container<
-            remove_cvref_t<typename Arg::element_type>, Arg, ParentArgs...>();
+        if constexpr (is_base_class<typename Arg::element_type>) {
+          // We can't make sure if derived class has container or not
+          return true;
+        }
+        else {
+          return check_if_has_container<
+              remove_cvref_t<typename Arg::element_type>, Arg, ParentArgs...>();
+        }
       }
       else if constexpr (id == type_id::container_t ||
                          id == type_id::string_t ||

--- a/src/struct_pack/tests/test_derived.cpp
+++ b/src/struct_pack/tests/test_derived.cpp
@@ -141,7 +141,7 @@ TEST_CASE("test unique_ptr<Base>") {
   }
 }
 
-TEST_CASE("test unique_ptr<Base> with virtual base") {
+TEST_CASE("test vector<unique_ptr<Base>> with virtual base") {
   using namespace test3;
   static_assert(struct_pack::detail::is_base_class<base>);
   std::vector<std::unique_ptr<base>> vec;
@@ -158,4 +158,13 @@ TEST_CASE("test unique_ptr<Base> with virtual base") {
   for (std::size_t i = 0; i < vec.size(); ++i) {
     CHECK(vec[i]->get_name() == vec2[i]->get_name());
   }
+}
+
+TEST_CASE("test unique_ptr<Base> with virtual base") {
+  using namespace test3;
+  std::unique_ptr<base> ptr = std::make_unique<derived4>();
+  auto buffer2 = struct_pack::serialize<std::string>(ptr);
+  auto res2 = struct_pack::deserialize<std::unique_ptr<base>>(buffer2);
+  CHECK(res2);
+  CHECK(res2.value()->get_name() == std::make_unique<derived4>()->get_name());
 }


### PR DESCRIPTION
… in compile-time.

<!-- Thank you for your contribution! -->

## Why

Closes #596.

when calculate buffer size, the old algorithm will try to optimize base pointer by check if it has container in compile-time. However, we can't check derived class in compile-time.

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

Disable the optimization on the type which contain base pointer.

## Example