### PR TITLE
[coro_rpc][fix] disable sso optimize in rpc client buffer, which may cause illegal address when user return value has std::string_view

### DIFF
--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -67,12 +67,16 @@ Lazy<void> show_rpc_call() {
 
   // assert(ret.error().code.val() == 404);
 
-  ret = co_await client.call<rpc_with_state_by_tag>();
-  assert(ret.value() == "1");
-  ret = co_await client.call<rpc_with_state_by_tag>();
-  assert(ret.value() == "2");
-  ret = co_await client.call<rpc_with_state_by_tag>();
-  assert(ret.value() == "3");
+  auto ret2 = co_await client.call<rpc_with_state_by_tag>();
+  auto str = ret2.value();
+  std::cout << ret2.value() << std::endl;
+  assert(ret2.value() == "1");
+  ret2 = co_await client.call<rpc_with_state_by_tag>();
+  std::cout << ret2.value() << std::endl;
+  assert(ret2.value() == "2");
+  ret2 = co_await client.call<rpc_with_state_by_tag>();
+  std::cout << ret2.value() << std::endl;
+  assert(ret2.value() == "3");
 }
 
 int main() {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example