### PR TITLE
[easylog][fix]add more restrict for writing log with data/str

### DIFF
--- a/include/ylt/easylog/record.hpp
+++ b/include/ylt/easylog/record.hpp
@@ -63,8 +63,8 @@ template <typename Type, typename = void>
 struct has_data : std::false_type {};
 
 template <typename T>
-struct has_data<T, std::void_t<decltype(std::declval<T>().data())>>
-    : std::true_type {};
+struct has_data<T, std::void_t<decltype(std::declval<std::string>().append(
+                       std::declval<T>().data()))>> : std::true_type {};
 
 template <typename T>
 constexpr inline bool has_data_v = has_data<std::remove_cvref_t<T>>::value;
@@ -73,8 +73,8 @@ template <typename Type, typename = void>
 struct has_str : std::false_type {};
 
 template <typename T>
-struct has_str<T, std::void_t<decltype(std::declval<T>().str())>>
-    : std::true_type {};
+struct has_str<T, std::void_t<decltype(std::declval<std::string>().append(
+                      std::declval<T>().str()))>> : std::true_type {};
 
 template <typename T>
 constexpr inline bool has_str_v = has_str<std::remove_cvref_t<T>>::value;

--- a/src/easylog/tests/test_easylog.cpp
+++ b/src/easylog/tests/test_easylog.cpp
@@ -42,6 +42,20 @@ TEST_CASE("test severity") {
         easylog::severity_str(easylog::Severity::FATAL));
 }
 
+struct dummy_t {
+  int* data() const {
+    static int val = 42;
+    return &val;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const dummy_t& t);
+};
+
+std::ostream& operator<<(std::ostream& os, const dummy_t& t) {
+  os << t.data();
+  return os;
+}
+
 TEST_CASE("test basic") {
   std::string filename = "easylog.txt";
   std::filesystem::remove(filename);
@@ -64,6 +78,8 @@ TEST_CASE("test basic") {
   easylog::set_min_severity(Severity::WARN);
   ELOG_INFO << "info log";
   easylog::set_min_severity(Severity::DEBUG);
+
+  ELOG_INFO << dummy_t{};
 
   std::unique_ptr<int> ptr(new int(42));
   ELOG_INFO << ptr.get();


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Add more restrict for data/str member, check if the return value can be appended to string or not.

## What is changing

## Example