### PR TITLE
[metric] fix metric refresh logic

### DIFF
--- a/src/metric/benchmark/bench.hpp
+++ b/src/metric/benchmark/bench.hpp
@@ -77,7 +77,7 @@ inline void bench_static_summary_mixed(size_t thd_num,
                                        std::chrono::seconds duration,
                                        std::chrono::seconds age = 1s) {
   ylt::metric::summary_t summary("summary mixed test", "",
-                                 {0.5, 0.9, 0.95, 0.99, 0.995}, 1s);
+                                 {0.5, 0.9, 0.95, 0.99, 0.995}, age);
   bench_mixed_impl(
       summary,
       [&]() {

--- a/src/metric/tests/parallel_test.cpp
+++ b/src/metric/tests/parallel_test.cpp
@@ -7,7 +7,7 @@
 
 TEST_CASE("test high parallel perform test") {
   bench_static_summary_mixed(std::thread::hardware_concurrency() * 4, 3s);
-  bench_dynamic_summary_mixed(std::thread::hardware_concurrency() * 4, 2s);
-  bench_static_counter_mixed(std::thread::hardware_concurrency() * 4, 2s);
-  bench_dynamic_counter_mixed(std::thread::hardware_concurrency() * 4, 2s);
+  bench_dynamic_summary_mixed(std::thread::hardware_concurrency() * 4, 3s);
+  bench_static_counter_mixed(std::thread::hardware_concurrency() * 4, 3s);
+  bench_dynamic_counter_mixed(std::thread::hardware_concurrency() * 4, 3s);
 }

--- a/src/metric/tests/test_metric.cpp
+++ b/src/metric/tests/test_metric.cpp
@@ -836,6 +836,38 @@ TEST_CASE("test summary with many quantities") {
 #endif
 }
 
+TEST_CASE("test summary refresh") {
+  summary_t summary{"test_summary", "summary help", {0.5, 0.9, 0.95, 1.1}, 1s};
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> distr(1, 100);
+  for (int i = 0; i < 50; i++) {
+    summary.observe(i);
+  }
+  double sum;
+  uint64_t cnt;
+  summary.get_rates(sum, cnt);
+  CHECK(cnt == 50);
+  std::this_thread::sleep_for(1s);
+  summary.get_rates(sum, cnt);
+  CHECK(cnt == 0);
+  for (int i = 0; i < 50; i++) {
+    summary.observe(i);
+  }
+  std::this_thread::sleep_for(500ms);
+  for (int i = 0; i < 10; i++) {
+    summary.observe(i);
+  }
+  summary.get_rates(sum, cnt);
+  CHECK(cnt == 60);
+  std::this_thread::sleep_for(500ms);
+  summary.get_rates(sum, cnt);
+  CHECK(cnt == 10);
+  std::this_thread::sleep_for(500ms);
+  summary.get_rates(sum, cnt);
+  CHECK(cnt == 0);
+}
+
 TEST_CASE("test register metric") {
   auto c = std::make_shared<counter_t>(std::string("get_count"),
                                        std::string("get counter"));


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

## What is changing

1. metric now will refresh outdated data correctly.
2. avoid heap-use-after-free in some corner case, however, summary wont lazy collect memory.

## Example