### PR TITLE
[CI] Fix website CI

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Install package
         run: sudo apt-get install doxygen graphviz
       - name: Yarn Install
@@ -48,10 +48,10 @@ jobs:
         run: bash generate.sh
         working-directory: ${{env.websiteDir}}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'website/dist'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Why

Commit CI failed with the error message `Missing download info for actions/upload-artifact@v3`.
reason: https://github.com/orgs/community/discussions/142581

## What is changing

- `actions/configure-pages@v3 => actions/configure-pages@v4`
- `actions/upload-pages-artifact@v2 => actions/upload-pages-artifact@v3`
- `actions/deploy-pages@v2 => actions/deploy-pages@v4`