### PR TITLE
[coro_rpc/coro_http][feat]support set server address

### DIFF
--- a/include/ylt/coro_rpc/impl/coro_rpc_server.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_server.hpp
@@ -432,8 +432,8 @@ class coro_rpc_server_base {
       auto port_sv = std::string_view(address).substr(pos + 1);
 
       uint16_t port;
-      auto [ptr, ec] =
-          std::from_chars(port_sv.begin(), port_sv.end(), port, 10);
+      auto [ptr, ec] = std::from_chars(
+          port_sv.data(), port_sv.data() + port_sv.size(), port, 10);
       if (ec != std::errc{}) {
         address_ = std::move(address);
         return;

--- a/include/ylt/coro_rpc/impl/errno.h
+++ b/include/ylt/coro_rpc/impl/errno.h
@@ -25,6 +25,9 @@ enum class errc : uint16_t {
   timed_out,
   invalid_argument,
   address_in_use,
+  bad_address,
+  open_error,
+  listen_error,
   operation_canceled,
   interrupted,
   function_not_registered,
@@ -47,6 +50,12 @@ inline constexpr std::string_view make_error_message(errc ec) noexcept {
       return "invalid_argument";
     case errc::address_in_use:
       return "address_in_use";
+    case errc::bad_address:
+      return "bad_address";
+    case errc::open_error:
+      return "open_error";
+    case errc::listen_error:
+      return "listen_error";
     case errc::operation_canceled:
       return "operation_canceled";
     case errc::interrupted:

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -796,8 +796,8 @@ class coro_http_server {
       auto port_sv = std::string_view(address).substr(pos + 1);
 
       uint16_t port;
-      auto [ptr, ec] =
-          std::from_chars(port_sv.begin(), port_sv.end(), port, 10);
+      auto [ptr, ec] = std::from_chars(
+          port_sv.data(), port_sv.data() + port_sv.size(), port, 10);
       if (ec != std::errc{}) {
         address_ = std::move(address);
         return;

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -1,13 +1,5 @@
 #pragma once
 
-#include <asio/dispatch.hpp>
-#include <cstdint>
-#include <mutex>
-#include <type_traits>
-
-#include "asio/streambuf.hpp"
-#include "async_simple/Promise.h"
-#include "async_simple/coro/Lazy.h"
 #include "cinatra/coro_http_client.hpp"
 #include "cinatra/coro_http_response.hpp"
 #include "cinatra/coro_http_router.hpp"
@@ -518,14 +510,19 @@ class coro_http_server {
     CINATRA_LOG_INFO << "begin to listen";
     using asio::ip::tcp;
     asio::error_code ec;
-    auto addr = asio::ip::address::from_string(address_, ec);
-    if (ec) {
+
+    asio::ip::tcp::resolver::query query(address_, std::to_string(port_));
+    asio::ip::tcp::resolver resolver(acceptor_.get_executor());
+    asio::ip::tcp::resolver::iterator it = resolver.resolve(query, ec);
+
+    asio::ip::tcp::resolver::iterator it_end;
+    if (ec || it == it_end) {
       CINATRA_LOG_ERROR << "bad address: " << address_
                         << " error: " << ec.message();
       return std::errc::bad_address;
     }
 
-    auto endpoint = tcp::endpoint(addr, port_);
+    auto endpoint = it->endpoint();
     acceptor_.open(endpoint.protocol(), ec);
     if (ec) {
       CINATRA_LOG_ERROR << "acceptor open failed"
@@ -805,10 +802,6 @@ class coro_http_server {
 
       port_ = port;
       address = address.substr(0, pos);
-    }
-
-    if (iequal0(address, "localhost")) {
-      address = "127.0.0.1";
     }
 
     address_ = std::move(address);

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -27,16 +27,21 @@ enum class file_resp_format_type {
 };
 class coro_http_server {
  public:
-  coro_http_server(asio::io_context &ctx, unsigned short port)
-      : out_ctx_(&ctx), port_(port), acceptor_(ctx), check_timer_(ctx) {}
+  coro_http_server(asio::io_context &ctx, unsigned short port,
+                   std::string address = "0.0.0.0")
+      : out_ctx_(&ctx), port_(port), acceptor_(ctx), check_timer_(ctx) {
+    init_address(address);
+  }
 
   coro_http_server(size_t thread_num, unsigned short port,
-                   bool cpu_affinity = false)
+                   std::string address = "0.0.0.0", bool cpu_affinity = false)
       : pool_(std::make_unique<coro_io::io_context_pool>(thread_num,
                                                          cpu_affinity)),
         port_(port),
         acceptor_(pool_->get_executor()->get_asio_executor()),
-        check_timer_(pool_->get_executor()->get_asio_executor()) {}
+        check_timer_(pool_->get_executor()->get_asio_executor()) {
+    init_address(address);
+  }
 
   ~coro_http_server() {
     CINATRA_LOG_INFO << "coro_http_server will quit";
@@ -64,21 +69,22 @@ class coro_http_server {
 
   // only call once, not thread safe.
   async_simple::Future<std::errc> async_start() {
-    auto ec = listen();
+    errc_ = listen();
 
     async_simple::Promise<std::errc> promise;
     auto future = promise.getFuture();
 
-    if (ec == std::errc{}) {
+    if (errc_ == std::errc{}) {
       if (out_ctx_ == nullptr) {
         thd_ = std::thread([this] {
           pool_->run();
         });
       }
 
-      accept().start([p = std::move(promise)](auto &&res) mutable {
+      accept().start([p = std::move(promise), this](auto &&res) mutable {
         if (res.hasError()) {
-          p.setValue(std::errc::io_error);
+          errc_ = std::errc::io_error;
+          p.setValue(errc_);
         }
         else {
           p.setValue(res.value());
@@ -86,7 +92,7 @@ class coro_http_server {
       });
     }
     else {
-      promise.setValue(ec);
+      promise.setValue(errc_);
     }
 
     return future;
@@ -150,7 +156,7 @@ class coro_http_server {
     static_assert(std::is_member_function_pointer_v<Func>,
                   "must be member function");
     using return_type = typename util::function_traits<Func>::return_type;
-    if constexpr (is_lazy_v<return_type>) {
+    if constexpr (coro_io::is_lazy_v<return_type>) {
       std::function<async_simple::coro::Lazy<void>(coro_http_request & req,
                                                    coro_http_response & resp)>
           f = std::bind(handler, &owner, std::placeholders::_1,
@@ -488,16 +494,31 @@ class coro_http_server {
     return connections_.size();
   }
 
+  std::string_view address() { return address_; }
+  std::errc get_errc() { return errc_; }
+
  private:
   std::errc listen() {
     CINATRA_LOG_INFO << "begin to listen";
     using asio::ip::tcp;
-    auto endpoint = tcp::endpoint(tcp::v4(), port_);
-    acceptor_.open(endpoint.protocol());
-#ifdef __GNUC__
-    acceptor_.set_option(tcp::acceptor::reuse_address(true));
-#endif
     asio::error_code ec;
+    auto addr = asio::ip::address::from_string(address_, ec);
+    if (ec) {
+      CINATRA_LOG_ERROR << "bad address: " << address_
+                        << " error: " << ec.message();
+      return std::errc::bad_address;
+    }
+
+    auto endpoint = tcp::endpoint(addr, port_);
+    acceptor_.open(endpoint.protocol(), ec);
+    if (ec) {
+      CINATRA_LOG_ERROR << "acceptor open failed"
+                        << " error: " << ec.message();
+      return std::errc::io_error;
+    }
+#ifdef __GNUC__
+    acceptor_.set_option(tcp::acceptor::reuse_address(true), ec);
+#endif
     acceptor_.bind(endpoint, ec);
     if (ec) {
       CINATRA_LOG_ERROR << "bind port: " << port_ << " error: " << ec.message();
@@ -508,7 +529,12 @@ class coro_http_server {
 #ifdef _MSC_VER
     acceptor_.set_option(tcp::acceptor::reuse_address(true));
 #endif
-    acceptor_.listen();
+    acceptor_.listen(asio::socket_base::max_listen_connections, ec);
+    if (ec) {
+      CINATRA_LOG_ERROR << "get local endpoint port: " << port_
+                        << " listen error: " << ec.message();
+      return std::errc::io_error;
+    }
 
     auto end_point = acceptor_.local_endpoint(ec);
     if (ec) {
@@ -749,11 +775,20 @@ class coro_http_server {
     response.set_delay(true);
   }
 
+  void init_address(std::string &address) {
+    if (iequal0(address, "localhost")) {
+      address = "127.0.0.1";
+    }
+    address_ = std::move(address);
+  }
+
  private:
   std::unique_ptr<coro_io::io_context_pool> pool_;
   asio::io_context *out_ctx_ = nullptr;
   std::unique_ptr<coro_io::ExecutorWrapper<>> out_executor_ = nullptr;
   uint16_t port_;
+  std::string address_;
+  std::errc errc_ = {};
   asio::ip::tcp::acceptor acceptor_;
   std::thread thd_;
   std::promise<void> acceptor_close_waiter_;

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -30,7 +30,13 @@ class coro_http_server {
   coro_http_server(asio::io_context &ctx, unsigned short port,
                    std::string address = "0.0.0.0")
       : out_ctx_(&ctx), port_(port), acceptor_(ctx), check_timer_(ctx) {
-    init_address(address);
+    init_address(std::move(address));
+  }
+
+  coro_http_server(asio::io_context &ctx,
+                   std::string address /* = "0.0.0.0:9001" */)
+      : out_ctx_(&ctx), acceptor_(ctx), check_timer_(ctx) {
+    init_address(std::move(address));
   }
 
   coro_http_server(size_t thread_num, unsigned short port,
@@ -40,7 +46,17 @@ class coro_http_server {
         port_(port),
         acceptor_(pool_->get_executor()->get_asio_executor()),
         check_timer_(pool_->get_executor()->get_asio_executor()) {
-    init_address(address);
+    init_address(std::move(address));
+  }
+
+  coro_http_server(size_t thread_num,
+                   std::string address /* = "0.0.0.0:9001" */,
+                   bool cpu_affinity = false)
+      : pool_(std::make_unique<coro_io::io_context_pool>(thread_num,
+                                                         cpu_affinity)),
+        acceptor_(pool_->get_executor()->get_asio_executor()),
+        check_timer_(pool_->get_executor()->get_asio_executor()) {
+    init_address(std::move(address));
   }
 
   ~coro_http_server() {
@@ -775,10 +791,26 @@ class coro_http_server {
     response.set_delay(true);
   }
 
-  void init_address(std::string &address) {
+  void init_address(std::string address) {
+    if (size_t pos = address.find(':'); pos != std::string::npos) {
+      auto port_sv = std::string_view(address).substr(pos + 1);
+
+      uint16_t port;
+      auto [ptr, ec] =
+          std::from_chars(port_sv.begin(), port_sv.end(), port, 10);
+      if (ec != std::errc{}) {
+        address_ = std::move(address);
+        return;
+      }
+
+      port_ = port;
+      address = address.substr(0, pos);
+    }
+
     if (iequal0(address, "localhost")) {
       address = "127.0.0.1";
     }
+
     address_ = std::move(address);
   }
 

--- a/src/coro_rpc/tests/ServerTester.hpp
+++ b/src/coro_rpc/tests/ServerTester.hpp
@@ -57,6 +57,7 @@ struct TesterConfig {
   bool sync_client;
   bool use_outer_io_context;
   unsigned short port;
+  std::string address = "0.0.0.0";
   std::chrono::steady_clock::duration conn_timeout_duration =
       std::chrono::seconds(0);
 
@@ -67,7 +68,8 @@ struct TesterConfig {
        << " use_ssl: " << config.use_ssl << ";"
        << " sync_client: " << config.sync_client << ";"
        << " use_outer_io_context: " << config.use_outer_io_context << ";"
-       << " port: " << config.port << ";";
+       << " port: " << config.port << ";"
+       << " address: " << config.address << ";";
     os << " conn_timeout_duration: ";
     auto val = std::chrono::duration_cast<std::chrono::milliseconds>(
                    config.conn_timeout_duration)

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -92,13 +92,13 @@ struct CoroServerTester : ServerTester {
     }
 
     {
-      coro_rpc_server server(1, 9001, "x.x.x");
+      coro_rpc_server server(1, 9001, "x.x.x.x");
       [[maybe_unused]] auto r = server.async_start();
       CHECK(server.get_errc() == coro_rpc::errc::bad_address);
     }
 
     {
-      coro_rpc_server server(1, "x.x.x:9001");
+      coro_rpc_server server(1, "x.x.x.x:9001");
       [[maybe_unused]] auto r = server.async_start();
       CHECK(server.get_errc() == coro_rpc::errc::bad_address);
     }

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -25,6 +25,7 @@
 #include "async_simple/coro/Lazy.h"
 #include "doctest.h"
 #include "rpc_api.hpp"
+#include "ylt/coro_rpc/impl/default_config/coro_rpc_config.hpp"
 #include "ylt/coro_rpc/impl/errno.h"
 #include "ylt/struct_pack.hpp"
 
@@ -33,7 +34,7 @@ async_simple::coro::Lazy<int> get_coro_value(int val) { co_return val; }
 struct CoroServerTester : ServerTester {
   CoroServerTester(TesterConfig config)
       : ServerTester(config),
-        server(2, config.port, config.conn_timeout_duration) {
+        server(2, config.port, config.address, config.conn_timeout_duration) {
 #ifdef YLT_ENABLE_SSL
     if (use_ssl) {
       server.init_ssl_context(
@@ -47,9 +48,42 @@ struct CoroServerTester : ServerTester {
 
   async_simple::coro::Lazy<int> get_value(int val) { co_return val; }
 
+  void test_set_server_address() {
+    {
+      coro_rpc_server server(1, 9001);
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(!server.get_errc());
+    }
+
+    {
+      coro_rpc_server server(1, 9001, "0.0.0.0");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(!server.get_errc());
+    }
+
+    {
+      coro_rpc_server server(1, 9001, "127.0.0.1");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(!server.get_errc());
+    }
+
+    {
+      coro_rpc_server server(1, 9001, "localhost");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(!server.get_errc());
+    }
+
+    {
+      coro_rpc_server server(1, 9001, "x.x.x");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(server.get_errc() == coro_rpc::errc::bad_address);
+    }
+  }
+
   void test_all() override {
     g_action = {};
     ELOGV(INFO, "run %s", __func__);
+    test_set_server_address();
     test_coro_handler();
     ServerTester::test_all();
     test_function_not_registered();

--- a/src/coro_rpc/tests/test_coro_rpc_server.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_server.cpp
@@ -74,7 +74,37 @@ struct CoroServerTester : ServerTester {
     }
 
     {
+      coro_rpc_server server(1, "0.0.0.0:9001");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(!server.get_errc());
+    }
+
+    {
+      coro_rpc_server server(1, "127.0.0.1:9001");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(!server.get_errc());
+    }
+
+    {
+      coro_rpc_server server(1, "localhost:9001");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(!server.get_errc());
+    }
+
+    {
       coro_rpc_server server(1, 9001, "x.x.x");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(server.get_errc() == coro_rpc::errc::bad_address);
+    }
+
+    {
+      coro_rpc_server server(1, "x.x.x:9001");
+      [[maybe_unused]] auto r = server.async_start();
+      CHECK(server.get_errc() == coro_rpc::errc::bad_address);
+    }
+
+    {
+      coro_rpc_server server(1, "127.0.0.1:aaa");
       [[maybe_unused]] auto r = server.async_start();
       CHECK(server.get_errc() == coro_rpc::errc::bad_address);
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

support set server address:

```cpp
coro_rpc_server server(1, 9001);
coro_rpc_server server(1, 9001, "0.0.0.0");
coro_rpc_server server(1, 9001, "127.0.0.1");
coro_rpc_server server(1, 9001, "localhost");
coro_rpc_server server(1, "0.0.0.0:9001");
coro_rpc_server server(1, "127.0.0.1:9001");
coro_rpc_server server(1, "localhost:9001");
```

## What is changing

## Example