### PR TITLE
[coro_rpc][feature] support complete handler

### DIFF
--- a/include/ylt/coro_rpc/impl/context.hpp
+++ b/include/ylt/coro_rpc/impl/context.hpp
@@ -81,8 +81,9 @@ class context_base {
       AS_UNLIKELY { return; };
     ELOGI << "rpc error in function:" << self_->get_rpc_function_name()
           << ". error code:" << error_code.ec << ". message : " << error_msg;
-    self_->conn_->template response_error<rpc_protocol>(error_code, error_msg,
-                                                        self_->req_head_);
+    self_->conn_->template response_error<rpc_protocol>(
+        error_code, error_msg, self_->req_head_,
+        std::move(self_->resp_handler_));
   }
   void response_error(coro_rpc::err_code error_code) {
     response_error(error_code, error_code.message());
@@ -108,7 +109,8 @@ class context_base {
           [&]<typename serialize_proto>(const serialize_proto &) {
             self_->conn_->template response_msg<rpc_protocol>(
                 serialize_proto::serialize(),
-                std::move(self_->resp_attachment_), self_->req_head_);
+                std::move(self_->resp_attachment_), self_->req_head_,
+                std::move(self_->resp_handler_));
           },
           *rpc_protocol::get_serialize_protocol(self_->req_head_));
     }
@@ -121,7 +123,8 @@ class context_base {
           [&]<typename serialize_proto>(const serialize_proto &) {
             self_->conn_->template response_msg<rpc_protocol>(
                 serialize_proto::serialize(ret),
-                std::move(self_->resp_attachment_), self_->req_head_);
+                std::move(self_->resp_attachment_), self_->req_head_,
+                std::move(self_->resp_handler_));
           },
           *rpc_protocol::get_serialize_protocol(self_->req_head_));
 

--- a/include/ylt/coro_rpc/impl/context.hpp
+++ b/include/ylt/coro_rpc/impl/context.hpp
@@ -83,7 +83,7 @@ class context_base {
           << ". error code:" << error_code.ec << ". message : " << error_msg;
     self_->conn_->template response_error<rpc_protocol>(
         error_code, error_msg, self_->req_head_,
-        std::move(self_->resp_handler_));
+        std::move(self_->complete_handler_));
   }
   void response_error(coro_rpc::err_code error_code) {
     response_error(error_code, error_code.message());
@@ -110,7 +110,7 @@ class context_base {
             self_->conn_->template response_msg<rpc_protocol>(
                 serialize_proto::serialize(),
                 std::move(self_->resp_attachment_), self_->req_head_,
-                std::move(self_->resp_handler_));
+                std::move(self_->complete_handler_));
           },
           *rpc_protocol::get_serialize_protocol(self_->req_head_));
     }
@@ -124,11 +124,11 @@ class context_base {
             self_->conn_->template response_msg<rpc_protocol>(
                 serialize_proto::serialize(ret),
                 std::move(self_->resp_attachment_), self_->req_head_,
-                std::move(self_->resp_handler_));
+                std::move(self_->complete_handler_));
           },
           *rpc_protocol::get_serialize_protocol(self_->req_head_));
 
-      // response_handler_(std::move(conn_), std::move(ret));
+      // complete_handler_(std::move(conn_), std::move(ret));
     }
     /*finish here*/
     self_->status_ = context_status::finish_response;

--- a/include/ylt/coro_rpc/impl/coro_connection.hpp
+++ b/include/ylt/coro_rpc/impl/coro_connection.hpp
@@ -56,6 +56,7 @@ struct context_info_t {
   std::function<std::string_view()> resp_attachment_ = [] {
     return std::string_view{};
   };
+  std::function<void(const std::error_code &, std::size_t)> resp_handler_;
   std::atomic<context_status> status_ = context_status::init;
 
  public:
@@ -79,6 +80,14 @@ struct context_info_t {
   void set_response_attachment(std::string_view attachment);
   void set_response_attachment(std::string attachment);
   void set_response_attachment(std::function<std::string_view()> attachment);
+  /* set a handler which will be called when data was serialized and write to
+   * socket*/
+  /* std::error_code: socket write result*/
+  /* std::size_t : write length*/
+  void set_response_handler(
+      std::function<void(const std::error_code &, std::size_t)> &&handler) {
+    resp_handler_ = std::move(handler);
+  }
   std::string_view get_request_attachment() const;
   std::string release_request_attachment();
   std::any &tag() noexcept;
@@ -285,7 +294,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
                                   ret = std::move(ret)]() mutable {
                 context_info->conn_->template direct_response_msg<rpc_protocol>(
                     ret.first, ret.second, context_info->req_head_,
-                    std::move(context_info->resp_attachment_));
+                    std::move(context_info->resp_attachment_),
+                    std::move(context_info->resp_handler_));
               });
             });
       }
@@ -326,7 +336,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
 #endif
         direct_response_msg<rpc_protocol>(
             resp_err, resp_buf, req_head,
-            std::move(context_info->resp_attachment_));
+            std::move(context_info->resp_attachment_),
+            std::move(context_info->resp_handler_));
         context_info->resp_attachment_ = [] {
           return std::string_view{};
         };
@@ -343,7 +354,9 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
   template <typename rpc_protocol>
   void direct_response_msg(coro_rpc::err_code &resp_err, std::string &resp_buf,
                            const typename rpc_protocol::req_header &req_head,
-                           std::function<std::string_view()> &&attachment) {
+                           std::function<std::string_view()> &&attachment,
+                           std::function<void(const std::error_code &,
+                                              std::size_t)> &&resp_handler) {
     std::string resp_error_msg;
     if (resp_err) {
       resp_error_msg = std::move(resp_buf);
@@ -355,7 +368,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
         resp_buf, req_head, attachment().length(), resp_err, resp_error_msg);
 
     response(std::move(header_buf), std::move(resp_buf), std::move(attachment),
-             nullptr)
+             std::move(resp_handler), nullptr)
         .start([](auto &&) {
         });
   }
@@ -363,18 +376,23 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
   template <typename rpc_protocol>
   void response_msg(std::string &&body_buf,
                     std::function<std::string_view()> &&resp_attachment,
-                    const typename rpc_protocol::req_header &req_head) {
+                    const typename rpc_protocol::req_header &req_head,
+                    std::function<void(const std::error_code &, std::size_t)>
+                        &&resp_handler) {
     std::string header_buf = rpc_protocol::prepare_response(
         body_buf, req_head, resp_attachment().size());
     response(std::move(header_buf), std::move(body_buf),
-             std::move(resp_attachment), shared_from_this())
+             std::move(resp_attachment), std::move(resp_handler),
+             shared_from_this())
         .via(executor_)
         .detach();
   }
 
   template <typename rpc_protocol>
   void response_error(coro_rpc::errc ec, std::string_view error_msg,
-                      const typename rpc_protocol::req_header &req_head) {
+                      const typename rpc_protocol::req_header &req_head,
+                      std::function<void(const std::error_code &, std::size_t)>
+                          &&resp_handler) {
     std::function<std::string_view()> attach_ment = []() -> std::string_view {
       return {};
     };
@@ -382,7 +400,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     std::string header_buf =
         rpc_protocol::prepare_response(body_buf, req_head, 0, ec, error_msg);
     response(std::move(header_buf), std::move(body_buf), std::move(attach_ment),
-             shared_from_this())
+             std::move(resp_handler), shared_from_this())
         .via(executor_)
         .detach();
   }
@@ -437,6 +455,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
   async_simple::coro::Lazy<void> response(
       std::string header_buf, std::string body_buf,
       std::function<std::string_view()> resp_attachment,
+      std::function<void(const std::error_code, std::size_t)> resp_handler,
       rpc_conn self) noexcept {
     if (has_closed())
       AS_UNLIKELY {
@@ -450,7 +469,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     }
 #endif
     write_queue_.emplace_back(std::move(header_buf), std::move(body_buf),
-                              std::move(resp_attachment));
+                              std::move(resp_attachment),
+                              std::move(resp_handler));
     --rpc_processing_cnt_;
     assert(rpc_processing_cnt_ >= 0);
     reset_timer();
@@ -507,6 +527,10 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
 #ifdef YLT_ENABLE_SSL
         }
 #endif
+      }
+      auto &response_handler = std::get<3>(msg);
+      if (response_handler) {
+        response_handler(ret.first, ret.second);
       }
       if (ret.first)
         AS_UNLIKELY {
@@ -578,7 +602,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
   asio::ip::tcp::socket socket_;
   // FIXME: queue's performance can be imporved.
   std::deque<
-      std::tuple<std::string, std::string, std::function<std::string_view()>>>
+      std::tuple<std::string, std::string, std::function<std::string_view()>,
+                 std::function<void(const std::error_code, std::size_t)>>>
       write_queue_;
   bool is_rpc_return_by_callback_{false};
 

--- a/src/coro_rpc/examples/base_examples/channel.cpp
+++ b/src/coro_rpc/examples/base_examples/channel.cpp
@@ -55,21 +55,21 @@ Lazy<std::vector<std::chrono::microseconds>> call_echo(
   ++working_echo;
   for (int i = 0; i < request_cnt; ++i) {
     auto res = co_await channel->send_request(
-        [](coro_rpc_client &client, std::string_view hostname) {
-          return client.send_request<echo>("Hello world!");
+        [](coro_rpc_client &client, std::string_view hostname) -> Lazy<void> {
+          auto res = co_await client.call<echo>("Hello world!");
+          if (!res.has_value()) {
+            ELOG_ERROR << "coro_rpc err: \n" << res.error().msg;
+            co_return;
+          }
+          if (res.value() != "Hello world!"sv) {
+            ELOG_ERROR << "err echo resp: \n" << res.value();
+            co_return;
+          }
+          co_return;
         });
     if (!res) {
-      ELOG_ERROR << "client pool err: connect failed.\n"
-                 << std::make_error_code(res.error());
+      ELOG_ERROR << "client pool err: connect failed.\n";
       break;
-    }
-    auto rpc_result = co_await res.value();
-    if (!rpc_result) {
-      ELOG_ERROR << "recv response failed\n" << rpc_result.error().msg;
-      break;
-    }
-    if (rpc_result->result() != "Hello world!") {
-      ELOG_ERROR << "error rpc reponse\n" << rpc_result->result();
     }
     ++qps;
     auto old_tp = tp;

--- a/src/coro_rpc/examples/base_examples/channel.cpp
+++ b/src/coro_rpc/examples/base_examples/channel.cpp
@@ -47,40 +47,6 @@ std::atomic<uint64_t> working_echo = 0;
 
 int request_cnt = 10000;
 
-// Lazy<std::vector<std::chrono::microseconds>>
-// call_echo(std::shared_ptr<coro_io::channel<coro_rpc_client>> channel) {
-//   std::vector<std::chrono::microseconds> result;
-//   result.reserve(request_cnt);
-//   auto tp = std::chrono::steady_clock::now();
-//   ++working_echo;
-//   for (int i = 0; i < request_cnt; ++i) {
-//     auto res = co_await channel->send_request(
-//         [](coro_rpc_client &client, std::string_view hostname) -> Lazy<void>
-//         {
-//           auto res = co_await client.call<echo>("Hello world!");
-//           if (!res.has_value()) {
-//             ELOG_ERROR << "coro_rpc err: \n" << res.error().msg;
-//             co_return;
-//           }
-//           if (res.value() != "Hello world!"sv) {
-//             ELOG_ERROR << "err echo resp: \n" << res.value();
-//             co_return;
-//           }
-//           co_return;
-//         });
-//     if (!res) {
-//       ELOG_ERROR << "client pool err: connect failed.\n";
-//       break;
-//     }
-//     ++qps;
-//     auto old_tp=tp;
-//     tp= std::chrono::steady_clock::now();
-//     result.push_back(std::chrono::duration_cast<std::chrono::microseconds>(
-//         tp - old_tp));
-//   }
-//   co_return std::move(result);
-// }
-
 Lazy<std::vector<std::chrono::microseconds>> call_echo(
     std::shared_ptr<coro_io::channel<coro_rpc_client>> channel) {
   std::vector<std::chrono::microseconds> result;

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <string>
+#include <vector>
 #include <ylt/coro_rpc/coro_rpc_client.hpp>
 
+#include "async_simple/Try.h"
+#include "async_simple/coro/Collect.h"
+#include "async_simple/coro/Lazy.h"
 #include "rpc_service.h"
+#include "ylt/coro_rpc/impl/coro_rpc_client.hpp"
 #include "ylt/coro_rpc/impl/errno.h"
 #include "ylt/coro_rpc/impl/protocol/coro_rpc_protocol.hpp"
 using namespace coro_rpc;
@@ -73,11 +79,34 @@ Lazy<void> show_rpc_call() {
   ret2 = co_await client.call<rpc_with_state_by_tag>();
   std::cout << ret2.value() << std::endl;
   assert(ret2.value() == "3");
+
+  ret = co_await client.call<rpc_with_response_handler>();
+  assert(ret == "Hello");
+}
+/*send multi request with same socket in the same time*/
+Lazy<void> connection_reuse() {
+  coro_rpc_client client;
+  [[maybe_unused]] auto ec = co_await client.connect("127.0.0.1", "8801");
+  assert(!ec);
+  std::vector<Lazy<async_rpc_result<int>>> handlers;
+  for (int i = 0; i < 10; ++i) {
+    /* send_request is thread-safe, so you can call it in different thread with
+     * same client*/
+    handlers.push_back(co_await client.send_request<add>(i, i + 1));
+  }
+  std::vector<async_simple::Try<async_rpc_result<int>>> results =
+      co_await collectAll(std::move(handlers));
+  for (int i = 0; i < 10; ++i) {
+    std::cout << results[i].value()->result() << std::endl;
+    assert(results[i].value()->result() == 2 * i + 1);
+  }
+  co_return;
 }
 
 int main() {
   try {
     syncAwait(show_rpc_call());
+    syncAwait(connection_reuse());
     std::cout << "Done!" << std::endl;
   } catch (const std::exception& e) {
     std::cout << "Error:" << e.what() << std::endl;

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -57,15 +57,14 @@ Lazy<void> show_rpc_call() {
   ret_void = co_await client.call<get_ctx_info>();
   assert(ret_void);
 
-  // TODO: fix return error
-  // ret_void = co_await client.call<return_error_by_context>();
+  ret_void = co_await client.call<return_error_by_context>();
 
-  // assert(ret.error().code.val() == 404);
-  // assert(ret.error().msg == "404 Not Found.");
+  assert(ret_void.error().code.val() == 404);
+  assert(ret_void.error().msg == "404 Not Found.");
 
-  // ret_void = co_await client.call<return_error_by_exception>();
+  ret_void = co_await client.call<return_error_by_exception>();
 
-  // assert(ret.error().code.val() == 404);
+  assert(ret_void.error().code.val() == 404);
 
   auto ret2 = co_await client.call<rpc_with_state_by_tag>();
   auto str = ret2.value();

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -35,14 +35,11 @@ Lazy<void> show_rpc_call() {
   auto ret = co_await client.call<echo>("hello");
   assert(ret.value() == "hello");
 
-  ret = co_await client.call<coroutine_echo>("42");
+  ret = co_await client.call<async_echo_by_coroutine>("42");
   assert(ret.value() == "42");
 
   ret = co_await client.call<async_echo_by_callback>("hi");
   assert(ret.value() == "hi");
-
-  ret = co_await client.call<async_echo_by_coroutine>("hey");
-  assert(ret.value() == "hey");
 
   client.set_req_attachment("This is attachment.");
   auto ret_void = co_await client.call<echo_with_attachment>();

--- a/src/coro_rpc/examples/base_examples/client.cpp
+++ b/src/coro_rpc/examples/base_examples/client.cpp
@@ -80,7 +80,7 @@ Lazy<void> show_rpc_call() {
   std::cout << ret2.value() << std::endl;
   assert(ret2.value() == "3");
 
-  ret = co_await client.call<rpc_with_response_handler>();
+  ret = co_await client.call<rpc_with_complete_handler>();
   assert(ret == "Hello");
 }
 /*send multi request with same socket in the same time*/

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -129,13 +129,13 @@ Lazy<std::string> rpc_with_state_by_tag() {
   ELOGV(INFO, "call count: %d", ++cnter);
   co_return std::to_string(cnter);
 }
-std::string_view rpc_with_response_handler() {
+std::string_view rpc_with_complete_handler() {
   std::string s;
   s.reserve(sizeof(std::string));
   s = "Hello";
   std::string_view result = s;
   auto *ctx = coro_rpc::get_context();
-  ctx->set_response_handler(
+  ctx->set_complete_handler(
       [s = std::move(s)](const std::error_code &ec, std::size_t len) {
         std::cout << "RPC result write to socket, msg: " << ec.message()
                   << " length:" << len << std::endl;

--- a/src/coro_rpc/examples/base_examples/rpc_service.cpp
+++ b/src/coro_rpc/examples/base_examples/rpc_service.cpp
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <system_error>
 #include <thread>
 #include <ylt/coro_rpc/coro_rpc_client.hpp>
 #include <ylt/easylog.hpp>
@@ -127,4 +128,17 @@ Lazy<std::string> rpc_with_state_by_tag() {
   auto &cnter = std::any_cast<uint64_t &>(ctx->tag());
   ELOGV(INFO, "call count: %d", ++cnter);
   co_return std::to_string(cnter);
+}
+std::string_view rpc_with_response_handler() {
+  std::string s;
+  s.reserve(sizeof(std::string));
+  s = "Hello";
+  std::string_view result = s;
+  auto *ctx = coro_rpc::get_context();
+  ctx->set_response_handler(
+      [s = std::move(s)](const std::error_code &ec, std::size_t len) {
+        std::cout << "RPC result write to socket, msg: " << ec.message()
+                  << " length:" << len << std::endl;
+      });
+  return result;
 }

--- a/src/coro_rpc/examples/base_examples/rpc_service.h
+++ b/src/coro_rpc/examples/base_examples/rpc_service.h
@@ -27,6 +27,7 @@ void async_echo_by_callback(
     coro_rpc::context<std::string_view /*rpc response data here*/> conn,
     std::string_view /*rpc request data here*/ data);
 void echo_with_attachment();
+inline int add(int a, int b) { return a + b; }
 async_simple::coro::Lazy<std::string_view> nested_echo(std::string_view sv);
 void return_error_by_context(coro_rpc::context<void> conn);
 void return_error_by_exception();
@@ -36,4 +37,5 @@ class HelloService {
   std::string_view hello();
 };
 async_simple::coro::Lazy<std::string> rpc_with_state_by_tag();
+std::string_view rpc_with_response_handler();
 #endif  // CORO_RPC_RPC_API_HPP

--- a/src/coro_rpc/examples/base_examples/rpc_service.h
+++ b/src/coro_rpc/examples/base_examples/rpc_service.h
@@ -21,13 +21,11 @@
 #include <ylt/coro_rpc/coro_rpc_context.hpp>
 
 std::string_view echo(std::string_view data);
-async_simple::coro::Lazy<std::string_view> coroutine_echo(
+async_simple::coro::Lazy<std::string_view> async_echo_by_coroutine(
     std::string_view data);
 void async_echo_by_callback(
     coro_rpc::context<std::string_view /*rpc response data here*/> conn,
     std::string_view /*rpc request data here*/ data);
-async_simple::coro::Lazy<std::string_view> async_echo_by_coroutine(
-    std::string_view sv);
 void echo_with_attachment();
 async_simple::coro::Lazy<std::string_view> nested_echo(std::string_view sv);
 void return_error_by_context(coro_rpc::context<void> conn);

--- a/src/coro_rpc/examples/base_examples/rpc_service.h
+++ b/src/coro_rpc/examples/base_examples/rpc_service.h
@@ -37,5 +37,5 @@ class HelloService {
   std::string_view hello();
 };
 async_simple::coro::Lazy<std::string> rpc_with_state_by_tag();
-std::string_view rpc_with_response_handler();
+std::string_view rpc_with_complete_handler();
 #endif  // CORO_RPC_RPC_API_HPP

--- a/src/coro_rpc/examples/base_examples/server.cpp
+++ b/src/coro_rpc/examples/base_examples/server.cpp
@@ -28,7 +28,7 @@ int main() {
 
   // regist normal function for rpc
   server.register_handler<
-      echo, coroutine_echo, async_echo_by_callback, async_echo_by_coroutine,
+      echo, async_echo_by_coroutine, async_echo_by_callback,
       echo_with_attachment, nested_echo, return_error_by_context,
       return_error_by_exception, rpc_with_state_by_tag, get_ctx_info>();
 

--- a/src/coro_rpc/examples/base_examples/server.cpp
+++ b/src/coro_rpc/examples/base_examples/server.cpp
@@ -27,10 +27,11 @@ int main() {
   coro_rpc_server server2{/*thread=*/1, /*port=*/8802};
 
   // regist normal function for rpc
-  server.register_handler<
-      echo, async_echo_by_coroutine, async_echo_by_callback,
-      echo_with_attachment, nested_echo, return_error_by_context,
-      return_error_by_exception, rpc_with_state_by_tag, get_ctx_info>();
+  server.register_handler<echo, async_echo_by_coroutine, async_echo_by_callback,
+                          echo_with_attachment, nested_echo,
+                          return_error_by_context, return_error_by_exception,
+                          rpc_with_state_by_tag, get_ctx_info,
+                          rpc_with_response_handler, add>();
 
   // regist member function for rpc
   HelloService hello_service;

--- a/src/coro_rpc/examples/base_examples/server.cpp
+++ b/src/coro_rpc/examples/base_examples/server.cpp
@@ -31,7 +31,7 @@ int main() {
                           echo_with_attachment, nested_echo,
                           return_error_by_context, return_error_by_exception,
                           rpc_with_state_by_tag, get_ctx_info,
-                          rpc_with_response_handler, add>();
+                          rpc_with_complete_handler, add>();
 
   // regist member function for rpc
   HelloService hello_service;

--- a/src/coro_rpc/tests/rpc_api.hpp
+++ b/src/coro_rpc/tests/rpc_api.hpp
@@ -22,6 +22,7 @@
 #include "ylt/coro_rpc/impl/errno.h"
 
 void hi();
+inline std::string_view test_string_view(std::string_view sv){return sv;}
 std::string hello();
 std::string hello_timeout();
 std::string client_hello();

--- a/src/coro_rpc/tests/rpc_api.hpp
+++ b/src/coro_rpc/tests/rpc_api.hpp
@@ -19,10 +19,21 @@
 #include <thread>
 #include <ylt/coro_rpc/coro_rpc_context.hpp>
 
+#include "ylt/coro_io/io_context_pool.hpp"
 #include "ylt/coro_rpc/impl/errno.h"
+#include "ylt/coro_rpc/impl/protocol/coro_rpc_protocol.hpp"
 
 void hi();
-inline std::string_view test_string_view(std::string_view sv){return sv;}
+inline std::string_view test_string_view(std::string_view sv) {
+  auto ctx = coro_rpc::get_context();
+  std::string str;
+  str.reserve(sizeof(std::string));
+  str = std::string{sv}.append("OK");
+  std::string_view result = str;
+  ctx->set_response_handler([str = std::move(str)](auto&&, auto) {
+  });
+  return result;
+}
 std::string hello();
 std::string hello_timeout();
 std::string client_hello();

--- a/src/coro_rpc/tests/rpc_api.hpp
+++ b/src/coro_rpc/tests/rpc_api.hpp
@@ -30,7 +30,7 @@ inline std::string_view test_string_view(std::string_view sv) {
   str.reserve(sizeof(std::string));
   str = std::string{sv}.append("OK");
   std::string_view result = str;
-  ctx->set_response_handler([str = std::move(str)](auto&&, auto) {
+  ctx->set_complete_handler([str = std::move(str)](auto&&, auto) {
   });
   return result;
 }

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -414,6 +414,28 @@ TEST_CASE("testing client with attachment") {
   CHECK(client.get_resp_attachment() == "");
 }
 
+TEST_CASE("testing std::string_view") {
+  g_action = {};
+  coro_rpc_server server(1, 8801);
+
+  auto res = server.async_start();
+  REQUIRE_MESSAGE(!res.hasResult(), "server start failed");
+  coro_rpc_client client(*coro_io::get_global_executor(), g_client_id++);
+  auto ec = client.sync_connect("127.0.0.1", "8801");
+  REQUIRE_MESSAGE(!ec, ec.message());
+
+  server.register_handler<test_string_view>();
+
+  auto ret = client.sync_call<test_string_view>("123");
+  CHECK(ret.value() == "123");
+
+  ret = client.sync_call<test_string_view>("1231232132123123");
+  CHECK(ret.value() == "1231232132123123");
+
+  ret = client.sync_call<test_string_view>("ABDD");
+  CHECK(ret.value() == "ABDD");
+}
+
 TEST_CASE("testing client with context response user-defined error") {
   g_action = {};
   coro_rpc_server server(2, 8801);

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -427,13 +427,13 @@ TEST_CASE("testing std::string_view") {
   server.register_handler<test_string_view>();
 
   auto ret = client.sync_call<test_string_view>("123");
-  CHECK(ret.value() == "123");
+  CHECK(ret.value() == "123OK");
 
   ret = client.sync_call<test_string_view>("1231232132123123");
-  CHECK(ret.value() == "1231232132123123");
+  CHECK(ret.value() == "1231232132123123OK");
 
   ret = client.sync_call<test_string_view>("ABDD");
-  CHECK(ret.value() == "ABDD");
+  CHECK(ret.value() == "ABDDOK");
 }
 
 TEST_CASE("testing client with context response user-defined error") {

--- a/website/docs/en/coro_rpc/coro_rpc_client.md
+++ b/website/docs/en/coro_rpc/coro_rpc_client.md
@@ -146,10 +146,8 @@ using namespace coro_rpc;
 using namespace async_simple::coro;
 std::string_view echo(std::string_view);
 Lazy<void> example(coro_rpc_client& client) {
-  // Wait for the request to be fully sent
-  Lazy<async_rpc_result> handler = co_await client.send_request<echo>("Hello");
-  // Then wait for the server to return the RPC request result
-  async_rpc_result result = co_await handler;
+  // call and wait for the server to return the RPC request result
+  Lazy<async_rpc_result<std::string_view>> handler = co_await client.send_request<echo>("Hello");
   if (result) {
     assert(result->result() == "Hello");
   }
@@ -165,15 +163,15 @@ We can call send_request multiple times to implement connection reuse:
 ```cpp
 using namespace coro_rpc;
 using namespace async_simple::coro;
-std::string_view echo(std::string_view);
+std::string echo(std::string);
 Lazy<void> example(coro_rpc_client& client) {
-  std::vector<Lazy<async_rpc_result>> handlers;
+  std::vector<Lazy<async_rpc_result<std::string>>> handlers;
   // First, send 10 requests consecutively
   for (int i=0;i<10;++i) {
-    handlers.push_back(co_await client.send_request<echo>(std::to_string(i)));
+    handlers.push_back(client.send_request<echo>(std::to_string(i)));
   }
   // Next, wait for all the requests to return
-  std::vector<async_rpc_result> results = co_await collectAll(std::move(handlers));
+  std::vector<async_rpc_result<std::string>> results = co_await collectAll(std::move(handlers));
   for (int i=0;i<10;++i) {
     assert(results[i]->result() == std::to_string(i));
   }
@@ -187,14 +185,12 @@ When using the `send_request` method, since multiple requests might be sent simu
 
 Instead, we can set the attachment when sending a request by calling the `send_request_with_attachment` function. Additionally, we can retrieve the attachment by calling the `->get_attachment()` and `->release_buffer()` methods of `async_rpc_result`.
 
-
-
 ```cpp
 using namespace coro_rpc;
 using namespace async_simple::coro;
 int add(int a, int b);
 Lazy<std::string> example(coro_rpc_client& client) {
-  async_rpc_result result = co_await co_await client.send_request_with_attachment<echo>("Hello", 1, 2);
+  async_rpc_result<std::string_view> result = co_await client.send_request_with_attachment<add>("Hello", 1, 2);
   assert(result->result() == 3);
   assert(result->get_attachment() == "Hello");
   co_return std::move(result->release_buffer().resp_attachment_buf_);

--- a/website/docs/en/coro_rpc/coro_rpc_server.md
+++ b/website/docs/en/coro_rpc/coro_rpc_server.md
@@ -265,7 +265,7 @@ void echo(coro_rpc::context<void> ctx) {
 
 The RPC error code is a 16-bit unsigned integer. The range 0-255 is reserved for error codes used by the RPC framework, and user-defined error codes can be any integer between [256, 65535]. When an RPC returns a user-defined error code, the connection will not be terminated. However, if an error code from the RPC framework is returned, it is considered a serious RPC error, leading to the disconnection of the RPC link.
 
-### Response Handler
+### Complete Handler
 
 When the server successfully writes the RPC response data to the socket, the response callback function is invoked. Users can set this callback function for logging, statistics, etc. Moreover, when the return value of the RPC function includes types like `std::string_view` or `std::span`, this callback function can be used to destruct objects at an appropriate time.
 
@@ -274,7 +274,7 @@ The callback function takes two parameters: the first is `const std::error_code&
 ```cpp
 void foo() {
   auto ctx = coro_rpc::get_context();
-  ctx->set_response_handler([](const std::error_code& ec, std::size_t length) {
+  ctx->set_complete_handler([](const std::error_code& ec, std::size_t length) {
     if (ec) {
       std::cout << "error: " << ec.message() << std::endl;
     } else {
@@ -302,13 +302,13 @@ If your rpc argument or return value type is not supported by the struct_pack ty
 
 The user's return value may contain view types such as `std::string_view` or `std::span`. These types can reduce copies during deserialization, thereby enhancing RPC performance. However, this requires that the objects they point to must not be destructed until after the RPC request has been successfully sent.
 
-Users can ensure this by setting a `response_handler`:
+Users can ensure this by setting a `complete_handler`:
 
 ```cpp
 std::string_view hello() {
   auto ctx = coro_rpc::get_context();
   auto str = std::make_unique<std::string>("Hello");
-  ctx->set_response_handler([str = std::move(str)](const std::error_code& ec, std::size_t length) {
+  ctx->set_complete_handler([str = std::move(str)](const std::error_code& ec, std::size_t length) {
     if (ec) {
       std::cout << "error: " << ec.message() << std::endl;
     } else {

--- a/website/docs/en/coro_rpc/coro_rpc_server.md
+++ b/website/docs/en/coro_rpc/coro_rpc_server.md
@@ -265,6 +265,26 @@ void echo(coro_rpc::context<void> ctx) {
 
 The RPC error code is a 16-bit unsigned integer. The range 0-255 is reserved for error codes used by the RPC framework, and user-defined error codes can be any integer between [256, 65535]. When an RPC returns a user-defined error code, the connection will not be terminated. However, if an error code from the RPC framework is returned, it is considered a serious RPC error, leading to the disconnection of the RPC link.
 
+### Response Handler
+
+When the server successfully writes the RPC response data to the socket, the response callback function is invoked. Users can set this callback function for logging, statistics, etc. Moreover, when the return value of the RPC function includes types like `std::string_view` or `std::span`, this callback function can be used to destruct objects at an appropriate time.
+
+The callback function takes two parameters: the first is `const std::error_code&`, which represents the result of writing to the socket. The second is `std::size_t`, which represents the number of bytes sent. Note that a success here only indicates that the server successfully sent the data; it does not guarantee that the client has received it.
+
+```cpp
+void foo() {
+  auto ctx = coro_rpc::get_context();
+  ctx->set_response_handler([](const std::error_code& ec, std::size_t length) {
+    if (ec) {
+      std::cout << "error: " << ec.message() << std::endl;
+    } else {
+      std::cout << "ok: wrote " << length << " bytes" << std::endl;
+    }
+  });
+  return;
+}
+```
+
 ## Connections and I/O Threads
 
 The server internally has an I/O thread pool, the size of which defaults to the number of logical threads of the CPU. After the server starts, it launches a listening task on one of the I/O threads to accept connections from clients. Each time a connection is accepted, the server selects an I/O thread through round-robin to bind it to. Subsequently, all steps including data transmission, serialization, RPC routing, etc., of that connection are executed on this I/O thread. The RPC functions are also executed on the same I/O thread.
@@ -278,7 +298,36 @@ coro_rpc allows users to register rpc functions with multiple parameters (up to 
 
 If your rpc argument or return value type is not supported by the struct_pack type system, we also allow users to register their own structures or custom serialization algorithms. For more details, see: [Custom feature](https://alibaba.github.io/yalantinglibs/en/struct_pack/struct_pack_intro.html#custom-type)
 
-## RPC Return Value Construction and Checking
+### Return Value with view
+
+The user's return value may contain view types such as `std::string_view` or `std::span`. These types can reduce copies during deserialization, thereby enhancing RPC performance. However, this requires that the objects they point to must not be destructed until after the RPC request has been successfully sent.
+
+Users can ensure this by setting a `response_handler`:
+
+```cpp
+std::string_view hello() {
+  auto ctx = coro_rpc::get_context();
+  auto str = std::make_unique<std::string>("Hello");
+  ctx->set_response_handler([str = std::move(str)](const std::error_code& ec, std::size_t length) {
+    if (ec) {
+      std::cout << "error: " << ec.message() << std::endl;
+    } else {
+      std::cout << "ok: write " << length << " bytes" << std::endl;
+    }
+  });
+  return *str; /*this is safe*/
+}
+```
+
+Especially, when the return value's view originates from the parameters within the RPC function, the RPC framework guarantees it to be valid without the need for extra operations.
+
+```cpp
+std::string_view echo(std::string_view sv) {
+  return sv;
+}
+```
+
+### RPC Return Value Construction and Checking
 
 Furthermore, for callback functions, coro_rpc will try to construct the return value type from the parameter list. If it fails to construct, it will lead to a compilation failure.
 

--- a/website/docs/zh/coro_rpc/coro_rpc_client.md
+++ b/website/docs/zh/coro_rpc/coro_rpc_client.md
@@ -139,7 +139,7 @@ do_something();
 
 ## 连接复用
 
-`coro_rpc_client` 可以通过 `send_request`函数实现连接复用。该函数是线程安全的，允许多个线程同时调用同一个client的 `send_request`方法。该函数返回值为`Lazy<Lazy<async_rpc_result<T>`。第一次`co_await`可以等待请求发送，再次`co_await`则等待rpc返回结果。
+`coro_rpc_client` 可以通过 `send_request`函数实现连接复用。该函数是线程安全的，允许多个线程同时调用同一个client的 `send_request`方法。该函数返回值为`Lazy<async_rpc_result<T>>`.
 
 
 连接复用允许我们在高并发下减少连接的个数，无需创建新的连接。同时也能提高每个连接的吞吐量。
@@ -151,10 +151,8 @@ using namespace coro_rpc;
 using namespace async_simple::coro;
 std::string_view echo(std::string_view);
 Lazy<void> example(coro_rpc_client& client) {
-  //先等待请求发送完毕
-  Lazy<async_rpc_result> handler = co_await client.send_request<echo>("Hello");
-  //然后等待服务器返回rpc请求结果
-  async_rpc_result result = co_await handler;
+  //向服务器发送请求
+  async_rpc_result<std::string_view> result = co_await client.send_request<echo>("Hello");
   if (result) {
     assert(result->result() == "Hello");
   }
@@ -170,15 +168,15 @@ Lazy<void> example(coro_rpc_client& client) {
 ```cpp
 using namespace coro_rpc;
 using namespace async_simple::coro;
-std::string_view echo(std::string_view);
+std::string echo(std::string);
 Lazy<void> example(coro_rpc_client& client) {
-  std::vector<Lazy<async_rpc_result>> handlers;
-  //首先连续发送10个请求
+  std::vector<Lazy<async_rpc_result<std::string>>> handlers;
+  // 准备发送10个请求
   for (int i=0;i<10;++i) {
-    handlers.push_back(co_await client.send_request<echo>(std::to_string(i)));
+    handlers.push_back(client.send_request<echo>(std::to_string(i)));
   }
   //接下来等待所有的请求返回
-  std::vector<async_rpc_result> results = co_await collectAll(std::move(handlers));
+  std::vector<async_rpc_result<std::string>> results = co_await collectAll(std::move(handlers));
   for (int i=0;i<10;++i) {
     assert(results[i]->result() == std::to_string(i));
   }
@@ -197,7 +195,7 @@ using namespace coro_rpc;
 using namespace async_simple::coro;
 int add(int a, int b);
 Lazy<std::string> example(coro_rpc_client& client) {
-  async_rpc_result result = co_await co_await client.send_request_with_attachment<echo>("Hello", 1, 2);
+  async_rpc_result<std::string_view> result = co_await co_await client.send_request_with_attachment<add>("Hello", 1, 2);
   assert(result->result() == 3);
   assert(result->get_attachment() == "Hello");
   co_return std::move(result->release_buffer().resp_attachment_buf_);

--- a/website/docs/zh/coro_rpc/coro_rpc_server.md
+++ b/website/docs/zh/coro_rpc/coro_rpc_server.md
@@ -263,16 +263,16 @@ void echo(coro_rpc::context<void> ctx) {
 rpc错误码是一个16位的无符号整数。其中，0-255是保留给rpc框架使用的错误码，用户自定义的错误码可以是[256,65535]之间的任一整数。当rpc返回用户自定义错误码时，连接不会断开。如果返回的是rpc框架自带的错误码，则视为发生了严重的rpc错误，会导致rpc连接断开。
 
 
-## 响应回调
+## 完成回调
 
-当服务器成功将rpc响应数据写入socket时，会调用响应回调函数。用户可以设置该回调函数，用于日志，统计。此外，当rpc函数的返回值具有`std::string_view`,`std::span`等类型时，也可以通过该回调函数在合适的时间点析构对象。
+当服务器成功将rpc响应数据写入socket时，会调用完成回调函数。用户可以设置该回调函数，用于日志，统计。此外，当rpc函数的返回值具有`std::string_view`,`std::span`等类型时，也可以通过该回调函数在合适的时间点析构对象。
 
 该回调函数有两个参数，第一个参数是`const std::error_code&`，代表写入`socket`的结果。第二个参数是`std::size_t` ,代表发送的字节数。需要注意，这里的成功只能代表服务器成功发送数据，不能代表客户端收到了数据。
 
 ```cpp
 void foo() {
   auto ctx = coro_rpc::get_context();
-  ctx->set_response_handler([](const std::error_code& ec, std::size_t length){
+  ctx->set_complete_handler([](const std::error_code& ec, std::size_t length){
     if (ec) {
       std::cout<<"error: "<<ec.message()<<std::endl;
     }
@@ -303,13 +303,13 @@ coro_rpc允许用户注册的rpc函数具有多个参数（最多255个），参
 
 用户的返回值可能包含了`std::string_view`或`std::span`等视图类型，这些类型能够减少反序列化时的拷贝，从而提升rpc性能。然而，这要求其指向的对象必须在rpc请求成功发送后才能析构。
 
-用户可以利用设置`response_handler`来保证这一点：
+用户可以利用设置`complete_handler`来保证这一点：
 
 ```cpp
 std::string_view hello() {
   auto ctx = coro_rpc::get_context();
   auto str=std::make_unique<std::string>("Hello");
-  ctx->set_response_handler([str=std::move(str)](const std::error_code& ec, std::size_t length){
+  ctx->set_complete_handler([str=std::move(str)](const std::error_code& ec, std::size_t length){
     if (ec) {
       std::cout<<"error: "<<ec.message()<<std::endl;
     }

--- a/website/docs/zh/coro_rpc/coro_rpc_server.md
+++ b/website/docs/zh/coro_rpc/coro_rpc_server.md
@@ -262,6 +262,29 @@ void echo(coro_rpc::context<void> ctx) {
 
 rpc错误码是一个16位的无符号整数。其中，0-255是保留给rpc框架使用的错误码，用户自定义的错误码可以是[256,65535]之间的任一整数。当rpc返回用户自定义错误码时，连接不会断开。如果返回的是rpc框架自带的错误码，则视为发生了严重的rpc错误，会导致rpc连接断开。
 
+
+## 响应回调
+
+当服务器成功将rpc响应数据写入socket时，会调用响应回调函数。用户可以设置该回调函数，用于日志，统计。此外，当rpc函数的返回值具有`std::string_view`,`std::span`等类型时，也可以通过该回调函数在合适的时间点析构对象。
+
+该回调函数有两个参数，第一个参数是`const std::error_code&`，代表写入`socket`的结果。第二个参数是`std::size_t` ,代表发送的字节数。需要注意，这里的成功只能代表服务器成功发送数据，不能代表客户端收到了数据。
+
+```cpp
+void foo() {
+  auto ctx = coro_rpc::get_context();
+  ctx->set_response_handler([](const std::error_code& ec, std::size_t length){
+    if (ec) {
+      std::cout<<"error: "<<ec.message()<<std::endl;
+    }
+    else {
+      std::cout<<"ok: write "<<length<<" bytes"<<std::endl;
+    }
+  });
+  return;
+}
+```
+
+
 ## 连接与IO线程
 
 服务器内部有一个IO线程池，其大小默认为cpu的逻辑线程数目。当服务器启动后，它会在某个IO线程上启动一个监听任务，接收客户端发来的连接。每次接收连接时，服务器会通过轮转法，选择一个IO线程将其绑定到连接上。随后，该连接上各请求收发数据，序列化，rpc路由等步骤都会在该IO线程上执行。rpc函数也同样会在该IO线程上执行。
@@ -276,7 +299,38 @@ coro_rpc允许用户注册的rpc函数具有多个参数（最多255个），参
 
 如果你的rpc参数或返回值类型不属于struct_pack的类型系统支持的类型，我们也允许用户注册自己的结构体或者自定义序列化算法，详见：[自定义功能支持](https://alibaba.github.io/yalantinglibs/zh/struct_pack/struct_pack_intro.html#%E8%87%AA%E5%AE%9A%E4%B9%89%E7%B1%BB%E5%9E%8B%E7%9A%84%E5%BA%8F%E5%88%97%E5%8C%96)
 
-## RPC返回值的构造与检查
+### 返回值包含视图类型
+
+用户的返回值可能包含了`std::string_view`或`std::span`等视图类型，这些类型能够减少反序列化时的拷贝，从而提升rpc性能。然而，这要求其指向的对象必须在rpc请求成功发送后才能析构。
+
+用户可以利用设置`response_handler`来保证这一点：
+
+```cpp
+std::string_view hello() {
+  auto ctx = coro_rpc::get_context();
+  auto str=std::make_unique<std::string>("Hello");
+  ctx->set_response_handler([str=std::move(str)](const std::error_code& ec, std::size_t length){
+    if (ec) {
+      std::cout<<"error: "<<ec.message()<<std::endl;
+    }
+    else {
+      std::cout<<"ok: write "<<length<<" bytes"<<std::endl;
+    }
+  });
+  return *str; /*this is safe*/
+}
+```
+
+特别的，当返回值的视图来自rpc函数中的参数时，rpc框架保证其一定是合法的，无需额外操作。
+
+```cpp
+std::string_view echo(std::string_view sv) {
+  return sv;
+}
+```
+
+
+### RPC返回值的构造与检查
 
 此外，对于回调函数，coro_rpc会尝试通过参数列表构造返回值类型。如果无法构造则会导致编译失败。
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

## What is changing

1. fix example
2. add more document
3. add support for coro_rpc_server to set complete callback, When the server successfully writes the RPC response data to the socket, the  complete callback function is invoked. Users can set this callback function for logging, statistics, etc. Moreover, when the return value of the RPC function includes types like `std::string_view` or `std::span`, this callback function can be used to destruct objects at an appropriate time.

## Example

```cpp
void foo() {
  auto ctx = coro_rpc::get_context();
  ctx->set_response_handler([](const std::error_code& ec, std::size_t length) {
    if (ec) {
      std::cout << "error: " << ec.message() << std::endl;
    } else {
      std::cout << "ok: wrote " << length << " bytes" << std::endl;
    }
  });
  return;
}
```

```cpp
std::string_view hello() {
  auto ctx = coro_rpc::get_context();
  auto str = std::make_unique<std::string>("Hello");
  ctx->set_response_handler([str = std::move(str)](const std::error_code& ec, std::size_t length) {
    if (ec) {
      std::cout << "error: " << ec.message() << std::endl;
    } else {
      std::cout << "ok: write " << length << " bytes" << std::endl;
    }
  });
  return *str; /*this is safe*/
}
```