### PR TITLE
call coro_rpc function return bool failed crossplatform

### DIFF
--- a/include/ylt/util/function_name.h
+++ b/include/ylt/util/function_name.h
@@ -17,9 +17,38 @@
 #include <string_view>
 
 #include "magic_names.hpp"
+
+using namespace std::string_view_literals;
+
+template <size_t N>
+constexpr std::string_view string_view_array_has(
+    const std::array<std::string_view, N>& array, std::string_view value) {
+  for (const auto& v : array) {
+    if (value.find(v) == 0)
+      return v;
+  }
+  return std::string_view{""};
+}
+
 namespace coro_rpc {
 template <auto func>
 constexpr std::string_view get_func_name() {
-  return std::string_view{refvalue::qualified_name_of_v<func>};
+  constexpr std::array func_style_array {
+      std::string_view{"__cdecl "},
+      std::string_view{"__clrcall "},
+      std::string_view{"__stdcall "}, 
+      std::string_view{"__fastcall "},
+      std::string_view{"__thiscall "}, 
+      std::string_view{"__vectorcall "}
+  };
+  constexpr auto qualified_name =
+      std::string_view{refvalue::qualified_name_of_v<func>};
+  constexpr auto func_style =
+      string_view_array_has(func_style_array, qualified_name);
+  if constexpr (func_style.length() > 0) {
+    return std::string_view{qualified_name.data() + func_style.length(),
+                            qualified_name.length() - func_style.length()};
+  }
+  return qualified_name;
 };
 }  // namespace coro_rpc

--- a/include/ylt/util/function_name.h
+++ b/include/ylt/util/function_name.h
@@ -18,10 +18,9 @@
 
 #include "magic_names.hpp"
 
-using namespace std::string_view_literals;
-
 template <size_t N>
-constexpr std::string_view string_view_array_has(const std::array<std::string_view, N>& array, std::string_view value) {
+constexpr std::string_view string_view_array_has(
+    const std::array<std::string_view, N>& array, std::string_view value) {
   for (const auto& v : array) {
     if (value.find(v) == 0)
       return v;
@@ -32,18 +31,17 @@ constexpr std::string_view string_view_array_has(const std::array<std::string_vi
 namespace coro_rpc {
 template <auto func>
 constexpr std::string_view get_func_name() {
-  constexpr std::array func_style_array {
-    std::string_view{"__cdecl "},
-    std::string_view{"__clrcall "},
-    std::string_view{"__stdcall "}, 
-    std::string_view{"__fastcall "},
-    std::string_view{"__thiscall "}, 
-    std::string_view{"__vectorcall "}
-  };
-  constexpr auto qualified_name = std::string_view{refvalue::qualified_name_of_v<func>};
-  constexpr auto func_style = string_view_array_has(func_style_array, qualified_name);
+  constexpr std::array func_style_array{
+      std::string_view{"__cdecl "},    std::string_view{"__clrcall "},
+      std::string_view{"__stdcall "},  std::string_view{"__fastcall "},
+      std::string_view{"__thiscall "}, std::string_view{"__vectorcall "}};
+  constexpr auto qualified_name =
+      std::string_view{refvalue::qualified_name_of_v<func>};
+  constexpr auto func_style =
+      string_view_array_has(func_style_array, qualified_name);
   if constexpr (func_style.length() > 0) {
-    return std::string_view{qualified_name.data() + func_style.length(), qualified_name.length() - func_style.length()};
+    return std::string_view{qualified_name.data() + func_style.length(),
+                            qualified_name.length() - func_style.length()};
   }
   return qualified_name;
 };

--- a/include/ylt/util/function_name.h
+++ b/include/ylt/util/function_name.h
@@ -21,8 +21,7 @@
 using namespace std::string_view_literals;
 
 template <size_t N>
-constexpr std::string_view string_view_array_has(
-    const std::array<std::string_view, N>& array, std::string_view value) {
+constexpr std::string_view string_view_array_has(const std::array<std::string_view, N>& array, std::string_view value) {
   for (const auto& v : array) {
     if (value.find(v) == 0)
       return v;
@@ -34,20 +33,17 @@ namespace coro_rpc {
 template <auto func>
 constexpr std::string_view get_func_name() {
   constexpr std::array func_style_array {
-      std::string_view{"__cdecl "},
-      std::string_view{"__clrcall "},
-      std::string_view{"__stdcall "}, 
-      std::string_view{"__fastcall "},
-      std::string_view{"__thiscall "}, 
-      std::string_view{"__vectorcall "}
+    std::string_view{"__cdecl "},
+    std::string_view{"__clrcall "},
+    std::string_view{"__stdcall "}, 
+    std::string_view{"__fastcall "},
+    std::string_view{"__thiscall "}, 
+    std::string_view{"__vectorcall "}
   };
-  constexpr auto qualified_name =
-      std::string_view{refvalue::qualified_name_of_v<func>};
-  constexpr auto func_style =
-      string_view_array_has(func_style_array, qualified_name);
+  constexpr auto qualified_name = std::string_view{refvalue::qualified_name_of_v<func>};
+  constexpr auto func_style = string_view_array_has(func_style_array, qualified_name);
   if constexpr (func_style.length() > 0) {
-    return std::string_view{qualified_name.data() + func_style.length(),
-                            qualified_name.length() - func_style.length()};
+    return std::string_view{qualified_name.data() + func_style.length(), qualified_name.length() - func_style.length()};
   }
   return qualified_name;
 };

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -30,6 +30,10 @@ std::string hello_world() {
   return "hello_world";
 }
 
+bool return_bool_hello_world() { 
+    return true; 
+}
+
 int A_add_B(int a, int b) {
   ELOGV(INFO, "call A+B");
   return a + b;

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -30,7 +30,7 @@ std::string hello_world() {
   return "hello_world";
 }
 
-bool return_bool_hello_world() { 
+bool return_bool_hello_world() {
   return true; 
 }
 

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -31,7 +31,7 @@ std::string hello_world() {
 }
 
 bool return_bool_hello_world() { 
-    return true; 
+  return true; 
 }
 
 int A_add_B(int a, int b) {

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -30,9 +30,7 @@ std::string hello_world() {
   return "hello_world";
 }
 
-bool return_bool_hello_world() {
-  return true; 
-}
+bool return_bool_hello_world() { return true; }
 
 int A_add_B(int a, int b) {
   ELOGV(INFO, "call A+B");

--- a/src/coro_rpc/examples/base_examples/rpc_service.h
+++ b/src/coro_rpc/examples/base_examples/rpc_service.h
@@ -21,6 +21,7 @@
 #include <ylt/coro_rpc/coro_rpc_context.hpp>
 
 std::string hello_world();
+bool return_bool_hello_world();
 int A_add_B(int a, int b);
 void hello_with_delay(coro_rpc::context<std::string> conn, std::string hello);
 std::string echo(std::string_view sv);

--- a/src/coro_rpc/examples/base_examples/server.cpp
+++ b/src/coro_rpc/examples/base_examples/server.cpp
@@ -26,6 +26,8 @@ int main() {
 
   coro_rpc_server server2{/*thread=*/1, /*port=*/8802};
 
+  server.register_handler<return_bool_hello_world>();
+
   // regist normal function for rpc
   server.register_handler<hello_world, A_add_B, hello_with_delay, echo,
                           nested_echo, coro_echo, echo_with_attachment,


### PR DESCRIPTION
call rpc function which return bool failed when rpc server and rpc client are run at different OS(Windows,Linux).

<!-- Thank you for your contribution! -->

## Why

close bug https://github.com/alibaba/yalantinglibs/issues/607

modify get_func_name function implement, when return string include windows function call style reference in [https://learn.microsoft.com/en-us/cpp/cpp/stdcall?view=msvc-170](url), remove the function call style string.

## What is changing

function get_func_name implement

## Example

![image](https://github.com/alibaba/yalantinglibs/assets/2830738/2cc1da0b-094f-4fc9-8c94-a18cd53818bd)
