### PR TITLE
[struct_json] is compatible with msvc versions

### DIFF
--- a/include/ylt/reflection/member_names.hpp
+++ b/include/ylt/reflection/member_names.hpp
@@ -127,13 +127,25 @@ get_member_names() {
   else {
     std::array<std::string_view, Count> arr;
 #if __cplusplus >= 202002L
+#if defined(_MSC_VER)
+#if _MSC_VER >= 1930
     constexpr auto tp = struct_to_tuple<T>();
     [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
       ((arr[Is] =
             internal::get_member_name<internal::wrap(std::get<Is>(tp))>()),
        ...);
-    }
-    (std::make_index_sequence<Count>{});
+    }(std::make_index_sequence<Count>{});
+#else
+    init_arr_with_tuple<T>(arr, std::make_index_sequence<Count>{});
+#endif
+#else
+    constexpr auto tp = struct_to_tuple<T>();
+    [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
+      ((arr[Is] =
+            internal::get_member_name<internal::wrap(std::get<Is>(tp))>()),
+       ...);
+    }(std::make_index_sequence<Count>{});
+#endif
 #else
     init_arr_with_tuple<T>(arr, std::make_index_sequence<Count>{});
 #endif
@@ -155,8 +167,7 @@ inline constexpr auto get_member_names_map() {
   return [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
     return frozen::unordered_map<frozen::string, size_t, name_arr.size()>{
         {name_arr[Is], Is}...};
-  }
-  (std::make_index_sequence<name_arr.size()>{});
+  }(std::make_index_sequence<name_arr.size()>{});
 #else
   return get_member_names_map_impl(name_arr,
                                    std::make_index_sequence<name_arr.size()>{});
@@ -177,15 +188,14 @@ inline const auto& get_member_offset_arr(T&& t) {
   auto tp = ylt::reflection::object_to_tuple(std::forward<T>(t));
 
 #if __cplusplus >= 202002L
-  [[maybe_unused]] static std::array<size_t, Count> arr = {[&]<size_t... Is>(
-      std::index_sequence<Is...>) mutable {std::array<size_t, Count> arr;
-  ((arr[Is] = size_t((const char*)&std::get<Is>(tp) - (char*)(&t))), ...);
-  return arr;
-}
-(std::make_index_sequence<Count>{})
-};  // namespace internal
+  [[maybe_unused]] static std::array<size_t, Count> arr = {
+      [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
+        std::array<size_t, Count> arr;
+        ((arr[Is] = size_t((const char*)&std::get<Is>(tp) - (char*)(&t))), ...);
+        return arr;
+      }(std::make_index_sequence<Count>{})};  // namespace internal
 
-return arr;
+  return arr;
 #else
   [[maybe_unused]] static std::array<size_t, Count> arr =
       get_member_offset_arr_impl(t, tp, std::make_index_sequence<Count>{});
@@ -357,8 +367,7 @@ inline constexpr void for_each(Visit&& func) {
                     "size_t], at least has std::string_view and make sure keep "
                     "the order of arguments");
     }
-  }
-  (std::make_index_sequence<arr.size()>{});
+  }(std::make_index_sequence<arr.size()>{});
 #else
   for_each_impl(std::forward<Visit>(func), arr,
                 std::make_index_sequence<arr.size()>{});

--- a/include/ylt/reflection/member_names.hpp
+++ b/include/ylt/reflection/member_names.hpp
@@ -132,7 +132,8 @@ get_member_names() {
       ((arr[Is] =
             internal::get_member_name<internal::wrap(std::get<Is>(tp))>()),
        ...);
-    }(std::make_index_sequence<Count>{});
+    }
+    (std::make_index_sequence<Count>{});
 #else
     init_arr_with_tuple<T>(arr, std::make_index_sequence<Count>{});
 #endif
@@ -154,7 +155,8 @@ inline constexpr auto get_member_names_map() {
   return [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
     return frozen::unordered_map<frozen::string, size_t, name_arr.size()>{
         {name_arr[Is], Is}...};
-  }(std::make_index_sequence<name_arr.size()>{});
+  }
+  (std::make_index_sequence<name_arr.size()>{});
 #else
   return get_member_names_map_impl(name_arr,
                                    std::make_index_sequence<name_arr.size()>{});
@@ -175,14 +177,15 @@ inline const auto& get_member_offset_arr(T&& t) {
   auto tp = ylt::reflection::object_to_tuple(std::forward<T>(t));
 
 #if __cplusplus >= 202002L
-  [[maybe_unused]] static std::array<size_t, Count> arr = {
-      [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
-        std::array<size_t, Count> arr;
-        ((arr[Is] = size_t((const char*)&std::get<Is>(tp) - (char*)(&t))), ...);
-        return arr;
-      }(std::make_index_sequence<Count>{})};  // namespace internal
-
+  [[maybe_unused]] static std::array<size_t, Count> arr = {[&]<size_t... Is>(
+      std::index_sequence<Is...>) mutable {std::array<size_t, Count> arr;
+  ((arr[Is] = size_t((const char*)&std::get<Is>(tp) - (char*)(&t))), ...);
   return arr;
+}
+(std::make_index_sequence<Count>{})
+};  // namespace internal
+
+return arr;
 #else
   [[maybe_unused]] static std::array<size_t, Count> arr =
       get_member_offset_arr_impl(t, tp, std::make_index_sequence<Count>{});
@@ -354,7 +357,8 @@ inline constexpr void for_each(Visit&& func) {
                     "size_t], at least has std::string_view and make sure keep "
                     "the order of arguments");
     }
-  }(std::make_index_sequence<arr.size()>{});
+  }
+  (std::make_index_sequence<arr.size()>{});
 #else
   for_each_impl(std::forward<Visit>(func), arr,
                 std::make_index_sequence<arr.size()>{});

--- a/include/ylt/reflection/member_names.hpp
+++ b/include/ylt/reflection/member_names.hpp
@@ -126,26 +126,13 @@ get_member_names() {
   }
   else {
     std::array<std::string_view, Count> arr;
-#if __cplusplus >= 202002L
-#if defined(_MSC_VER)
-#if _MSC_VER >= 1930
+#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >= 1930)
     constexpr auto tp = struct_to_tuple<T>();
     [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
       ((arr[Is] =
             internal::get_member_name<internal::wrap(std::get<Is>(tp))>()),
        ...);
     }(std::make_index_sequence<Count>{});
-#else
-    init_arr_with_tuple<T>(arr, std::make_index_sequence<Count>{});
-#endif
-#else
-    constexpr auto tp = struct_to_tuple<T>();
-    [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
-      ((arr[Is] =
-            internal::get_member_name<internal::wrap(std::get<Is>(tp))>()),
-       ...);
-    }(std::make_index_sequence<Count>{});
-#endif
 #else
     init_arr_with_tuple<T>(arr, std::make_index_sequence<Count>{});
 #endif

--- a/include/ylt/reflection/member_names.hpp
+++ b/include/ylt/reflection/member_names.hpp
@@ -132,8 +132,7 @@ get_member_names() {
       ((arr[Is] =
             internal::get_member_name<internal::wrap(std::get<Is>(tp))>()),
        ...);
-    }
-    (std::make_index_sequence<Count>{});
+    }(std::make_index_sequence<Count>{});
 #else
     init_arr_with_tuple<T>(arr, std::make_index_sequence<Count>{});
 #endif
@@ -155,8 +154,7 @@ inline constexpr auto get_member_names_map() {
   return [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
     return frozen::unordered_map<frozen::string, size_t, name_arr.size()>{
         {name_arr[Is], Is}...};
-  }
-  (std::make_index_sequence<name_arr.size()>{});
+  }(std::make_index_sequence<name_arr.size()>{});
 #else
   return get_member_names_map_impl(name_arr,
                                    std::make_index_sequence<name_arr.size()>{});
@@ -177,15 +175,14 @@ inline const auto& get_member_offset_arr(T&& t) {
   auto tp = ylt::reflection::object_to_tuple(std::forward<T>(t));
 
 #if __cplusplus >= 202002L
-  [[maybe_unused]] static std::array<size_t, Count> arr = {[&]<size_t... Is>(
-      std::index_sequence<Is...>) mutable {std::array<size_t, Count> arr;
-  ((arr[Is] = size_t((const char*)&std::get<Is>(tp) - (char*)(&t))), ...);
-  return arr;
-}
-(std::make_index_sequence<Count>{})
-};  // namespace internal
+  [[maybe_unused]] static std::array<size_t, Count> arr = {
+      [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
+        std::array<size_t, Count> arr;
+        ((arr[Is] = size_t((const char*)&std::get<Is>(tp) - (char*)(&t))), ...);
+        return arr;
+      }(std::make_index_sequence<Count>{})};  // namespace internal
 
-return arr;
+  return arr;
 #else
   [[maybe_unused]] static std::array<size_t, Count> arr =
       get_member_offset_arr_impl(t, tp, std::make_index_sequence<Count>{});
@@ -357,8 +354,7 @@ inline constexpr void for_each(Visit&& func) {
                     "size_t], at least has std::string_view and make sure keep "
                     "the order of arguments");
     }
-  }
-  (std::make_index_sequence<arr.size()>{});
+  }(std::make_index_sequence<arr.size()>{});
 #else
   for_each_impl(std::forward<Visit>(func), arr,
                 std::make_index_sequence<arr.size()>{});

--- a/include/ylt/reflection/member_value.hpp
+++ b/include/ylt/reflection/member_value.hpp
@@ -219,7 +219,8 @@ inline constexpr void for_each(T&& t, Visit&& func) {
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is]), ...);
-        }(std::make_index_sequence<sizeof...(args)>{});
+        }
+        (std::make_index_sequence<sizeof...(args)>{});
 #else
         visit_members_impl0<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
 #endif
@@ -232,7 +233,8 @@ inline constexpr void for_each(T&& t, Visit&& func) {
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is], Is), ...);
-        }(std::make_index_sequence<sizeof...(args)>{});
+        }
+        (std::make_index_sequence<sizeof...(args)>{});
 #else
         visit_members_impl<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
 #endif

--- a/include/ylt/reflection/member_value.hpp
+++ b/include/ylt/reflection/member_value.hpp
@@ -215,22 +215,11 @@ inline constexpr void for_each(T&& t, Visit&& func) {
   else {
     if constexpr (std::is_invocable_v<Visit, first_t, std::string_view>) {
       visit_members(t, [&](auto&... args) {
-#if __cplusplus >= 202002L
-#if defined(_MSC_VER)
-#if _MSC_VER >= 1930
+#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >= 1930)
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is]), ...);
         }(std::make_index_sequence<sizeof...(args)>{});
-#else
-        visit_members_impl0<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
-#endif
-#else
-        [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
-            constexpr auto arr = get_member_names<T>();
-            (func(args, arr[Is]), ...);
-        }(std::make_index_sequence<sizeof...(args)>{});
-#endif
 #else
         visit_members_impl0<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
 #endif
@@ -239,24 +228,13 @@ inline constexpr void for_each(T&& t, Visit&& func) {
     else if constexpr (std::is_invocable_v<Visit, first_t, std::string_view,
                                            size_t>) {
       visit_members(t, [&](auto&... args) {
-#if __cplusplus >= 202002L
-#if defined(_MSC_VER)
-#if _MSC_VER >= 1930
+#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >= 1930)
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is], Is), ...);
         }(std::make_index_sequence<sizeof...(args)>{});
 #else
         visit_members_impl<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
-#endif
-#else
-        [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
-            constexpr auto arr = get_member_names<T>();
-            (func(args, arr[Is], Is), ...);
-        }(std::make_index_sequence<sizeof...(args)>{});
-#endif
-#else
-		visit_members_impl<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
 #endif
       });
     }

--- a/include/ylt/reflection/member_value.hpp
+++ b/include/ylt/reflection/member_value.hpp
@@ -215,8 +215,7 @@ inline constexpr void for_each(T&& t, Visit&& func) {
   else {
     if constexpr (std::is_invocable_v<Visit, first_t, std::string_view>) {
       visit_members(t, [&](auto&... args) {
-#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >=
-        1930)
+#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >= 1930)
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is]), ...);
@@ -233,8 +232,7 @@ inline constexpr void for_each(T&& t, Visit&& func) {
     else if constexpr (std::is_invocable_v<Visit, first_t, std::string_view,
                                            size_t>) {
       visit_members(t, [&](auto&... args) {
-#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >=
-        1930)
+#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >= 1930)
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is], Is), ...);

--- a/include/ylt/reflection/member_value.hpp
+++ b/include/ylt/reflection/member_value.hpp
@@ -219,8 +219,7 @@ inline constexpr void for_each(T&& t, Visit&& func) {
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is]), ...);
-        }
-        (std::make_index_sequence<sizeof...(args)>{});
+        }(std::make_index_sequence<sizeof...(args)>{});
 #else
         visit_members_impl0<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
 #endif
@@ -233,8 +232,7 @@ inline constexpr void for_each(T&& t, Visit&& func) {
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is], Is), ...);
-        }
-        (std::make_index_sequence<sizeof...(args)>{});
+        }(std::make_index_sequence<sizeof...(args)>{});
 #else
         visit_members_impl<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
 #endif

--- a/include/ylt/reflection/member_value.hpp
+++ b/include/ylt/reflection/member_value.hpp
@@ -216,15 +216,23 @@ inline constexpr void for_each(T&& t, Visit&& func) {
     if constexpr (std::is_invocable_v<Visit, first_t, std::string_view>) {
       visit_members(t, [&](auto&... args) {
 #if __cplusplus >= 202002L
+#if defined(_MSC_VER)
+#if _MSC_VER >= 1930
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is]), ...);
-        }
-        (std::make_index_sequence<sizeof...(args)>{});
+        }(std::make_index_sequence<sizeof...(args)>{});
 #else
-            visit_members_impl0<T>(std::forward<Visit>(func),
-                                   std::make_index_sequence<sizeof...(args)>{},
-                                   args...);
+        visit_members_impl0<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
+#endif
+#else
+        [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
+            constexpr auto arr = get_member_names<T>();
+            (func(args, arr[Is]), ...);
+        }(std::make_index_sequence<sizeof...(args)>{});
+#endif
+#else
+        visit_members_impl0<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
 #endif
       });
     }
@@ -232,15 +240,23 @@ inline constexpr void for_each(T&& t, Visit&& func) {
                                            size_t>) {
       visit_members(t, [&](auto&... args) {
 #if __cplusplus >= 202002L
+#if defined(_MSC_VER)
+#if _MSC_VER >= 1930
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is], Is), ...);
-        }
-        (std::make_index_sequence<sizeof...(args)>{});
+        }(std::make_index_sequence<sizeof...(args)>{});
 #else
-            visit_members_impl<T>(std::forward<Visit>(func),
-                                  std::make_index_sequence<sizeof...(args)>{},
-                                  args...);
+        visit_members_impl<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
+#endif
+#else
+        [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
+            constexpr auto arr = get_member_names<T>();
+            (func(args, arr[Is], Is), ...);
+        }(std::make_index_sequence<sizeof...(args)>{});
+#endif
+#else
+		visit_members_impl<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
 #endif
       });
     }

--- a/include/ylt/reflection/member_value.hpp
+++ b/include/ylt/reflection/member_value.hpp
@@ -215,28 +215,35 @@ inline constexpr void for_each(T&& t, Visit&& func) {
   else {
     if constexpr (std::is_invocable_v<Visit, first_t, std::string_view>) {
       visit_members(t, [&](auto&... args) {
-#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >= 1930)
+#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >=
+        1930)
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is]), ...);
         }
         (std::make_index_sequence<sizeof...(args)>{});
 #else
-        visit_members_impl0<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
+        visit_members_impl0<T>(std::forward<Visit>(func),
+                               std::make_index_sequence<sizeof...(args)>{},
+                               args...);
+
 #endif
       });
     }
     else if constexpr (std::is_invocable_v<Visit, first_t, std::string_view,
                                            size_t>) {
       visit_members(t, [&](auto&... args) {
-#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >= 1930)
+#if __cplusplus >= 202002L && (!defined(_MSC_VER) || _MSC_VER >=
+        1930)
         [&]<size_t... Is>(std::index_sequence<Is...>) mutable {
           constexpr auto arr = get_member_names<T>();
           (func(args, arr[Is], Is), ...);
         }
         (std::make_index_sequence<sizeof...(args)>{});
 #else
-        visit_members_impl<T>(std::forward<Visit>(func), std::make_index_sequence<sizeof...(args)>{}, args...);
+        visit_members_impl<T>(std::forward<Visit>(func),
+                              std::make_index_sequence<sizeof...(args)>{},
+                              args...);
 #endif
       });
     }

--- a/include/ylt/reflection/member_value.hpp
+++ b/include/ylt/reflection/member_value.hpp
@@ -222,10 +222,9 @@ inline constexpr void for_each(T&& t, Visit&& func) {
         }
         (std::make_index_sequence<sizeof...(args)>{});
 #else
-        visit_members_impl0<T>(std::forward<Visit>(func),
-                               std::make_index_sequence<sizeof...(args)>{},
-                               args...);
-
+            visit_members_impl0<T>(std::forward<Visit>(func),
+                                   std::make_index_sequence<sizeof...(args)>{},
+                                   args...);
 #endif
       });
     }
@@ -239,9 +238,9 @@ inline constexpr void for_each(T&& t, Visit&& func) {
         }
         (std::make_index_sequence<sizeof...(args)>{});
 #else
-        visit_members_impl<T>(std::forward<Visit>(func),
-                              std::make_index_sequence<sizeof...(args)>{},
-                              args...);
+            visit_members_impl<T>(std::forward<Visit>(func),
+                                  std::make_index_sequence<sizeof...(args)>{},
+                                  args...);
 #endif
       });
     }


### PR DESCRIPTION
The purpose of this change is to ensure compatibility with different versions of the Microsoft Visual Studio (MSVC) compiler. The `_MSC_VER` macro is used to determine the compiler version, allowing the code to handle differences between Visual Studio 2019 (MSVC 14.2x) and Visual Studio 2022 (MSVC 14.30+). This is particularly important because VS2022 introduces full support for C++20 features, while earlier versions require a fallback implementation.

## What is changing

The code now includes conditional checks for `_MSC_VER`:
- When `_MSC_VER >= 1930` (Visual Studio 2022 or newer), the code leverages C++20 features such as generic lambdas and fold expressions.
- For older versions like VS2019 (`_MSC_VER >= 1920 && _MSC_VER < 1930`), the code falls back to an alternative implementation to maintain compatibility.

This ensures that the code can be compiled with both VS2019 and VS2022 while taking full advantage of C++20 features where available.

## Example

For example, the following macro-based logic ensures that the code behaves correctly in both compilers:

```cpp
#if __cplusplus >= 202002L
  #if _MSC_VER >= 1930
    // Code that uses C++20 features, supported in VS2022
  #else
    // Fallback code for VS2019, which lacks full C++20 support
  #endif
#else
  // Code for non-C++20 environments
#endif
