### PR TITLE
[reflection][fix][msvc]: warning C4127

### DIFF
--- a/include/ylt/reflection/template_string.hpp
+++ b/include/ylt/reflection/template_string.hpp
@@ -36,7 +36,7 @@ inline constexpr std::string_view type_string() {
   constexpr auto next1 = str.rfind(sample[pos + 3]);
 #if defined(_MSC_VER)
   constexpr std::size_t npos = str.find_first_of(" ", pos);
-  if (npos != std::string_view::npos)
+  if constexpr (npos != std::string_view::npos)
     return str.substr(npos + 1, next1 - npos - 1);
   else
     return str.substr(pos, next1 - pos);


### PR DESCRIPTION
## Why

MSVC: Compiler Warning (level 4) C4127, conditional expression is constant.

## Example

```C++
struct TestReflected
{
    int a;
};
constexpr auto name = ylt::reflection::get_struct_name<TestReflected>();
```