### PR TITLE
[struct_pack] fixed serialize std::unique_ptr<T> with T is derived class.

### DIFF
--- a/include/ylt/struct_pack/derived_helper.hpp
+++ b/include/ylt/struct_pack/derived_helper.hpp
@@ -168,6 +168,9 @@ struct deserialize_one_derived_class_helper {
   }
 };
 
+template <typename T>
+void struct_pack_derived_decl(const T *) = delete;
+
 template <typename Base>
 using derived_class_set_t = decltype(struct_pack_derived_decl((Base *)nullptr));
 

--- a/include/ylt/struct_pack/derived_marco.hpp
+++ b/include/ylt/struct_pack/derived_marco.hpp
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-#include "foreach_macro.h"
-
 #pragma once
+#include "foreach_macro.h"
 
 #define GET_STRUCT_PACK_ID_IMPL_FOR_LOOP(idx, type)              \
   inline uint32_t type::get_struct_pack_id() const {             \
@@ -26,7 +25,7 @@
 #define STRUCT_PACK_DERIVED_DECL(base, ...)                                    \
                                                                                \
   inline decltype(struct_pack::detail::derived_decl_impl<base, __VA_ARGS__>()) \
-  struct_pack_derived_decl(base*);
+  struct_pack_derived_decl(const base*);
 
 #define STRUCT_PACK_DERIVED_IMPL(base, ...)                         \
   STRUCT_PACK_EXPAND_EACH(, GET_STRUCT_PACK_ID_IMPL_FOR_LOOP, base, \


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## Why

Close #627 

The reason of this compile error is struct_pack::detail::is_base_class<derived1> returns true even though it is not the base class.


## What is changing

Add a deleted template function to stop the implicit type conversion can fix this problem.

## Example