### PR TITLE
[struct_pb][feat]to_pb support stream

### DIFF
--- a/.github/workflows/linux_llvm_cov.yml
+++ b/.github/workflows/linux_llvm_cov.yml
@@ -63,7 +63,7 @@ jobs:
           echo "Code Coverage Report" > tmp.log
           echo "for detail, [goto summary](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{github.run_id}}) download Artifacts `llvm-cov`" >> tmp.log
           echo "\`\`\`" >> tmp.log
-          llvm-cov report coro_io_test -object coro_rpc_test -object easylog_test -object struct_pack_test -object struct_pack_test_with_optimize -instr-profile=test_ylt.profdata -ignore-filename-regex="thirdparty|asio|src" -show-region-summary=false >> tmp.log
+          llvm-cov report coro_io_test -object coro_rpc_test -object easylog_test -object struct_pack_test -object struct_pack_test_with_optimize -object metric_test -object struct_pb_test -object reflection_test -instr-profile=test_ylt.profdata -ignore-filename-regex="thirdparty|asio|src" -show-region-summary=false >> tmp.log
           echo "\`\`\`" >> tmp.log
 
       - name: Create Comment

--- a/include/ylt/standalone/iguana/detail/traits.hpp
+++ b/include/ylt/standalone/iguana/detail/traits.hpp
@@ -114,5 +114,100 @@ template <typename T, std::size_t I>
 using variant_type_at_t =
     typename variant_type_at<typename member_traits<T>::value_type, I>::type;
 
+/// concepts
+template <typename Type>
+constexpr bool is_char_v =
+    std::is_same_v<Type, signed char> || std::is_same_v<Type, char> ||
+    std::is_same_v<Type, unsigned char> || std::is_same_v<Type, wchar_t> ||
+    std::is_same_v<Type, char16_t> || std::is_same_v<Type, char32_t>
+#ifdef __cpp_lib_char8_t
+    || std::is_same_v<Type, char8_t>
+#endif
+    ;
+
+#if __cplusplus >= 202002L
+template <typename Type>
+concept is_container_v = requires(Type container) {
+  typename std::remove_cvref_t<Type>::value_type;
+  container.size();
+  container.begin();
+  container.end();
+};
+
+template <typename Type>
+concept is_resizable_char_container_v = requires(Type container) {
+  typename std::remove_cvref_t<Type>::value_type;
+  container.size();
+  container.begin();
+  container.end();
+  requires is_char_v<typename std::remove_cvref_t<Type>::value_type>;
+  container.resize(std::size_t{});
+};
+
+template <typename T>
+concept char_writer = requires(T t) {
+  t.write((const char *)nullptr, std::size_t{});
+};
+
+template <typename T>
+concept char_reader = requires(T t) {
+  t.read((char *)nullptr, std::size_t{});
+};
+#else
+template <typename T, typename = void>
+struct container_impl : std::false_type {};
+
+template <typename T>
+struct container_impl<T,
+                      std::void_t<typename std::remove_cvref_t<T>::value_type,
+                                  decltype(std::declval<T>().size()),
+                                  decltype(std::declval<T>().begin()),
+                                  decltype(std::declval<T>().end())>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool is_container_v = container_impl<T>::value;
+
+template <typename T, typename = void>
+struct resizable_char_container_impl : std::false_type {};
+
+template <typename T>
+struct resizable_char_container_impl<
+    T, std::void_t<typename std::remove_cvref_t<T>::value_type,
+                   decltype(std::declval<T>().size()),
+                   decltype(std::declval<T>().begin()),
+                   decltype(std::declval<T>().end()),
+                   std::enable_if_t<
+                       is_char_v<typename std::remove_cvref_t<T>::value_type>>,
+                   decltype(std::declval<T>().resize(std::size_t{}))>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool is_resizable_char_container_v =
+    resizable_char_container_impl<T>::value;
+
+template <typename T, typename = void>
+struct char_writer_impl : std::false_type {};
+
+template <typename T>
+struct char_writer_impl<T, std::void_t<decltype(std::declval<T>().write(
+                               (const char *)nullptr, std::size_t{}))>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool char_writer = char_writer_impl<T>::value;
+
+template <typename T, typename = void>
+struct char_reader_impl : std::false_type {};
+
+template <typename T>
+struct char_reader_impl<T, std::void_t<decltype(std::declval<T>().read(
+                               (char *)nullptr, std::size_t{}))>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool char_reader = char_reader_impl<T>::value;
+#endif
+
 }  // namespace iguana
 #endif  // SERIALIZE_TRAITS_HPP

--- a/include/ylt/standalone/iguana/pb_writer.hpp
+++ b/include/ylt/standalone/iguana/pb_writer.hpp
@@ -5,47 +5,46 @@
 namespace iguana {
 namespace detail {
 
-template <uint32_t key, typename V, typename It>
-IGUANA_INLINE void encode_varint_field(V val, It&& it) {
+template <uint32_t key, typename V, typename Writer>
+IGUANA_INLINE void encode_varint_field(V val, Writer& writer) {
   static_assert(std::is_integral_v<V>, "must be integral");
   if constexpr (key != 0) {
-    serialize_varint_u32_constexpr<key>(it);
+    serialize_varint_u32<key>(writer);
   }
-  serialize_varint(val, it);
+  serialize_varint(val, writer);
 }
 
-template <uint32_t key, typename V, typename It>
-IGUANA_INLINE void encode_fixed_field(V val, It&& it) {
+template <uint32_t key, typename V, typename Writer>
+IGUANA_INLINE void encode_fixed_field(V val, Writer& writer) {
   if constexpr (key != 0) {
-    serialize_varint_u32_constexpr<key>(it);
+    serialize_varint_u32<key>(writer);
   }
   constexpr size_t size = sizeof(V);
   // TODO: check Stream continuous
-  memcpy(it, &val, size);
-  it += size;
+  writer.write((const char*)&val, size);
 }
 
 template <uint32_t key, bool omit_default_val = true, typename Type,
-          typename It>
-IGUANA_INLINE void to_pb_impl(Type&& t, It&& it, uint32_t*& sz_ptr);
+          typename Writer>
+IGUANA_INLINE void to_pb_impl(Type&& t, uint32_t*& sz_ptr, Writer& writer);
 
-template <uint32_t key, typename V, typename It>
-IGUANA_INLINE void encode_pair_value(V&& val, It&& it, size_t size,
-                                     uint32_t*& sz_ptr) {
+template <uint32_t key, typename V, typename Writer>
+IGUANA_INLINE void encode_pair_value(V&& val, size_t size, uint32_t*& sz_ptr,
+                                     Writer& writer) {
   if (size == 0)
     IGUANA_UNLIKELY {
       // map keys can't be omitted even if values are empty
       // TODO: repeated ?
-      serialize_varint_u32_constexpr<key>(it);
-      serialize_varint(0, it);
+      serialize_varint_u32<key>(writer);
+      serialize_varint(0, writer);
     }
   else {
-    to_pb_impl<key, false>(val, it, sz_ptr);
+    to_pb_impl<key, false>(val, sz_ptr, writer);
   }
 }
 
-template <uint32_t key, bool omit_default_val, typename T, typename It>
-IGUANA_INLINE void encode_numeric_field(T t, It&& it) {
+template <uint32_t key, bool omit_default_val, typename T, typename Writer>
+IGUANA_INLINE void encode_numeric_field(T t, Writer& writer) {
   if constexpr (omit_default_val) {
     if constexpr (is_fixed_v<T> || is_signed_varint_v<T>) {
       if (t.val == 0) {
@@ -58,31 +57,31 @@ IGUANA_INLINE void encode_numeric_field(T t, It&& it) {
     }
   }
   if constexpr (std::is_integral_v<T>) {
-    detail::encode_varint_field<key>(t, it);
+    detail::encode_varint_field<key>(t, writer);
   }
   else if constexpr (detail::is_signed_varint_v<T>) {
-    detail::encode_varint_field<key>(encode_zigzag(t.val), it);
+    detail::encode_varint_field<key>(encode_zigzag(t.val), writer);
   }
   else if constexpr (detail::is_fixed_v<T>) {
-    detail::encode_fixed_field<key>(t.val, it);
+    detail::encode_fixed_field<key>(t.val, writer);
   }
   else if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
-    detail::encode_fixed_field<key>(t, it);
+    detail::encode_fixed_field<key>(t, writer);
   }
   else if constexpr (std::is_enum_v<T>) {
     using U = std::underlying_type_t<T>;
-    detail::encode_varint_field<key>(static_cast<U>(t), it);
+    detail::encode_varint_field<key>(static_cast<U>(t), writer);
   }
   else {
     static_assert(!sizeof(T), "unsupported type");
   }
 }
 
-template <uint32_t field_no, typename Type, typename It>
-IGUANA_INLINE void to_pb_oneof(Type&& t, It&& it, uint32_t*& sz_ptr) {
+template <uint32_t field_no, typename Type, typename Writer>
+IGUANA_INLINE void to_pb_oneof(Type&& t, uint32_t*& sz_ptr, Writer& writer) {
   using T = std::decay_t<Type>;
   std::visit(
-      [&it, &sz_ptr](auto&& value) IGUANA__INLINE_LAMBDA {
+      [&sz_ptr, &writer](auto&& value) IGUANA__INLINE_LAMBDA {
         using raw_value_type = decltype(value);
         using value_type =
             std::remove_const_t<std::remove_reference_t<decltype(value)>>;
@@ -91,28 +90,29 @@ IGUANA_INLINE void to_pb_oneof(Type&& t, It&& it, uint32_t*& sz_ptr) {
         constexpr uint32_t key =
             ((field_no + offset) << 3) |
             static_cast<uint32_t>(get_wire_type<value_type>());
-        to_pb_impl<key, false>(std::forward<raw_value_type>(value), it, sz_ptr);
+        to_pb_impl<key, false>(std::forward<raw_value_type>(value), sz_ptr,
+                               writer);
       },
       std::forward<Type>(t));
 }
 
 // omit_default_val = true indicates to omit the default value in searlization
-template <uint32_t key, bool omit_default_val, typename Type, typename It>
-IGUANA_INLINE void to_pb_impl(Type&& t, It&& it, uint32_t*& sz_ptr) {
+template <uint32_t key, bool omit_default_val, typename Type, typename Writer>
+IGUANA_INLINE void to_pb_impl(Type&& t, uint32_t*& sz_ptr, Writer& writer) {
   using T = std::remove_const_t<std::remove_reference_t<Type>>;
   if constexpr (ylt_refletable_v<T> || is_custom_reflection_v<T>) {
     // can't be omitted even if values are empty
     if constexpr (key != 0) {
       auto len = pb_value_size(t, sz_ptr);
-      serialize_varint_u32_constexpr<key>(it);
-      serialize_varint(len, it);
+      serialize_varint_u32<key>(writer);
+      serialize_varint(len, writer);
       if (len == 0)
         IGUANA_UNLIKELY { return; }
     }
     static auto tuple = get_pb_members_tuple(std::forward<Type>(t));
     constexpr size_t SIZE = std::tuple_size_v<std::decay_t<decltype(tuple)>>;
     for_each_n(
-        [&t, &it, &sz_ptr](auto i) IGUANA__INLINE_LAMBDA {
+        [&t, &sz_ptr, &writer](auto i) IGUANA__INLINE_LAMBDA {
           using field_type =
               std::tuple_element_t<decltype(i)::value,
                                    std::decay_t<decltype(tuple)>>;
@@ -125,14 +125,14 @@ IGUANA_INLINE void to_pb_impl(Type&& t, It&& it, uint32_t*& sz_ptr) {
             constexpr auto offset =
                 get_variant_index<U, sub_type, std::variant_size_v<U> - 1>();
             if constexpr (offset == 0) {
-              to_pb_oneof<value.field_no>(val, it, sz_ptr);
+              to_pb_oneof<value.field_no>(val, sz_ptr, writer);
             }
           }
           else {
             constexpr uint32_t sub_key =
                 (value.field_no << 3) |
                 static_cast<uint32_t>(get_wire_type<U>());
-            to_pb_impl<sub_key>(val, it, sz_ptr);
+            to_pb_impl<sub_key>(val, sz_ptr, writer);
           }
         },
         std::make_index_sequence<SIZE>{});
@@ -144,16 +144,16 @@ IGUANA_INLINE void to_pb_impl(Type&& t, It&& it, uint32_t*& sz_ptr) {
     if constexpr (is_lenprefix_v<item_type>) {
       // non-packed
       for (auto& item : t) {
-        to_pb_impl<key, false>(item, it, sz_ptr);
+        to_pb_impl<key, false>(item, sz_ptr, writer);
       }
     }
     else {
       if (t.empty())
         IGUANA_UNLIKELY { return; }
-      serialize_varint_u32_constexpr<key>(it);
-      serialize_varint(pb_value_size(t, sz_ptr), it);
+      serialize_varint_u32<key>(writer);
+      serialize_varint(pb_value_size(t, sz_ptr), writer);
       for (auto& item : t) {
-        encode_numeric_field<false, 0>(item, it);
+        encode_numeric_field<false, 0>(item, writer);
       }
     }
   }
@@ -168,7 +168,7 @@ IGUANA_INLINE void to_pb_impl(Type&& t, It&& it, uint32_t*& sz_ptr) {
     constexpr auto key2_size = variant_uint32_size_constexpr(key2);
 
     for (auto& [k, v] : t) {
-      serialize_varint_u32_constexpr<key>(it);
+      serialize_varint_u32<key>(writer);
       // k must be string or numeric
       auto k_val_len = str_numeric_size<0, false>(k);
       auto v_val_len = pb_value_size<false>(v, sz_ptr);
@@ -179,17 +179,17 @@ IGUANA_INLINE void to_pb_impl(Type&& t, It&& it, uint32_t*& sz_ptr) {
       if constexpr (is_lenprefix_v<second_type>) {
         pair_len += variant_uint32_size(v_val_len);
       }
-      serialize_varint(pair_len, it);
+      serialize_varint(pair_len, writer);
       // map k and v can't be omitted even if values are empty
-      encode_pair_value<key1>(k, it, k_val_len, sz_ptr);
-      encode_pair_value<key2>(v, it, v_val_len, sz_ptr);
+      encode_pair_value<key1>(k, k_val_len, sz_ptr, writer);
+      encode_pair_value<key2>(v, v_val_len, sz_ptr, writer);
     }
   }
   else if constexpr (optional_v<T>) {
     if (!t.has_value()) {
       return;
     }
-    to_pb_impl<key, omit_default_val>(*t, it, sz_ptr);
+    to_pb_impl<key, omit_default_val>(*t, sz_ptr, writer);
   }
   else if constexpr (std::is_same_v<T, std::string> ||
                      std::is_same_v<T, std::string_view>) {
@@ -197,13 +197,12 @@ IGUANA_INLINE void to_pb_impl(Type&& t, It&& it, uint32_t*& sz_ptr) {
       if (t.size() == 0)
         IGUANA_UNLIKELY { return; }
     }
-    serialize_varint_u32_constexpr<key>(it);
-    serialize_varint(t.size(), it);
-    memcpy(it, t.data(), t.size());
-    it += t.size();
+    serialize_varint_u32<key>(writer);
+    serialize_varint(t.size(), writer);
+    writer.write(t.data(), t.size());
   }
   else {
-    encode_numeric_field<key, omit_default_val>(t, it);
+    encode_numeric_field<key, omit_default_val>(t, writer);
   }
 }
 
@@ -475,9 +474,19 @@ template <
 IGUANA_INLINE void to_pb(T const& t, Stream& out) {
   std::vector<uint32_t> size_arr;
   auto byte_len = detail::pb_key_value_size<0>(t, size_arr);
-  detail::resize(out, byte_len);
   auto sz_ptr = size_arr.empty() ? nullptr : &size_arr[0];
-  detail::to_pb_impl<0>(t, &out[0], sz_ptr);
+
+  if constexpr (is_resizable_char_container_v<Stream>) {
+    detail::resize(out, byte_len);
+    memory_writer writer{out.data()};
+    detail::to_pb_impl<0>(t, sz_ptr, writer);
+  }
+  else if constexpr (char_writer<Stream>) {
+    detail::to_pb_impl<0>(t, sz_ptr, out);
+  }
+  else {
+    static_assert(!sizeof(Stream), "Invalid stream type");
+  }
 }
 
 #if defined(__clang__) || defined(_MSC_VER) || \

--- a/include/ylt/standalone/iguana/util.hpp
+++ b/include/ylt/standalone/iguana/util.hpp
@@ -195,6 +195,14 @@ struct underline_type<std::optional<T>> {
 template <typename T>
 using underline_type_t = typename underline_type<std::remove_cvref_t<T>>::type;
 
+struct memory_writer {
+  char* buffer;
+  void write(const char* data, std::size_t len) {
+    memcpy(buffer, data, len);
+    buffer += len;
+  }
+};
+
 template <char... C, typename It>
 IGUANA_INLINE void match(It&& it, It&& end) {
   const auto n = static_cast<size_t>(std::distance(it, end));

--- a/src/struct_pb/tests/main.cpp
+++ b/src/struct_pb/tests/main.cpp
@@ -854,7 +854,7 @@ TEST_CASE("test struct_pb") {
     iguana::from_pb(inner2, str);
     CHECK(inner.x == inner2.x);
     CHECK(inner.y == inner2.y);
-    CHECK(inner.z == inner2.z);    
+    CHECK(inner.z == inner2.z);
   }
 
   {

--- a/src/struct_pb/tests/main.cpp
+++ b/src/struct_pb/tests/main.cpp
@@ -846,6 +846,15 @@ TEST_CASE("test struct_pb") {
     CHECK(inner.x == inner1.x);
     CHECK(inner.y == inner1.y);
     CHECK(inner.z == inner1.z);
+
+    std::stringstream ss;
+    iguana::to_pb(inner, ss);
+    std::string str1 = ss.str();
+    my_space::inner_struct inner2;
+    iguana::from_pb(inner2, str);
+    CHECK(inner.x == inner2.x);
+    CHECK(inner.y == inner2.y);
+    CHECK(inner.z == inner2.z);    
   }
 
   {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

to_pb support stream.

## What is changing

## Example
```cpp
    my_space::inner_struct inner{41, 42, 43};

    std::stringstream ss;
    iguana::to_pb(inner, ss);

    std::string str;
    iguana::to_pb(inner, str);
```