### PR TITLE
[coro_http_client]fix reset

### DIFF
--- a/include/ylt/standalone/cinatra/coro_http_client.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_client.hpp
@@ -667,8 +667,9 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
   bool is_body_in_out_buf() const { return !out_buf_.empty(); }
 
   void reset() {
-    if (!has_closed())
+    if (!has_closed()) {
       close_socket(*socket_);
+    }
 
     socket_->impl_ = asio::ip::tcp::socket{executor_wrapper_.context()};
     if (!socket_->impl_.is_open()) {
@@ -689,6 +690,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
       socket_->ssl_stream_ =
           std::make_unique<asio::ssl::stream<asio::ip::tcp::socket &>>(
               socket_->impl_, *ssl_ctx_);
+      has_init_ssl_ = false;
     }
 #endif
 #ifdef BENCHMARK_TEST

--- a/src/coro_http/tests/test_cinatra.cpp
+++ b/src/coro_http/tests/test_cinatra.cpp
@@ -251,7 +251,16 @@ TEST_CASE("test ssl client") {
     auto result = client.get("https://www.bing.com");
     CHECK(result.status >= 200);
   }
-
+  {
+    coro_http_client client{};
+    auto ret = client.get("https://baidu.com");
+    client.reset();
+    ret = client.get("http://cn.bing.com");
+    std::cout << ret.status << std::endl;
+    client.reset();
+    ret = client.get("https://baidu.com");
+    std::cout << ret.status << std::endl;
+  }
   {
     coro_http_client client{};
     auto r =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

fix the bug: 
- request ssl server ok;
- then reset client;
- request non ssl server failed, should be ok;

## What is changing

## Example