### PR TITLE
[coro_io][feat]support select coroutine

### DIFF
--- a/include/ylt/coro_io/coro_io.hpp
+++ b/include/ylt/coro_io/coro_io.hpp
@@ -391,77 +391,10 @@ async_simple::coro::Lazy<std::pair<
   });
 }
 
-template <typename... Channel>
-class select_t {
- public:
-  select_t(Channel &...channels)
-      : coros_(std::make_tuple(get_lazy(channels)...)) {}
-
-  select_t(Channel &&...channels)
-      : coros_(std::make_tuple(get_lazy(channels)...)){};
-
-  template <typename... Func>
-  async_simple::coro::Lazy<size_t> on_recieve(Func... fn) {
-    std::tuple<Func...> tuple(std::move(fn)...);
-    helper<std::tuple<Func...>> helper{std::move(tuple)};
-    co_return co_await std::apply(helper, coros_);
-  }
-
- private:
-  template <typename T>
-  auto get_lazy(T &t) {
-    using U = std::decay_t<T>;
-    if constexpr (util::is_specialization_v<U, coro_channel>) {
-      return std::move(async_receive(t));
-    }
-    else {
-      return std::move(t);
-    }
-  }
-
-  template <typename Tuple>
-  struct helper {
-    template <size_t Idx>
-    void call(auto &fn, auto &result) {
-      using ValueType = std::remove_cvref_t<decltype(std::get<Idx>(result))>;
-      using Inner =
-          std::remove_cvref_t<decltype(std::declval<ValueType>().value())>;
-      if constexpr (std::is_same_v<Inner, async_simple::Try<void>> ||
-                    std::is_void_v<Inner>) {
-        fn();
-      }
-      else {
-        fn(std::move(std::get<Idx>(result).value()));
-      }
-    }
-
-    template <class Result, std::size_t... Is>
-    void tuple_switch_impl(std::size_t i, Tuple &t, Result &result,
-                           std::index_sequence<Is...>) {
-      ((void)(i == Is && (call<Is>(std::get<Is>(t), result), false)), ...);
-    }
-
-    template <class Result>
-    void tuple_switch(std::size_t i, Tuple &t, Result &result) {
-      tuple_switch_impl(i, t, result,
-                        std::make_index_sequence<std::tuple_size_v<Tuple>>{});
-    }
-
-    async_simple::coro::Lazy<size_t> operator()(auto &&...tests) {
-      auto result =
-          co_await async_simple::coro::collectAny(std::move(tests)...);
-
-      tuple_switch(result.index(), tuple_, result);
-      co_return result.index();
-    }
-
-    Tuple tuple_;
-  };
-
-  std::tuple<async_simple::coro::Lazy<
-      typename std::remove_reference_t<Channel>::ValueType>...>
-      coros_;
-};
+template <typename... T>
+auto select(T &&...args) {
+  return async_simple::coro::collectAny(std::forward<T>(args)...);
+}
 
 template <typename Socket, typename AsioBuffer>
 std::pair<asio::error_code, size_t> read_some(Socket &sock,

--- a/include/ylt/coro_io/coro_io.hpp
+++ b/include/ylt/coro_io/coro_io.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <async_simple/Executor.h>
+#include <async_simple/coro/Collect.h>
 #include <async_simple/coro/Lazy.h>
 #include <async_simple/coro/Sleep.h>
 #include <async_simple/coro/SyncAwait.h>
@@ -349,8 +350,24 @@ post(Func func,
   co_return co_await awaitor.await_resume(helper);
 }
 
+template <typename R>
+struct coro_channel
+    : public asio::experimental::channel<void(std::error_code, R)> {
+  using return_type = R;
+  using ValueType = std::pair<std::error_code, R>;
+  using asio::experimental::channel<void(std::error_code, R)>::channel;
+};
+
+template <typename R>
+inline coro_channel<R> create_channel(
+    size_t capacity,
+    asio::io_context::executor_type executor =
+        coro_io::get_global_block_executor()->get_asio_executor()) {
+  return coro_channel<R>(executor, capacity);
+}
+
 template <typename T>
-async_simple::coro::Lazy<std::error_code> async_send(
+inline async_simple::coro::Lazy<std::error_code> async_send(
     asio::experimental::channel<void(std::error_code, T)> &channel, T val) {
   callback_awaitor<std::error_code> awaitor;
   co_return co_await awaitor.await_resume(
@@ -361,16 +378,90 @@ async_simple::coro::Lazy<std::error_code> async_send(
       });
 }
 
-template <typename R>
-async_simple::coro::Lazy<std::pair<std::error_code, R>> async_receive(
-    asio::experimental::channel<void(std::error_code, R)> &channel) {
-  callback_awaitor<std::pair<std::error_code, R>> awaitor;
+template <typename Channel>
+async_simple::coro::Lazy<std::pair<
+    std::error_code,
+    typename Channel::return_type>> inline async_receive(Channel &channel) {
+  callback_awaitor<std::pair<std::error_code, typename Channel::return_type>>
+      awaitor;
   co_return co_await awaitor.await_resume([&](auto handler) {
     channel.async_receive([handler](auto ec, auto val) {
       handler.set_value_then_resume(std::make_pair(ec, std::move(val)));
     });
   });
 }
+
+template <typename... Channel>
+class select_t {
+ public:
+  select_t(Channel &...channels)
+      : coros_(std::make_tuple(get_lazy(channels)...)) {}
+
+  select_t(Channel &&...channels)
+      : coros_(std::make_tuple(get_lazy(channels)...)){};
+
+  template <typename... Func>
+  async_simple::coro::Lazy<size_t> on_recieve(Func... fn) {
+    std::tuple<Func...> tuple(std::move(fn)...);
+    helper<std::tuple<Func...>> helper{std::move(tuple)};
+    co_return co_await std::apply(helper, coros_);
+  }
+
+ private:
+  template <typename T>
+  auto get_lazy(T &t) {
+    using U = std::decay_t<T>;
+    if constexpr (util::is_specialization_v<U, coro_channel>) {
+      return std::move(async_receive(t));
+    }
+    else {
+      return std::move(t);
+    }
+  }
+
+  template <typename Tuple>
+  struct helper {
+    template <size_t Idx>
+    void call(auto &fn, auto &result) {
+      using ValueType = std::remove_cvref_t<decltype(std::get<Idx>(result))>;
+      using Inner =
+          std::remove_cvref_t<decltype(std::declval<ValueType>().value())>;
+      if constexpr (std::is_same_v<Inner, async_simple::Try<void>> ||
+                    std::is_void_v<Inner>) {
+        fn();
+      }
+      else {
+        fn(std::move(std::get<Idx>(result).value()));
+      }
+    }
+
+    template <class Result, std::size_t... Is>
+    void tuple_switch_impl(std::size_t i, Tuple &t, Result &result,
+                           std::index_sequence<Is...>) {
+      ((void)(i == Is && (call<Is>(std::get<Is>(t), result), false)), ...);
+    }
+
+    template <class Result>
+    void tuple_switch(std::size_t i, Tuple &t, Result &result) {
+      tuple_switch_impl(i, t, result,
+                        std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+    }
+
+    async_simple::coro::Lazy<size_t> operator()(auto &&...tests) {
+      auto result =
+          co_await async_simple::coro::collectAny(std::move(tests)...);
+
+      tuple_switch(result.index(), tuple_, result);
+      co_return result.index();
+    }
+
+    Tuple tuple_;
+  };
+
+  std::tuple<async_simple::coro::Lazy<
+      typename std::remove_reference_t<Channel>::ValueType>...>
+      coros_;
+};
 
 template <typename Socket, typename AsioBuffer>
 std::pair<asio::error_code, size_t> read_some(Socket &sock,

--- a/include/ylt/thirdparty/async_simple/MoveWrapper.h
+++ b/include/ylt/thirdparty/async_simple/MoveWrapper.h
@@ -18,6 +18,7 @@
 #define ASYNC_SIMPLE_MOVEWRAPPER_H
 
 #include <exception>
+
 #include "async_simple/Common.h"
 
 namespace async_simple {
@@ -26,23 +27,23 @@ namespace async_simple {
 // copy as move.
 template <typename T>
 class MoveWrapper {
-public:
-    MoveWrapper() = default;
-    MoveWrapper(T&& value) : _value(std::move(value)) {}
+ public:
+  MoveWrapper() = default;
+  MoveWrapper(T&& value) : _value(std::move(value)) {}
 
-    MoveWrapper(const MoveWrapper& other) : _value(std::move(other._value)) {}
-    MoveWrapper(MoveWrapper&& other) : _value(std::move(other._value)) {}
+  MoveWrapper(const MoveWrapper& other) : _value(std::move(other._value)) {}
+  MoveWrapper(MoveWrapper&& other) : _value(std::move(other._value)) {}
 
-    MoveWrapper& operator=(const MoveWrapper&) = delete;
-    MoveWrapper& operator=(MoveWrapper&&) = delete;
+  MoveWrapper& operator=(const MoveWrapper&) = delete;
+  MoveWrapper& operator=(MoveWrapper&&) = delete;
 
-    T& get() { return _value; }
-    const T& get() const { return _value; }
+  T& get() { return _value; }
+  const T& get() const { return _value; }
 
-    ~MoveWrapper() {}
+  ~MoveWrapper() {}
 
-private:
-    mutable T _value;
+ private:
+  mutable T _value;
 };
 
 }  // namespace async_simple

--- a/include/ylt/thirdparty/async_simple/MoveWrapper.h
+++ b/include/ylt/thirdparty/async_simple/MoveWrapper.h
@@ -25,7 +25,7 @@ namespace async_simple {
 // std::function requre copyConstructable, hence we provide MoveWrapper perform
 // copy as move.
 template <typename T>
-class [[deprecated]] MoveWrapper {
+class MoveWrapper {
 public:
     MoveWrapper() = default;
     MoveWrapper(T&& value) : _value(std::move(value)) {}

--- a/src/coro_http/examples/example.cpp
+++ b/src/coro_http/examples/example.cpp
@@ -544,8 +544,7 @@ void http_proxy() {
 }
 
 void coro_channel() {
-  auto ctx = coro_io::get_global_block_executor()->get_asio_executor();
-  asio::experimental::channel<void(std::error_code, int)> ch(ctx, 10000);
+  auto ch = coro_io::create_channel<int>(10000);
   auto ec = async_simple::coro::syncAwait(coro_io::async_send(ch, 41));
   assert(!ec);
   ec = async_simple::coro::syncAwait(coro_io::async_send(ch, 42));
@@ -554,12 +553,12 @@ void coro_channel() {
   std::error_code err;
   int val;
   std::tie(err, val) =
-      async_simple::coro::syncAwait(coro_io::async_receive<int>(ch));
+      async_simple::coro::syncAwait(coro_io::async_receive(ch));
   assert(!err);
   assert(val == 41);
 
   std::tie(err, val) =
-      async_simple::coro::syncAwait(coro_io::async_receive<int>(ch));
+      async_simple::coro::syncAwait(coro_io::async_receive(ch));
   assert(!err);
   assert(val == 42);
 }

--- a/src/coro_io/tests/CMakeLists.txt
+++ b/src/coro_io/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(coro_io_test
         test_channel.cpp
         test_client_pool.cpp
         test_rate_limiter.cpp
+        test_coro_channel.cpp
         main.cpp
         )
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_SYSTEM_NAME MATCHES "Windows") # mingw-w64

--- a/src/coro_io/tests/test_coro_channel.cpp
+++ b/src/coro_io/tests/test_coro_channel.cpp
@@ -1,0 +1,101 @@
+#include <doctest.h>
+
+#include <array>
+#include <chrono>
+#include <iostream>
+#include <ylt/coro_io/coro_io.hpp>
+using namespace std::chrono_literals;
+
+async_simple::coro::Lazy<void> test_coro_channel() {
+  auto ch = coro_io::create_channel<int>(1000);
+
+  co_await coro_io::async_send(ch, 41);
+  co_await coro_io::async_send(ch, 42);
+
+  std::error_code ec;
+  int val;
+  std::tie(ec, val) = co_await coro_io::async_receive(ch);
+  CHECK(val == 41);
+
+  std::tie(ec, val) = co_await coro_io::async_receive(ch);
+  CHECK(val == 42);
+}
+
+async_simple::coro::Lazy<void> test_select_channel() {
+  using namespace coro_io;
+  auto ch1 = coro_io::create_channel<int>(1000);
+  auto ch2 = coro_io::create_channel<int>(1000);
+
+  co_await async_send(ch1, 41);
+  co_await async_send(ch2, 42);
+
+  std::array<int, 2> arr{41, 42};
+  int val;
+  size_t index = co_await select_t(ch1, ch2).on_recieve(
+      [&](std::pair<std::error_code, int> result) {
+        val = result.second;
+      },
+      [&](std::pair<std::error_code, int> result) {
+        val = result.second;
+      });
+  CHECK(val == arr[index]);
+
+  period_timer timer1(coro_io::get_global_executor());
+  timer1.expires_after(100ms);
+  period_timer timer2(coro_io::get_global_executor());
+  timer2.expires_after(200ms);
+
+  int val1;
+  index = co_await select_t(timer1.async_await(), timer2.async_await())
+              .on_recieve(
+                  [&](bool timeout) {
+                    CHECK(timeout);
+                    val1 = 0;
+                  },
+                  [&](bool timeout) {
+                    CHECK(timeout);
+                    val1 = 1;
+                  });
+  CHECK(index == val1);
+
+  int val2;
+  index = co_await select_t(coro_io::post([] {
+                            }),
+                            coro_io::post([] {
+                            }))
+              .on_recieve(
+                  [&]() {
+                    std::cout << "post1\n";
+                    val2 = 0;
+                  },
+                  [&]() {
+                    std::cout << "post2\n";
+                    val2 = 1;
+                  });
+  CHECK(index == val2);
+
+  co_await async_send(ch1, 43);
+  auto lazy = coro_io::post([] {
+  });
+
+  int val3 = -1;
+  index = co_await select_t(ch1, lazy).on_recieve(
+      [&](std::pair<std::error_code, int> result) {
+        val3 = result.second;
+      },
+      [&] {
+        val3 = 0;
+      });
+
+  if (index == 0) {
+    CHECK(val3 == 43);
+  }
+  else if (index == 1) {
+    CHECK(val3 == 0);
+  }
+}
+
+TEST_CASE("test channel send recieve, test select channel and coroutine") {
+  async_simple::coro::syncAwait(test_coro_channel());
+  async_simple::coro::syncAwait(test_select_channel());
+}

--- a/src/coro_io/tests/test_coro_channel.cpp
+++ b/src/coro_io/tests/test_coro_channel.cpp
@@ -23,6 +23,7 @@ async_simple::coro::Lazy<void> test_coro_channel() {
 
 async_simple::coro::Lazy<void> test_select_channel() {
   using namespace coro_io;
+  using namespace async_simple::coro;
   auto ch1 = coro_io::create_channel<int>(1000);
   auto ch2 = coro_io::create_channel<int>(1000);
 
@@ -31,13 +32,30 @@ async_simple::coro::Lazy<void> test_select_channel() {
 
   std::array<int, 2> arr{41, 42};
   int val;
-  size_t index = co_await select_t(ch1, ch2).on_recieve(
-      [&](std::pair<std::error_code, int> result) {
-        val = result.second;
-      },
-      [&](std::pair<std::error_code, int> result) {
-        val = result.second;
-      });
+
+  size_t index =
+      co_await select(std::pair{async_receive(ch1),
+                                [&val](auto value) {
+                                  auto [ec, r] = value.value();
+                                  val = r;
+                                }},
+                      std::pair{async_receive(ch2), [&val](auto value) {
+                                  auto [ec, r] = value.value();
+                                  val = r;
+                                }});
+
+  CHECK(val == arr[index]);
+
+  co_await async_send(ch1, 41);
+  co_await async_send(ch2, 42);
+
+  std::vector<Lazy<std::pair<std::error_code, int>>> vec;
+  vec.push_back(async_receive(ch1));
+  vec.push_back(async_receive(ch2));
+
+  index = co_await select(std::move(vec), [&](size_t i, auto result) {
+    val = result.value().second;
+  });
   CHECK(val == arr[index]);
 
   period_timer timer1(coro_io::get_global_executor());
@@ -46,32 +64,30 @@ async_simple::coro::Lazy<void> test_select_channel() {
   timer2.expires_after(200ms);
 
   int val1;
-  index = co_await select_t(timer1.async_await(), timer2.async_await())
-              .on_recieve(
-                  [&](bool timeout) {
-                    CHECK(timeout);
-                    val1 = 0;
-                  },
-                  [&](bool timeout) {
-                    CHECK(timeout);
-                    val1 = 1;
-                  });
+  index = co_await select(std::pair{timer1.async_await(),
+                                    [&](auto val) {
+                                      CHECK(val.value());
+                                      val1 = 0;
+                                    }},
+                          std::pair{timer2.async_await(), [&](auto val) {
+                                      CHECK(val.value());
+                                      val1 = 0;
+                                    }});
   CHECK(index == val1);
 
   int val2;
-  index = co_await select_t(coro_io::post([] {
-                            }),
-                            coro_io::post([] {
-                            }))
-              .on_recieve(
-                  [&]() {
-                    std::cout << "post1\n";
-                    val2 = 0;
-                  },
-                  [&]() {
-                    std::cout << "post2\n";
-                    val2 = 1;
-                  });
+  index = co_await select(std::pair{coro_io::post([] {
+                                    }),
+                                    [&](auto) {
+                                      std::cout << "post1\n";
+                                      val2 = 0;
+                                    }},
+                          std::pair{coro_io::post([] {
+                                    }),
+                                    [&](auto) {
+                                      std::cout << "post2\n";
+                                      val2 = 1;
+                                    }});
   CHECK(index == val2);
 
   co_await async_send(ch1, 43);
@@ -79,13 +95,13 @@ async_simple::coro::Lazy<void> test_select_channel() {
   });
 
   int val3 = -1;
-  index = co_await select_t(ch1, lazy).on_recieve(
-      [&](std::pair<std::error_code, int> result) {
-        val3 = result.second;
-      },
-      [&] {
-        val3 = 0;
-      });
+  index = co_await select(std::pair{async_receive(ch1),
+                                    [&](auto result) {
+                                      val3 = result.value().second;
+                                    }},
+                          std::pair{std::move(lazy), [&](auto) {
+                                      val3 = 0;
+                                    }});
 
   if (index == 0) {
     CHECK(val3 == 43);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

support select coroutine and coroutine channel.

similar with go and kotlin select.

## What is changing

## Example
```c++
async_simple::coro::Lazy<void> test_select_channel() {
  auto channel = coro_io::create_channel<int>(1000);
  co_await async_send(channel, 42);
  auto lazy = coro_io::post([] {
  });

  int val3 = -1;
  index = co_await select(std::pair{async_receive(channel),
                                    [&](Try<std::pair<std::error_code, int>> result) {
                                      val3 = result.value().second;
                                    }},
                          std::pair{std::move(lazy), [&](Try<void>) {
                                      val3 = 0;
                                    }});

  if (index == 0) {
    CHECK(val3 == 42);
  }
  else if (index == 1) {
    CHECK(val3 == 0);
  }
}
```