### PR TITLE
[coro_http][fix]coro_http_client tcp_no_delay as default, fix response content view

### DIFF
--- a/include/ylt/standalone/cinatra/coro_http_client.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_client.hpp
@@ -2125,7 +2125,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
       std::chrono::seconds(8);
   std::chrono::steady_clock::duration req_timeout_duration_ =
       std::chrono::seconds(60);
-  bool enable_tcp_no_delay_ = false;
+  bool enable_tcp_no_delay_ = true;
   std::string resp_chunk_str_;
   std::span<char> out_buf_;
 

--- a/include/ylt/standalone/cinatra/coro_http_connection.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_connection.hpp
@@ -392,9 +392,19 @@ class coro_http_connection
     co_return true;
   }
 
-  std::string local_address() { return get_address_impl(false); }
+  std::string local_address() {
+    std::string addr;
+    set_address_impl(addr, false);
+    return addr;
+  }
 
-  std::string remote_address() { return get_address_impl(); }
+  std::string remote_address() {
+    if (!remote_addr_.empty()) {
+      return remote_addr_;
+    }
+    set_address_impl(remote_addr_, false);
+    return remote_addr_;
+  }
 
   void set_multi_buf(bool r) { multi_buf_ = r; }
 
@@ -843,22 +853,21 @@ class coro_http_connection
     }
   }
 
-  std::string get_address_impl(bool remote = true) {
+  void set_address_impl(std::string &address, bool remote = true) {
     if (has_closed_) {
-      return "";
+      return;
     }
 
     std::error_code ec;
     auto pt = remote ? socket_.remote_endpoint(ec) : socket_.local_endpoint(ec);
     if (ec) {
-      return "";
+      return;
     }
-    auto addr = pt.address().to_string(ec);
+    address = pt.address().to_string(ec);
     if (ec) {
-      return "";
+      return;
     }
-    addr.append(":").append(std::to_string(pt.port()));
-    return addr;
+    address.append(":").append(std::to_string(pt.port()));
   }
 
  private:
@@ -898,5 +907,6 @@ class coro_http_connection
   std::function<void(coro_http_request &, coro_http_response &)>
       default_handler_ = nullptr;
   std::string chunk_size_str_;
+  std::string remote_addr_;
 };
 }  // namespace cinatra

--- a/include/ylt/standalone/cinatra/coro_http_response.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_response.hpp
@@ -173,8 +173,11 @@ class coro_http_response {
                 : resp_str.append(CONN_CLOSE_SV);
     }
 
-    if (!content_type_.empty()) {
-      resp_str.append(content_type_);
+    if (content_view_.empty()) {
+      resp_str.append(content_);
+    }
+    else {
+      resp_str.append(content_view_);
     }
 
     append_header_str(resp_str, resp_headers_);

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -863,8 +863,8 @@ class coro_http_server {
   }
 
   void init_address(std::string address) {
-    CINATRA_LOG_ERROR << "init log";  // init easylog singleton to make sure
-                                      // server destruct before easylog.
+    easylog::logger<>::instance();  // init easylog singleton to make sure
+                                    // server destruct before easylog.
     if (size_t pos = address.find(':'); pos != std::string::npos) {
       auto port_sv = std::string_view(address).substr(pos + 1);
 

--- a/src/coro_http/examples/example.cpp
+++ b/src/coro_http/examples/example.cpp
@@ -319,6 +319,8 @@ async_simple::coro::Lazy<void> basic_usage() {
       "/post", [](coro_http_request &req, coro_http_response &resp) {
         assert(resp.get_conn()->remote_address().find("127.0.0.1") !=
                std::string::npos);
+        assert(resp.get_conn()->remote_address().find("127.0.0.1") !=
+               std::string::npos);
         assert(resp.get_conn()->local_address() == "127.0.0.1:9001");
         auto req_body = req.get_body();
         resp.set_status_and_content(status_type::ok, std::string{req_body});


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

- fix response content view
- coro_http_client tcp_no_delay as default

## What is changing

## Example