### PR TITLE
[coro_http_client][ifx]fix ssl option

### DIFF
--- a/include/ylt/standalone/cinatra/coro_http_client.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_client.hpp
@@ -294,7 +294,12 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
     bool no_schema = !has_schema(uri);
     std::string append_uri;
     if (no_schema) {
-      append_uri.append("http://").append(uri);
+#ifdef CINATRA_ENABLE_SSL
+      if (is_ssl_schema_)
+        append_uri.append("https://").append(uri);
+      else
+#endif
+        append_uri.append("http://").append(uri);
     }
 
     auto [ok, u] = handle_uri(data, no_schema ? append_uri : uri);

--- a/src/coro_http/examples/example.cpp
+++ b/src/coro_http/examples/example.cpp
@@ -424,6 +424,17 @@ async_simple::coro::Lazy<void> basic_usage() {
   co_await client3.connect("https://www.baidu.com");
   result = co_await client3.async_get("/");
   assert(result.status == 200);
+
+  coro_http_client client4{};
+  client4.set_ssl_schema(true);
+  result = client4.get("www.baidu.com");
+  assert(result.status == 200);
+
+  coro_http_client client5{};
+  client5.set_ssl_schema(true);
+  co_await client5.connect("www.baidu.com");
+  result = co_await client5.async_get("/");
+  assert(result.status == 200);
 #endif
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

if client set_ssl_schema(true), the url should add `https://` automatically.

## What is changing

## Example

```cpp
  coro_http_client client4{};
  client4.set_ssl_schema(true);
  result = client4.get("www.baidu.com");
  assert(result.status == 200);

  coro_http_client client5{};
  client5.set_ssl_schema(true);
  co_await client5.connect("www.baidu.com");
  result = co_await client5.async_get("/");
  assert(result.status == 200);
```