### PR TITLE
[coro_http_client][modify]update out buf logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(yaLanTingLibs
-        VERSION 0.3.4
+        VERSION 0.3.5
         DESCRIPTION "yaLanTingLibs"
         HOMEPAGE_URL "https://github.com/alibaba/yalantinglibs"
         LANGUAGES CXX

--- a/include/ylt/standalone/cinatra/coro_http_client.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_client.hpp
@@ -808,6 +808,8 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
         async_download(std::move(uri), std::move(filename), std::move(range)));
   }
 
+  bool is_body_in_out_buf() const { return !out_buf_.empty(); }
+
   void reset() {
     if (!has_closed())
       close_socket(*socket_);
@@ -1780,9 +1782,8 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
       bool is_out_buf = !out_buf_.empty();
       if (is_out_buf) {
         if (content_len > 0 && out_buf_.size() < content_len) {
-          data.status = 404;
-          data.net_err = std::make_error_code(std::errc::no_buffer_space);
-          co_return data;
+          out_buf_ = {};
+          is_out_buf = false;
         }
       }
 

--- a/include/ylt/version.hpp
+++ b/include/ylt/version.hpp
@@ -20,4 +20,4 @@
 // YLT_VERSION % 100 is the sub-minor version
 // YLT_VERSION / 100 % 1000 is the minor version
 // YLT_VERSION / 100000 is the major version
-#define YLT_VERSION 304  // 0.3.4
+#define YLT_VERSION 305  // 0.3.5


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

out buffer is not an error, client will use inner buffer instead of out buffer when out buffer space is not enough.

## What is changing

## Example