### PR TITLE
[reflection] fix type_string that lose const

### DIFF
--- a/include/ylt/reflection/template_string.hpp
+++ b/include/ylt/reflection/template_string.hpp
@@ -42,9 +42,8 @@ inline constexpr auto type_string() {
   constexpr refvalue::meta_string name{
       std::span<const char, str.size()>{str.data(), str.size()}};
 #if defined(__clang__)
-  constexpr auto name_ref = refvalue::replace_v<name, " &", "&">;
-  constexpr auto name_pointer = refvalue::replace_v<name_ref, " *", "*">;
-  return name_pointer;
+  constexpr auto name_no_blank = refvalue::replace_v<name, " &", "&">;
+  return name_no_blank;
 #elif defined(_MSC_VER)
   constexpr auto name_no_struct = refvalue::remove_v<name, "struct ">;
   constexpr auto name_no_class = refvalue::remove_v<name_no_struct, "class ">;

--- a/include/ylt/reflection/template_string.hpp
+++ b/include/ylt/reflection/template_string.hpp
@@ -42,8 +42,9 @@ inline constexpr auto type_string() {
   constexpr refvalue::meta_string name{
       std::span<const char, str.size()>{str.data(), str.size()}};
 #if defined(__clang__)
-  constexpr auto name_no_blank = refvalue::replace_v<name, " &", "&">;
-  return name_no_blank;
+  constexpr auto name_ref = refvalue::replace_v<name, " &", "&">;
+  constexpr auto name_pointer = refvalue::replace_v<name_ref, " *", "*">;
+  return name_pointer;
 #elif defined(_MSC_VER)
   constexpr auto name_no_struct = refvalue::remove_v<name, "struct ">;
   constexpr auto name_no_class = refvalue::remove_v<name_no_struct, "class ">;

--- a/include/ylt/reflection/template_string.hpp
+++ b/include/ylt/reflection/template_string.hpp
@@ -4,7 +4,6 @@
 
 #include "frozen/string.h"
 #include "frozen/unordered_map.h"
-#include "ylt/util/meta_string.hpp"
 
 namespace ylt::reflection {
 
@@ -30,28 +29,13 @@ constexpr std::string_view get_raw_name() {
 }
 
 template <typename T>
-inline constexpr auto type_string() {
+inline constexpr std::string_view type_string() {
   constexpr std::string_view sample = get_raw_name<int>();
   constexpr size_t prefix_length = sample.find("int");
   constexpr size_t suffix_length = sample.size() - prefix_length - 3;
 
-  constexpr std::string_view raw_str = get_raw_name<T>();
-  constexpr std::string_view str = raw_str.substr(
-      prefix_length, raw_str.size() - prefix_length - suffix_length);
-
-  constexpr refvalue::meta_string name{
-      std::span<const char, str.size()>{str.data(), str.size()}};
-#if defined(__clang__)
-  constexpr auto name_no_blank = refvalue::replace_v<name, " &", "&">;
-  return name_no_blank;
-#elif defined(_MSC_VER)
-  constexpr auto name_no_struct = refvalue::remove_v<name, "struct ">;
-  constexpr auto name_no_class = refvalue::remove_v<name_no_struct, "class ">;
-  constexpr auto name_no_union = refvalue::remove_v<name_no_class, "union ">;
-  return name_no_union;
-#else
-  return name;
-#endif
+  constexpr std::string_view str = get_raw_name<T>();
+  return str.substr(prefix_length, str.size() - prefix_length - suffix_length);
 }
 
 template <auto T>

--- a/include/ylt/reflection/template_string.hpp
+++ b/include/ylt/reflection/template_string.hpp
@@ -31,18 +31,11 @@ constexpr std::string_view get_raw_name() {
 template <typename T>
 inline constexpr std::string_view type_string() {
   constexpr std::string_view sample = get_raw_name<int>();
-  constexpr size_t pos = sample.find("int");
+  constexpr size_t prefix_length = sample.find("int");
+  constexpr size_t suffix_length = sample.size() - prefix_length - 3;
+
   constexpr std::string_view str = get_raw_name<T>();
-  constexpr auto next1 = str.rfind(sample[pos + 3]);
-#if defined(_MSC_VER)
-  constexpr std::size_t npos = str.find_first_of(" ", pos);
-  if constexpr (npos != std::string_view::npos)
-    return str.substr(npos + 1, next1 - npos - 1);
-  else
-    return str.substr(pos, next1 - pos);
-#else
-  return str.substr(pos, next1 - pos);
-#endif
+  return str.substr(prefix_length, str.size() - prefix_length - suffix_length);
 }
 
 template <auto T>

--- a/include/ylt/util/meta_string.hpp
+++ b/include/ylt/util/meta_string.hpp
@@ -318,50 +318,5 @@ struct remove {
 
 template <meta_string S, meta_string Removal>
 inline constexpr auto&& remove_v = remove<S, Removal>::value;
-
-template <meta_string S, meta_string Old, meta_string New>
-struct replace {
-  static constexpr std::string_view view{S};
-  static constexpr auto value = []() {
-    constexpr auto input_size = S.size();
-    constexpr auto old_size = Old.size();
-    constexpr auto new_size = New.size();
-
-    constexpr auto result_size = []() -> size_t {
-      size_t old_count = 0;
-      for (std::size_t i = 0; i + old_size <= input_size;) {
-        if (view.substr(i, old_size) == Old) {
-          i += old_size;
-          old_count++;
-        }
-        else {
-          i++;
-        }
-      }
-      return input_size + (new_size - old_size) * old_count;
-    }();
-
-    std::array<char, result_size> result{};
-    std::size_t write_pos = 0;
-    std::size_t i = 0;
-    while (i + old_size <= input_size) {
-      if (view.substr(i, old_size) == Old) {
-        std::copy(New.begin(), New.end(), result.begin() + write_pos);
-        i += old_size;
-        write_pos += new_size;
-      }
-      else {
-        result[write_pos++] = view[i++];
-      }
-    }
-    while (write_pos < result_size) {
-      result[write_pos++] = view[i++];
-    }
-    return meta_string{std::span<const char, result_size>{result.data(), result.size()}};
-  }();
-};
-
-template <meta_string S, meta_string Old, meta_string New>
-inline constexpr auto&& replace_v = replace<S, Old, New>::value;
 #endif
 }  // namespace refvalue

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -3,8 +3,8 @@
 
 #include "ylt/reflection/member_value.hpp"
 #include "ylt/reflection/private_visitor.hpp"
-#include "ylt/reflection/template_switch.hpp"
 #include "ylt/reflection/template_string.hpp"
+#include "ylt/reflection/template_switch.hpp"
 #include "ylt/reflection/user_reflect_macro.hpp"
 
 using namespace ylt::reflection;

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -330,7 +330,7 @@ TEST_CASE("test macros") {
   CHECK(t.color == 10);
 
   using Tuple = decltype(struct_to_tuple<simple2>());
-  std::cout << type_string<Tuple>().data() << "\n";
+  std::cout << type_string<Tuple>() << "\n";
 
   constexpr size_t size2 = members_count_v<dummy_t2>;
   static_assert(size2 == 3);
@@ -471,36 +471,28 @@ namespace test_type_string {
   };
   class class_test {
   };
-  union union_test {
-  };
 }
 
 TEST_CASE("test type_string") {
   CHECK(type_string<int>() == "int");
   CHECK(type_string<const int>() == "const int");
   CHECK(type_string<volatile int>() == "volatile int");
-  CHECK(type_string<int&>() == "int&");
-  CHECK(type_string<int&&>() == "int&&");
-  CHECK(type_string<const int&>() == "const int&");
-  CHECK(type_string<const int&&>() == "const int&&");
-  CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
-  CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test&");
-  CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test&&");
-  CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
-  CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test&");
-  CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test&&");
-  CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
-  CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test&");
-  CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test&&");
-  CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
-  CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test&");
-  CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test&&");
-  CHECK(type_string<test_type_string::union_test>() == "test_type_string::union_test");
-  CHECK(type_string<test_type_string::union_test&>() == "test_type_string::union_test&");
-  CHECK(type_string<test_type_string::union_test&&>() == "test_type_string::union_test&&");
-  CHECK(type_string<const test_type_string::union_test>() == "const test_type_string::union_test");
-  CHECK(type_string<const test_type_string::union_test&>() == "const test_type_string::union_test&");
-  CHECK(type_string<const test_type_string::union_test&&>() == "const test_type_string::union_test&&");
+  // CHECK(type_string<int&>() == "int &");
+  // CHECK(type_string<int&&>() == "int &&");
+  // CHECK(type_string<const int&>() == "const int &");
+  // CHECK(type_string<const int&&>() == "const int &&");
+  // CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
+  // CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test &");
+  // CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test &&");
+  // CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
+  // CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test &");
+  // CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test &&");
+  // CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
+  // CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test &");
+  // CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test &&");
+  // CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
+  // CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test &");
+  // CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test &&");
 }
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -467,32 +467,59 @@ TEST_CASE("test visit private") {
 }
 
 namespace test_type_string {
-  struct struct_test {
-  };
-  class class_test {
-  };
-}
+struct struct_test {};
+class class_test {};
+union union_test {};
+}  // namespace test_type_string
 
 TEST_CASE("test type_string") {
   CHECK(type_string<int>() == "int");
   CHECK(type_string<const int>() == "const int");
   CHECK(type_string<volatile int>() == "volatile int");
-  // CHECK(type_string<int&>() == "int &");
-  // CHECK(type_string<int&&>() == "int &&");
-  // CHECK(type_string<const int&>() == "const int &");
-  // CHECK(type_string<const int&&>() == "const int &&");
-  // CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
-  // CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test &");
-  // CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test &&");
-  // CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
-  // CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test &");
-  // CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test &&");
-  // CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
-  // CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test &");
-  // CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test &&");
-  // CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
-  // CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test &");
-  // CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test &&");
+
+#if defined(__clang__)
+  CHECK(type_string<int&>() == "int &");
+  CHECK(type_string<int&&>() == "int &&");
+  CHECK(type_string<const int&>() == "const int &");
+  CHECK(type_string<const int&&>() == "const int &&");
+  CHECK(type_string<volatile int&>() == "volatile int &");
+  CHECK(type_string<volatile int&&>() == "volatile int &&");
+#else
+  CHECK(type_string<int&>() == "int&");
+  CHECK(type_string<int&&>() == "int&&");
+  CHECK(type_string<const int&>() == "const int&");
+  CHECK(type_string<const int&&>() == "const int&&");
+  CHECK(type_string<volatile int&>() == "volatile int&");
+  CHECK(type_string<volatile int&&>() == "volatile int&&");
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+  CHECK(type_string<test_type_string::struct_test>() ==
+        "struct test_type_string::struct_test");
+  CHECK(type_string<const test_type_string::struct_test>() ==
+        "const struct test_type_string::struct_test");
+  CHECK(type_string<test_type_string::class_test>() ==
+        "class test_type_string::class_test");
+  CHECK(type_string<const test_type_string::class_test>() ==
+        "const class test_type_string::class_test");
+  CHECK(type_string<test_type_string::union_test>() ==
+        "union test_type_string::union_test");
+  CHECK(type_string<const test_type_string::union_test>() ==
+        "const union test_type_string::union_test");
+#else
+  CHECK(type_string<test_type_string::struct_test>() ==
+        "test_type_string::struct_test");
+  CHECK(type_string<const test_type_string::struct_test>() ==
+        "const test_type_string::struct_test");
+  CHECK(type_string<test_type_string::class_test>() ==
+        "test_type_string::class_test");
+  CHECK(type_string<const test_type_string::class_test>() ==
+        "const test_type_string::class_test");
+  CHECK(type_string<test_type_string::union_test>() ==
+        "test_type_string::union_test");
+  CHECK(type_string<const test_type_string::union_test>() ==
+        "const test_type_string::union_test");
+#endif
 }
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -481,26 +481,42 @@ TEST_CASE("test type_string") {
   CHECK(type_string<volatile int>() == "volatile int");
   CHECK(type_string<int&>() == "int&");
   CHECK(type_string<int&&>() == "int&&");
+  CHECK(type_string<int*>() == "int*");
   CHECK(type_string<const int&>() == "const int&");
   CHECK(type_string<const int&&>() == "const int&&");
+  CHECK(type_string<const int*>() == "const int*");
   CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
   CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test&");
   CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test&&");
+  CHECK(type_string<test_type_string::struct_test*>() == "test_type_string::struct_test*");
   CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
   CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test&");
   CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test&&");
+  CHECK(type_string<const test_type_string::struct_test*>() == "const test_type_string::struct_test*");
   CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
   CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test&");
   CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test&&");
+  CHECK(type_string<test_type_string::class_test*>() == "test_type_string::class_test*");
   CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
   CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test&");
   CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test&&");
+  CHECK(type_string<const test_type_string::class_test*>() == "const test_type_string::class_test*");
   CHECK(type_string<test_type_string::union_test>() == "test_type_string::union_test");
   CHECK(type_string<test_type_string::union_test&>() == "test_type_string::union_test&");
   CHECK(type_string<test_type_string::union_test&&>() == "test_type_string::union_test&&");
+  CHECK(type_string<test_type_string::union_test*>() == "test_type_string::union_test*");
   CHECK(type_string<const test_type_string::union_test>() == "const test_type_string::union_test");
   CHECK(type_string<const test_type_string::union_test&>() == "const test_type_string::union_test&");
   CHECK(type_string<const test_type_string::union_test&&>() == "const test_type_string::union_test&&");
+  CHECK(type_string<const test_type_string::union_test*>() == "const test_type_string::union_test*");
+  CHECK(type_string<std::string>() == "std::basic_string<char>");
+  CHECK(type_string<std::string&>() == "std::basic_string<char>&");
+  CHECK(type_string<std::string&&>() == "std::basic_string<char>&&");
+  CHECK(type_string<std::string*>() == "std::basic_string<char>*");
+  CHECK(type_string<const std::string>() == "const std::basic_string<char>");
+  CHECK(type_string<const std::string&>() == "const std::basic_string<char>&");
+  CHECK(type_string<const std::string&&>() == "const std::basic_string<char>&&");
+  CHECK(type_string<const std::string*>() == "const std::basic_string<char>*");
 }
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -4,6 +4,7 @@
 #include "ylt/reflection/member_value.hpp"
 #include "ylt/reflection/private_visitor.hpp"
 #include "ylt/reflection/template_switch.hpp"
+#include "ylt/reflection/template_string.hpp"
 #include "ylt/reflection/user_reflect_macro.hpp"
 
 using namespace ylt::reflection;
@@ -463,6 +464,35 @@ TEST_CASE("test visit private") {
 
   auto id = bank.*(std::get<0>(tp));    // 1
   auto name = bank.*(std::get<1>(tp));  // ok
+}
+
+namespace test_type_string {
+  struct struct_test {
+  };
+  class class_test {
+  };
+}
+
+TEST_CASE("test type_string") {
+  CHECK(type_string<int>() == "int");
+  CHECK(type_string<const int>() == "const int");
+  CHECK(type_string<volatile int>() == "volatile int");
+  // CHECK(type_string<int&>() == "int &");
+  // CHECK(type_string<int&&>() == "int &&");
+  // CHECK(type_string<const int&>() == "const int &");
+  // CHECK(type_string<const int&&>() == "const int &&");
+  // CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
+  // CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test &");
+  // CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test &&");
+  // CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
+  // CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test &");
+  // CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test &&");
+  // CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
+  // CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test &");
+  // CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test &&");
+  // CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
+  // CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test &");
+  // CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test &&");
 }
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -481,42 +481,26 @@ TEST_CASE("test type_string") {
   CHECK(type_string<volatile int>() == "volatile int");
   CHECK(type_string<int&>() == "int&");
   CHECK(type_string<int&&>() == "int&&");
-  CHECK(type_string<int*>() == "int*");
   CHECK(type_string<const int&>() == "const int&");
   CHECK(type_string<const int&&>() == "const int&&");
-  CHECK(type_string<const int*>() == "const int*");
   CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
   CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test&");
   CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test&&");
-  CHECK(type_string<test_type_string::struct_test*>() == "test_type_string::struct_test*");
   CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
   CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test&");
   CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test&&");
-  CHECK(type_string<const test_type_string::struct_test*>() == "const test_type_string::struct_test*");
   CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
   CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test&");
   CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test&&");
-  CHECK(type_string<test_type_string::class_test*>() == "test_type_string::class_test*");
   CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
   CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test&");
   CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test&&");
-  CHECK(type_string<const test_type_string::class_test*>() == "const test_type_string::class_test*");
   CHECK(type_string<test_type_string::union_test>() == "test_type_string::union_test");
   CHECK(type_string<test_type_string::union_test&>() == "test_type_string::union_test&");
   CHECK(type_string<test_type_string::union_test&&>() == "test_type_string::union_test&&");
-  CHECK(type_string<test_type_string::union_test*>() == "test_type_string::union_test*");
   CHECK(type_string<const test_type_string::union_test>() == "const test_type_string::union_test");
   CHECK(type_string<const test_type_string::union_test&>() == "const test_type_string::union_test&");
   CHECK(type_string<const test_type_string::union_test&&>() == "const test_type_string::union_test&&");
-  CHECK(type_string<const test_type_string::union_test*>() == "const test_type_string::union_test*");
-  CHECK(type_string<std::string>() == "std::basic_string<char>");
-  CHECK(type_string<std::string&>() == "std::basic_string<char>&");
-  CHECK(type_string<std::string&&>() == "std::basic_string<char>&&");
-  CHECK(type_string<std::string*>() == "std::basic_string<char>*");
-  CHECK(type_string<const std::string>() == "const std::basic_string<char>");
-  CHECK(type_string<const std::string&>() == "const std::basic_string<char>&");
-  CHECK(type_string<const std::string&&>() == "const std::basic_string<char>&&");
-  CHECK(type_string<const std::string*>() == "const std::basic_string<char>*");
 }
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -330,7 +330,7 @@ TEST_CASE("test macros") {
   CHECK(t.color == 10);
 
   using Tuple = decltype(struct_to_tuple<simple2>());
-  std::cout << type_string<Tuple>() << "\n";
+  std::cout << type_string<Tuple>().data() << "\n";
 
   constexpr size_t size2 = members_count_v<dummy_t2>;
   static_assert(size2 == 3);
@@ -471,28 +471,36 @@ namespace test_type_string {
   };
   class class_test {
   };
+  union union_test {
+  };
 }
 
 TEST_CASE("test type_string") {
   CHECK(type_string<int>() == "int");
   CHECK(type_string<const int>() == "const int");
   CHECK(type_string<volatile int>() == "volatile int");
-  // CHECK(type_string<int&>() == "int &");
-  // CHECK(type_string<int&&>() == "int &&");
-  // CHECK(type_string<const int&>() == "const int &");
-  // CHECK(type_string<const int&&>() == "const int &&");
-  // CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
-  // CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test &");
-  // CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test &&");
-  // CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
-  // CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test &");
-  // CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test &&");
-  // CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
-  // CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test &");
-  // CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test &&");
-  // CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
-  // CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test &");
-  // CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test &&");
+  CHECK(type_string<int&>() == "int&");
+  CHECK(type_string<int&&>() == "int&&");
+  CHECK(type_string<const int&>() == "const int&");
+  CHECK(type_string<const int&&>() == "const int&&");
+  CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
+  CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test&");
+  CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test&&");
+  CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
+  CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test&");
+  CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test&&");
+  CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
+  CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test&");
+  CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test&&");
+  CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
+  CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test&");
+  CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test&&");
+  CHECK(type_string<test_type_string::union_test>() == "test_type_string::union_test");
+  CHECK(type_string<test_type_string::union_test&>() == "test_type_string::union_test&");
+  CHECK(type_string<test_type_string::union_test&&>() == "test_type_string::union_test&&");
+  CHECK(type_string<const test_type_string::union_test>() == "const test_type_string::union_test");
+  CHECK(type_string<const test_type_string::union_test&>() == "const test_type_string::union_test&");
+  CHECK(type_string<const test_type_string::union_test&&>() == "const test_type_string::union_test&&");
 }
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why
Fixes https://github.com/alibaba/yalantinglibs/issues/872
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing
raw_name = fixed length prefix + type_name + fixed length suffix

so we can get prefix_length and suffix_length first, then substr

## Example
but I'm wondering is this the right way, because the output is not exactly the same for all compilers,
on my win11:
clang:
* there is a space between int and &
* there is no **class** or **struct** for class name
```
  CHECK(type_string<int&>() == "int &");
  CHECK(type_string<int&&>() == "int &&");
  CHECK(type_string<const int&>() == "const int &");
  CHECK(type_string<const int&&>() == "const int &&");
  CHECK(type_string<test_type_string::struct_test>() == "test_type_string::struct_test");
  CHECK(type_string<test_type_string::struct_test&>() == "test_type_string::struct_test &");
  CHECK(type_string<test_type_string::struct_test&&>() == "test_type_string::struct_test &&");
  CHECK(type_string<const test_type_string::struct_test>() == "const test_type_string::struct_test");
  CHECK(type_string<const test_type_string::struct_test&>() == "const test_type_string::struct_test &");
  CHECK(type_string<const test_type_string::struct_test&&>() == "const test_type_string::struct_test &&");
  CHECK(type_string<test_type_string::class_test>() == "test_type_string::class_test");
  CHECK(type_string<test_type_string::class_test&>() == "test_type_string::class_test &");
  CHECK(type_string<test_type_string::class_test&&>() == "test_type_string::class_test &&");
  CHECK(type_string<const test_type_string::class_test>() == "const test_type_string::class_test");
  CHECK(type_string<const test_type_string::class_test&>() == "const test_type_string::class_test &");
  CHECK(type_string<const test_type_string::class_test&&>() == "const test_type_string::class_test &&");
```
msvc:
* there is no space between int and &
* there is a **class** or **struct** for class name
```
  CHECK(type_string<int&>() == "int&");
  CHECK(type_string<int&&>() == "int&&");
  CHECK(type_string<const int&>() == "const int&");
  CHECK(type_string<const int&&>() == "const int&&");
  CHECK(type_string<test_type_string::struct_test>() == "struct test_type_string::struct_test");
  CHECK(type_string<test_type_string::struct_test&>() == "struct test_type_string::struct_test&");
  CHECK(type_string<test_type_string::struct_test&&>() == "struct test_type_string::struct_test&&");
  CHECK(type_string<const test_type_string::struct_test>() == "const struct test_type_string::struct_test");
  CHECK(type_string<const test_type_string::struct_test&>() == "const struct test_type_string::struct_test&");
  CHECK(type_string<const test_type_string::struct_test&&>() == "const struct test_type_string::struct_test&&");
  CHECK(type_string<test_type_string::class_test>() == "class test_type_string::class_test");
  CHECK(type_string<test_type_string::class_test&>() == "class test_type_string::class_test&");
  CHECK(type_string<test_type_string::class_test&&>() == "class test_type_string::class_test&&");
  CHECK(type_string<const test_type_string::class_test>() == "const class test_type_string::class_test");
  CHECK(type_string<const test_type_string::class_test&>() == "const class test_type_string::class_test&");
  CHECK(type_string<const test_type_string::class_test&&>() == "const class test_type_string::class_test&&");
```
