### PR TITLE
[coro_http_server]fix content_view

### DIFF
--- a/include/ylt/standalone/cinatra/coro_http_connection.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_connection.hpp
@@ -204,7 +204,7 @@ class coro_http_connection
         }
         else {
           if (default_handler_) {
-            default_handler_(request_, response_);
+            co_await default_handler_(request_, response_);
           }
           else {
             bool is_exist = false;
@@ -409,7 +409,8 @@ class coro_http_connection
   void set_multi_buf(bool r) { multi_buf_ = r; }
 
   void set_default_handler(
-      std::function<void(coro_http_request &, coro_http_response &)> &handler) {
+      std::function<async_simple::coro::Lazy<void>(
+          coro_http_request &, coro_http_response &)> &handler) {
     default_handler_ = handler;
   }
 
@@ -904,7 +905,8 @@ class coro_http_connection
 #endif
   bool need_shrink_every_time_ = false;
   bool multi_buf_ = true;
-  std::function<void(coro_http_request &, coro_http_response &)>
+  std::function<async_simple::coro::Lazy<void>(coro_http_request &,
+                                               coro_http_response &)>
       default_handler_ = nullptr;
   std::string chunk_size_str_;
   std::string remote_addr_;

--- a/include/ylt/standalone/cinatra/coro_http_response.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_response.hpp
@@ -173,13 +173,6 @@ class coro_http_response {
                 : resp_str.append(CONN_CLOSE_SV);
     }
 
-    if (content_view_.empty()) {
-      resp_str.append(content_);
-    }
-    else {
-      resp_str.append(content_view_);
-    }
-
     append_header_str(resp_str, resp_headers_);
 
     if (!resp_header_span_.empty()) {
@@ -187,7 +180,12 @@ class coro_http_response {
     }
 
     resp_str.append(CRCF);
-    resp_str.append(content_);
+    if (content_view_.empty()) {
+      resp_str.append(content_);
+    }
+    else {
+      resp_str.append(content_view_);
+    }
   }
 
   void append_header_str(auto &resp_str, auto &resp_headers) {

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -550,8 +550,9 @@ class coro_http_server {
 
   void set_shrink_to_fit(bool r) { need_shrink_every_time_ = r; }
 
-  void set_default_handler(
-      std::function<void(coro_http_request &, coro_http_response &)> handler) {
+  void set_default_handler(std::function<async_simple::coro::Lazy<void>(
+                               coro_http_request &, coro_http_response &)>
+                               handler) {
     default_handler_ = std::move(handler);
   }
 
@@ -923,7 +924,8 @@ class coro_http_server {
 #endif
   coro_http_router router_;
   bool need_shrink_every_time_ = false;
-  std::function<void(coro_http_request &, coro_http_response &)>
+  std::function<async_simple::coro::Lazy<void>(coro_http_request &,
+                                               coro_http_response &)>
       default_handler_ = nullptr;
 };
 

--- a/src/coro_http/examples/example.cpp
+++ b/src/coro_http/examples/example.cpp
@@ -361,6 +361,12 @@ async_simple::coro::Lazy<void> basic_usage() {
                                          req.get_body());  // no copy
         co_await resp.get_conn()->reply();
       });
+  server.set_default_handler(
+      [](coro_http_request &req,
+         coro_http_response &resp) -> async_simple::coro::Lazy<void> {
+        resp.set_status_and_content(status_type::ok, "default response");
+        co_return;
+      });
 
   person_t person{};
   server.set_http_handler<GET>("/person", &person_t::foo, person);
@@ -403,6 +409,10 @@ async_simple::coro::Lazy<void> basic_usage() {
   result = co_await client.async_get(
       "http://127.0.0.1:9001/users/ultramarines/subscriptions/guilliman");
   assert(result.status == 200);
+
+  result = co_await client.async_get("/not_exist");
+  assert(result.status == 200);
+  assert(result.resp_body == "default response");
 
   // make sure you have install openssl and enable CINATRA_ENABLE_SSL
 #ifdef CINATRA_ENABLE_SSL


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

fix build response with content view.
change function type default http hander to lazy type;

## What is changing

## Example

```cpp
  server.set_http_handler<POST>(
      "/view",
      [](coro_http_request &req,
         coro_http_response &resp) -> async_simple::coro::Lazy<void> {
        resp.set_delay(true);
        resp.set_status_and_content_view(status_type::ok,
                                         req.get_body());  // no copy
        co_await resp.get_conn()->reply();
      });
```