### PR TITLE
[struct_pack][fix] fix mod zero error when struct only contain compat…

### DIFF
--- a/include/ylt/struct_pack/alignment.hpp
+++ b/include/ylt/struct_pack/alignment.hpp
@@ -160,7 +160,7 @@ constexpr auto calculate_padding_size() {
   std::array<std::size_t, struct_pack::members_count<T> + 1> padding_size{};
   std::size_t offset = 0;
   for_each<T, calculate_padding_size_impl>(offset, padding_size);
-  if (offset % align::alignment_v<T>) {
+  if (align::alignment_v < T >> 0 && offset % align::alignment_v<T>) {
     padding_size[struct_pack::members_count<T>] =
         align::alignment_v<T> - offset % align::alignment_v<T>;
   }

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -1311,11 +1311,10 @@ TEST_CASE("test nested trival_serialzable_obj_with_compatible") {
 }
 
 struct only_compatible {
-  int i;
   struct_pack::compatible<int> hi;
 };
 TEST_CASE("test only_compatible") {
-  only_compatible o{{0}};
+  only_compatible o{0};
   auto buffer = struct_pack::serialize(o);
   auto result = struct_pack::deserialize<only_compatible>(buffer);
   CHECK(result.has_value());

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -3,6 +3,7 @@
 
 #include "doctest.h"
 #include "test_struct.hpp"
+#include "ylt/struct_pack/compatible.hpp"
 #include "ylt/struct_pack/endian_wrapper.hpp"
 
 using namespace struct_pack;
@@ -1307,4 +1308,16 @@ TEST_CASE("test nested trival_serialzable_obj_with_compatible") {
     CHECK(result.has_value());
     CHECK(test_equal(result.value(), a_v1));
   }
+}
+
+struct only_compatible {
+  int i;
+  struct_pack::compatible<int> hi;
+};
+TEST_CASE("test only_compatible") {
+  only_compatible o{{0}};
+  auto buffer = struct_pack::serialize(o);
+  auto result = struct_pack::deserialize<only_compatible>(buffer);
+  CHECK(result.has_value());
+  CHECK(result->hi == o.hi);
 }


### PR DESCRIPTION
…ible

<!-- Thank you for your contribution! -->

## Why

struct foo {
  struct_pack::compatible<int> foo;
};

this struct cant work in struct_pack, because when calculate padding size, the code mod zero cause compiler error.

## What is changing

## Example