### PR TITLE
[reflection][change]get alias name by adl

### DIFF
--- a/include/ylt/reflection/member_count.hpp
+++ b/include/ylt/reflection/member_count.hpp
@@ -28,7 +28,9 @@ concept expected = requires(Type e) {
   e.has_value();
   e.error();
   requires std::is_same_v<void, typename remove_cvref_t<Type>::value_type> ||
-               requires(Type e) { e.value(); };
+      requires(Type e) {
+    e.value();
+  };
 };
 #else
 template <typename T, typename = void>
@@ -72,8 +74,9 @@ constexpr bool optional = !expected<T> && optional_impl<T>::value;
 namespace internal {
 #if __cpp_concepts >= 201907L
 template <typename Type>
-concept tuple_size =
-    requires(Type tuple) { std::tuple_size<remove_cvref_t<Type>>::value; };
+concept tuple_size = requires(Type tuple) {
+  std::tuple_size<remove_cvref_t<Type>>::value;
+};
 #else
 template <typename T, typename = void>
 struct tuple_size_impl : std::false_type {};

--- a/src/struct_xml/examples/main.cpp
+++ b/src/struct_xml/examples/main.cpp
@@ -291,14 +291,13 @@ struct next_obj_t {
 };
 YLT_REFL(next_obj_t, x, y);
 
-template <>
-struct ylt::reflection::ylt_alias_struct<next_obj_t> {
-  static constexpr std::string_view get_alias_struct_name() { return "next"; }
-
-  static constexpr auto get_alias_field_names() {
-    return std::array{field_alias_t{"w", 0}, field_alias_t{"h", 1}};
-  }
-};
+constexpr std::string_view get_alias_struct_name(next_obj_t *) {
+  return "next";
+}
+constexpr auto get_alias_field_names(next_obj_t *) {
+  using namespace ylt::reflection;
+  return std::array{field_alias_t{"w", 0}, field_alias_t{"h", 1}};
+}
 
 struct out_object {
   std::unique_ptr<int> id;
@@ -307,14 +306,11 @@ struct out_object {
 };
 YLT_REFL(out_object, id, name, obj);
 
-template <>
-struct ylt::reflection::ylt_alias_struct<out_object> {
-  static constexpr std::string_view get_alias_struct_name() { return "qi"; }
-
-  static constexpr auto get_alias_field_names() {
-    return std::array{field_alias_t{"i", 0}, field_alias_t{"na", 1}};
-  }
-};
+constexpr std::string_view get_alias_struct_name(out_object *) { return "qi"; }
+constexpr auto get_alias_field_names(out_object *) {
+  using namespace ylt::reflection;
+  return std::array{field_alias_t{"i", 0}, field_alias_t{"na", 1}};
+}
 
 void test_alias() {
   out_object m{std::make_unique<int>(20), "tom", {21, 42}};


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

get alias name by ADL

## What is changing

## Example

```cpp
struct point_t1 {
  int x;
  int y;

  static constexpr auto get_alias_field_names(point_t1*) {
    return std::array{field_alias_t{"X", 0}, field_alias_t{"Y", 1}};
  }
  static constexpr std::string_view get_alias_struct_name(point_t1*) {
    return "point";
  }
};
YLT_REFL(point_t1, x, y);
```

or 

```cpp
struct point_t1 {
  int x;
  int y;
};
YLT_REFL(point_t1, x, y);
inline constexpr auto get_alias_field_names(point_t1*) {
  return std::array{field_alias_t{"X", 0}, field_alias_t{"Y", 1}};
}
inline constexpr std::string_view get_alias_struct_name(point_t1*) {
  return "point";
}
```