### PR TITLE
[Version Bump Configuration]add configure version in hpp file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ node_modules
 bazel-*
 !BUILD.bazel
 cdb.json
+
+# Generated files
+include/ylt/ylt.hpp

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ bazel-*
 cdb.json
 
 # Generated files
-include/ylt/ylt.hpp
+include/ylt/version.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include(cmake/install.cmake)
 if(CMAKE_PROJECT_NAME STREQUAL "yaLanTingLibs") # if ylt is top-level project
         # add include path
         include_directories(include)
+        include_directories(${PROJECT_BINARY_DIR}/include)
         include_directories(include/ylt/thirdparty)
         include_directories(src/include)
 
@@ -43,5 +44,5 @@ message("Git hash is ${GIT_HASH}, branch is ${GIT_BRANCH}")
 
 configure_file(
         ${PROJECT_SOURCE_DIR}/include/ylt/version.hpp.in
-        ${PROJECT_SOURCE_DIR}/include/ylt/version.hpp
+        ${PROJECT_BINARY_DIR}/include/ylt/version.hpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(yaLanTingLibs
-        VERSION 0.2.9
+        VERSION 0.3.0
         DESCRIPTION "yaLanTingLibs"
         HOMEPAGE_URL "https://github.com/alibaba/yalantinglibs"
         LANGUAGES CXX
@@ -33,3 +33,12 @@ else ()
         include(cmake/config.cmake)
 endif()
 
+set(VERSION "0.3.0")
+set(GIT_HASH "")
+get_git_hash(GIT_HASH)
+message("Git hash is ${GIT_HASH}")
+
+configure_file(
+        ${PROJECT_SOURCE_DIR}/include/ylt/ylt.hpp.in
+        ${PROJECT_SOURCE_DIR}/include/ylt/ylt.hpp
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,14 @@ else ()
 endif()
 
 set(VERSION "0.3.0")
+set(NUM_VERSION 300)
 set(GIT_HASH "")
 get_git_hash(GIT_HASH)
-message("Git hash is ${GIT_HASH}")
+set(GIT_BRANCH "")
+get_git_branch(GIT_BRANCH)
+message("Git hash is ${GIT_HASH}, branch is ${GIT_BRANCH}")
 
 configure_file(
-        ${PROJECT_SOURCE_DIR}/include/ylt/ylt.hpp.in
-        ${PROJECT_SOURCE_DIR}/include/ylt/ylt.hpp
+        ${PROJECT_SOURCE_DIR}/include/ylt/version.hpp.in
+        ${PROJECT_SOURCE_DIR}/include/ylt/version.hpp
 )

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -12,3 +12,31 @@ int main()
     )
     unset(CMAKE_REQUIRED_FLAGS)
 endmacro()
+
+macro(get_git_hash _git_hash)
+  find_package(Git QUIET)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      OUTPUT_VARIABLE ${_git_hash}
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      WORKING_DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+  endif()
+endmacro()
+
+macro(get_git_branch _git_branch)
+  find_package(Git QUIET)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      OUTPUT_VARIABLE ${_git_branch}
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      WORKING_DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+  endif()
+endmacro()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -31,7 +31,7 @@ macro(get_git_branch _git_branch)
   find_package(Git QUIET)
   if(GIT_FOUND)
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      COMMAND ${GIT_EXECUTABLE} symbolic-ref --short HEAD
       OUTPUT_VARIABLE ${_git_branch}
       OUTPUT_STRIP_TRAILING_WHITESPACE
       ERROR_QUIET

--- a/include/ylt/version.hpp.in
+++ b/include/ylt/version.hpp.in
@@ -18,5 +18,5 @@
 // YLT_NUM_VERSION % 100 is the sub-minor version
 // YLT_NUM_VERSION / 100 % 1000 is the minor version
 // YLT_NUM_VERSION / 100000 is the major version
-#define YLT_NUM_VERSION @NUM_VERSION @
+#define YLT_NUM_VERSION @NUM_VERSION@
 #define YLT_FULL_BUILD_VERSION "@VERSION@-@GIT_HASH@-@GIT_BRANCH@"

--- a/include/ylt/version.hpp.in
+++ b/include/ylt/version.hpp.in
@@ -15,4 +15,8 @@
  */
 #pragma once
 #define YLT_VERSION "@VERSION@"
-#define YLT_FULL_BUILD_VERSION "@VERSION@-@GIT_HASH@"
+// YLT_NUM_VERSION % 100 is the sub-minor version
+// YLT_NUM_VERSION / 100 % 1000 is the minor version
+// YLT_NUM_VERSION / 100000 is the major version
+#define YLT_NUM_VERSION @NUM_VERSION @
+#define YLT_FULL_BUILD_VERSION "@VERSION@-@GIT_HASH@-@GIT_BRANCH@"

--- a/include/ylt/ylt.hpp.in
+++ b/include/ylt/ylt.hpp.in
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, Alibaba Group Holding Limited;
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#define YLT_VERSION "@VERSION@"
+#define YLT_FULL_BUILD_VERSION "@VERSION@-@GIT_HASH@"

--- a/src/util/tests/CMakeLists.txt
+++ b/src/util/tests/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output/tests/util)
 
 add_executable(util_meta_string_test test_meta_string.cpp)
 add_executable(util_time_test test_time_util.cpp)
+add_executable(misc_test test_misc.cpp)
 
 add_test(NAME util_meta_string_test COMMAND util_meta_string_test)
 add_test(NAME util_time_test COMMAND util_time_test)
+add_test(NAME misc_test COMMAND misc_test)

--- a/src/util/tests/test_misc.cpp
+++ b/src/util/tests/test_misc.cpp
@@ -9,5 +9,5 @@ int main() {
   assert(std::string(YLT_VERSION) == "0.3.0");
   assert(YLT_NUM_VERSION % 100 == 0);
   assert(YLT_NUM_VERSION / 100 % 1000 == 3);
-  assert(YLT_NUM_VERSION / 1e5 == 0);
+  assert(int(YLT_NUM_VERSION / 100000) == 0);
 }

--- a/src/util/tests/test_misc.cpp
+++ b/src/util/tests/test_misc.cpp
@@ -1,0 +1,9 @@
+#include <cassert>
+#include <iostream>
+#include <ylt/ylt.hpp>
+
+int main() {
+  std::cout << "FULL_BUILD_VERSION : " << YLT_FULL_BUILD_VERSION
+            << ", VERSION : " << YLT_VERSION << std::endl;
+  assert(std::string(YLT_VERSION) == "0.3.0");
+}

--- a/src/util/tests/test_misc.cpp
+++ b/src/util/tests/test_misc.cpp
@@ -1,9 +1,13 @@
 #include <cassert>
 #include <iostream>
-#include <ylt/ylt.hpp>
+#include <ylt/version.hpp>
 
 int main() {
   std::cout << "FULL_BUILD_VERSION : " << YLT_FULL_BUILD_VERSION
-            << ", VERSION : " << YLT_VERSION << std::endl;
+            << ", VERSION : " << YLT_VERSION
+            << ", NUM VERSION : " << YLT_NUM_VERSION << std::endl;
   assert(std::string(YLT_VERSION) == "0.3.0");
+  assert(YLT_NUM_VERSION % 100 == 0);
+  assert(YLT_NUM_VERSION / 100 % 1000 == 3);
+  assert(YLT_NUM_VERSION / 1e5 == 0);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
Users can get ylt version from header file and specific package with git hash might help us to locate detail branch and commit id.
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example