### PR TITLE
fix: with MSVC, SP_LIKELY takes no effect

### DIFF
--- a/include/ylt/struct_pack/marco.h
+++ b/include/ylt/struct_pack/marco.h
@@ -31,19 +31,14 @@
 #define STRUCT_PACK_MAY_INLINE inline
 #endif
 
-#if __has_cpp_attribute(likely) && __cplusplus >= 202002L
+#if __has_cpp_attribute(likely) && __has_cpp_attribute(unlikely)
 #define SP_LIKELY(expr) (expr) [[likely]]
-#elif __GNUC__
-#define SP_LIKELY(expr) (__builtin_expect(!!(expr), 1))
-#else
-#define SP_LIKELY(expr) (expr)
-#endif
-
-#if __has_cpp_attribute(unlikely) && __cplusplus >= 202002L
 #define SP_UNLIKELY(expr) (expr) [[unlikely]]
 #elif __GNUC__
+#define SP_LIKELY(expr) (__builtin_expect(!!(expr), 1))
 #define SP_UNLIKELY(expr) (__builtin_expect(!!(expr), 0))
 #else
+#define SP_LIKELY(expr) (expr)
 #define SP_UNLIKELY(expr) (expr)
 #endif
 


### PR DESCRIPTION
MSVC intentionally defined `__cplusplus` to `199711L`, ignoring the actual standard, hence MACRO definitions of `SP_LIKELY` and `SP_UNLIKELY` go to wrong branches in MSVC build.

<!-- Thank you for your contribution! -->

## Why
MSVC builds struct_pack with no [[likely]] attribute.

see [/Zc:__cplusplus](https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170)

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing
Just copied-pasted from iguana/Common.h

## Example