### PR TITLE
[coro_rpc] support multi protocol, support big-endian

### DIFF
--- a/include/ylt/coro_io/coro_io.hpp
+++ b/include/ylt/coro_io/coro_io.hpp
@@ -688,4 +688,35 @@ async_sendfile(asio::ip::tcp::socket &socket, int fd, off_t offset,
   co_return std::pair{ec, size - least_bytes};
 }
 #endif
+
+struct socket_wrapper_t {
+  socket_wrapper_t(asio::ip::tcp::socket &&soc,
+                   coro_io::ExecutorWrapper<> *executor)
+      : socket_(std::make_unique<asio::ip::tcp::socket>(std::move(soc))),
+        executor_(executor) {}
+
+ private:
+  std::unique_ptr<asio::ip::tcp::socket> socket_;
+  coro_io::ExecutorWrapper<> *executor_;
+#ifdef YLT_ENABLE_SSL
+  std::unique_ptr<asio::ssl::stream<asio::ip::tcp::socket &>> ssl_stream_;
+#endif
+ public:
+  bool use_ssl() const noexcept {
+#ifdef YLT_ENABLE_SSL
+    return ssl_stream_ != nullptr;
+#else
+    return false;
+#endif
+  }
+  auto get_executor() const noexcept { return executor_; }
+  std::unique_ptr<asio::ip::tcp::socket> &socket() noexcept { return socket_; }
+#ifdef YLT_ENABLE_SSL
+  std::unique_ptr<asio::ssl::stream<asio::ip::tcp::socket &>>
+      &ssl_stream() noexcept {
+    return ssl_stream_;
+  }
+#endif
+};
+
 }  // namespace coro_io

--- a/include/ylt/coro_rpc/impl/coro_connection.hpp
+++ b/include/ylt/coro_rpc/impl/coro_connection.hpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <system_error>
 #include <thread>
@@ -31,6 +32,7 @@
 #include <ylt/easylog.hpp>
 
 #include "async_simple/Common.h"
+#include "async_simple/util/move_only_function.h"
 #include "ylt/coro_io/coro_io.hpp"
 #include "ylt/coro_rpc/impl/errno.h"
 #include "ylt/util/utils.hpp"
@@ -121,6 +123,9 @@ context_info_t<rpc_protocol> *&set_context();
 }
 
 class coro_connection : public std::enable_shared_from_this<coro_connection> {
+  using TransferCallback = async_simple::util::move_only_function<void(
+      coro_io::socket_wrapper_t &&socket, std::string_view magic_number)>;
+
  public:
   template <typename rpc_protocol_t>
   struct connection_lazy_ctx : public async_simple::coro::LazyLocalBase {
@@ -139,12 +144,11 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
    * @param socket
    * @param timeout_duration
    */
-  template <typename executor_t>
+  using executor_t = coro_io::ExecutorWrapper<>;
   coro_connection(executor_t *executor, asio::ip::tcp::socket socket,
                   std::chrono::steady_clock::duration timeout_duration =
                       std::chrono::seconds(0))
-      : executor_(executor),
-        socket_(std::move(socket)),
+      : socket_wrapper_(std::move(socket), executor),
         timer_(executor->get_asio_executor()) {
     if (timeout_duration == std::chrono::seconds(0)) {
       return;
@@ -166,9 +170,9 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
 
 #ifdef YLT_ENABLE_SSL
   void init_ssl(asio::ssl::context &ssl_ctx) {
-    ssl_stream_ = std::make_unique<asio::ssl::stream<asio::ip::tcp::socket &>>(
-        socket_, ssl_ctx);
-    use_ssl_ = true;
+    socket_wrapper_.ssl_stream() =
+        std::make_unique<asio::ssl::stream<asio::ip::tcp::socket &>>(
+            *socket_wrapper_.socket(), ssl_ctx);
   }
 #endif
 
@@ -176,12 +180,11 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
   async_simple::coro::Lazy<void> start(
       typename rpc_protocol::router &router) noexcept {
 #ifdef YLT_ENABLE_SSL
-    if (use_ssl_) {
-      assert(ssl_stream_);
+    if (socket_wrapper_.use_ssl()) {
       ELOG_INFO << "begin to handshake conn_id " << conn_id_;
       reset_timer();
       auto shake_ec = co_await coro_io::async_handshake(
-          ssl_stream_, asio::ssl::stream_base::server);
+          socket_wrapper_.ssl_stream(), asio::ssl::stream_base::server);
       cancel_timer();
       if (shake_ec) {
         ELOG_ERROR << "handshake failed: " << shake_ec.message() << " conn_id  "
@@ -190,12 +193,13 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
       }
       else {
         ELOG_INFO << "handshake ok conn_id " << conn_id_;
-        co_await start_impl<rpc_protocol>(router, *ssl_stream_);
+        co_await start_impl<rpc_protocol>(router,
+                                          *socket_wrapper_.ssl_stream());
       }
     }
     else {
 #endif
-      co_await start_impl<rpc_protocol>(router, socket_);
+      co_await start_impl<rpc_protocol>(router, *socket_wrapper_.socket());
 #ifdef YLT_ENABLE_SSL
     }
 #endif
@@ -206,19 +210,29 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     auto context_info = std::make_shared<context_info_t<rpc_protocol>>(
         router, shared_from_this());
     reset_timer();
-    while (true) {
+    std::string magic_number;
+    if (transfer_callback_ == nullptr) {
+      magic_number = "SKIP";
+    }
+    for (int64_t req_count = 0;; req_count++) {
       typename rpc_protocol::req_header req_head_tmp;
       // timer will be reset after rpc call response
-      auto ec = co_await rpc_protocol::read_head(socket, req_head_tmp);
+      auto ec =
+          co_await rpc_protocol::read_head(socket, req_head_tmp, magic_number);
       // `co_await async_read` uses asio::async_read underlying.
       // If eof occurred, the bytes_transferred of `co_await async_read` must
       // less than RPC_HEAD_LEN. Incomplete data will be discarded.
       // So, no special handling of eof is required.
-      if (ec) {
+      if (ec) [[unlikely]] {
         ELOG_INFO << "connection " << conn_id_ << " close: " << ec.message();
-        close();
+        if (req_count == 0 && magic_number.size() && transfer_callback_) {
+          ELOG_INFO << "The connection is not coro_rpc connection.";
+          (*transfer_callback_)(std::move(socket_wrapper_), magic_number);
+        }
         break;
       }
+      // we won't transfer connection after first check magic number
+      magic_number = "SKIP";
 
 #ifdef UNIT_TEST_INJECT
       client_id_ = req_head_tmp.seq_num;
@@ -229,7 +243,6 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
       if (g_action == inject_action::close_socket_after_read_header) {
         ELOG_WARN << "inject action: close_socket_after_read_header, conn_id "
                   << conn_id_ << ", client_id " << client_id_;
-        close();
         break;
       }
 #endif
@@ -260,7 +273,6 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
       if (!serialize_proto.has_value())
         AS_UNLIKELY {
           ELOG_ERROR << "bad serialize protocol type, conn_id " << conn_id_;
-          close();
           break;
         }
 
@@ -276,7 +288,6 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
         AS_UNLIKELY {
           ELOG_ERROR << "read error: " << ec.message() << ", conn_id "
                      << conn_id_;
-          close();
           break;
         }
 
@@ -310,7 +321,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
                             std::move(context_info->complete_handler_));
                   });
                 },
-                executor_);
+                socket_wrapper_.get_executor());
       }
       else {
         coro_rpc::detail::set_context<rpc_protocol>() = context_info.get();
@@ -336,7 +347,6 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
           std::string header_buf = rpc_protocol::prepare_response(
               resp_buf, req_head, 0, resp_err, "");
           co_await coro_io::async_write(socket, asio::buffer(header_buf));
-          close();
           break;
         }
         if (g_action == inject_action::server_send_bad_rpc_result) {
@@ -354,6 +364,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
         };
       }
     }
+    close();
     cancel_timer();
   }
   /*!
@@ -395,7 +406,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     response(std::move(header_buf), std::move(body_buf),
              std::move(resp_attachment), std::move(complete_handler),
              shared_from_this())
-        .via(executor_)
+        .via(socket_wrapper_.get_executor())
         .detach();
   }
 
@@ -412,7 +423,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
         rpc_protocol::prepare_response(body_buf, req_head, 0, ec, error_msg);
     response(std::move(header_buf), std::move(body_buf), std::move(attach_ment),
              std::move(complete_handler), shared_from_this())
-        .via(executor_)
+        .via(socket_wrapper_.get_executor())
         .detach();
   }
 
@@ -436,7 +447,7 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     if (has_closed_) {
       return;
     }
-    executor_->schedule([this, self = shared_from_this()] {
+    socket_wrapper_.get_executor()->schedule([this, self = shared_from_this()] {
       this->close();
     });
   }
@@ -447,19 +458,23 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     conn_id_ = conn_id;
   }
 
+  void set_transfer_callback(TransferCallback *callback) {
+    transfer_callback_ = callback;
+  }
+
   uint64_t get_connection_id() const noexcept { return conn_id_; }
 
   std::any &tag() { return tag_; }
   const std::any &tag() const { return tag_; }
 
-  auto get_executor() { return executor_; }
+  executor_t *get_executor() { return socket_wrapper_.get_executor(); }
 
   asio::ip::tcp::endpoint get_remote_endpoint() {
-    return socket_.remote_endpoint();
+    return socket_wrapper_.socket()->remote_endpoint();
   }
 
   asio::ip::tcp::endpoint get_local_endpoint() {
-    return socket_.local_endpoint();
+    return socket_wrapper_.socket()->local_endpoint();
   }
 
  private:
@@ -510,13 +525,14 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
         std::array<asio::const_buffer, 2> buffers{
             asio::buffer(std::get<0>(msg)), asio::buffer(std::get<1>(msg))};
 #ifdef YLT_ENABLE_SSL
-        if (use_ssl_) {
-          assert(ssl_stream_);
-          ret = co_await coro_io::async_write(*ssl_stream_, buffers);
+        if (socket_wrapper_.use_ssl()) {
+          ret = co_await coro_io::async_write(*socket_wrapper_.ssl_stream(),
+                                              buffers);
         }
         else {
 #endif
-          ret = co_await coro_io::async_write(socket_, buffers);
+          ret =
+              co_await coro_io::async_write(*socket_wrapper_.socket(), buffers);
 #ifdef YLT_ENABLE_SSL
         }
 #endif
@@ -526,13 +542,14 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
             asio::buffer(std::get<0>(msg)), asio::buffer(std::get<1>(msg)),
             asio::buffer(attachment)};
 #ifdef YLT_ENABLE_SSL
-        if (use_ssl_) {
-          assert(ssl_stream_);
-          ret = co_await coro_io::async_write(*ssl_stream_, buffers);
+        if (socket_wrapper_.use_ssl()) {
+          ret = co_await coro_io::async_write(*socket_wrapper_.ssl_stream(),
+                                              buffers);
         }
         else {
 #endif
-          ret = co_await coro_io::async_write(socket_, buffers);
+          ret =
+              co_await coro_io::async_write(*socket_wrapper_.socket(), buffers);
 #ifdef YLT_ENABLE_SSL
         }
 #endif
@@ -569,8 +586,11 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     }
     has_closed_ = true;
     asio::error_code ignored_ec;
-    socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ignored_ec);
-    socket_.close(ignored_ec);
+    if (socket_wrapper_.socket()) {
+      socket_wrapper_.socket()->shutdown(asio::ip::tcp::socket::shutdown_both,
+                                         ignored_ec);
+      socket_wrapper_.socket()->close(ignored_ec);
+    }
     if (quit_callback_) {
       quit_callback_(conn_id_);
     }
@@ -605,8 +625,8 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
     asio::error_code ec;
     timer_.cancel(ec);
   }
-  async_simple::Executor *executor_;
-  asio::ip::tcp::socket socket_;
+  coro_io::socket_wrapper_t socket_wrapper_;
+  TransferCallback *transfer_callback_{nullptr};
   // FIXME: queue's performance can be imporved.
   std::deque<
       std::tuple<std::string, std::string, std::function<std::string_view()>,
@@ -627,11 +647,6 @@ class coro_connection : public std::enable_shared_from_this<coro_connection> {
 
   std::any tag_;
 
-#ifdef YLT_ENABLE_SSL
-  std::unique_ptr<asio::ssl::stream<asio::ip::tcp::socket &>> ssl_stream_ =
-      nullptr;
-  bool use_ssl_ = false;
-#endif
 #ifdef UNIT_TEST_INJECT
   uint32_t client_id_ = 0;
 #endif

--- a/include/ylt/standalone/cinatra/coro_http_client.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_client.hpp
@@ -2036,7 +2036,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
           << "start connect to endpoint lists. total endpoint count:"
           << eps->size()
           << ", the first endpoint is: " << (*eps)[0].address().to_string()
-          << std::to_string((*eps)[0].port());
+          << ":" << std::to_string((*eps)[0].port());
       std::error_code ec;
       asio::ip::tcp::endpoint endpoint;
       if (std::tie(ec, endpoint) = co_await coro_io::async_connect(

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <memory>
+
+#include "asio/basic_stream_socket.hpp"
+#include "asio/bind_executor.hpp"
+#include "asio/executor.hpp"
+#include "asio/ip/tcp.hpp"
 #include "cinatra/coro_http_client.hpp"
 #include "cinatra/coro_http_response.hpp"
 #include "cinatra/coro_http_router.hpp"
@@ -22,12 +28,16 @@ class coro_http_server {
   coro_http_server(asio::io_context &ctx, unsigned short port,
                    std::string address = "0.0.0.0")
       : out_ctx_(&ctx), port_(port), acceptor_(ctx), check_timer_(ctx) {
+    out_executor_ =
+        std::make_unique<coro_io::ExecutorWrapper<>>(out_ctx_->get_executor());
     init_address(std::move(address));
   }
 
   coro_http_server(asio::io_context &ctx,
                    std::string address /* = "0.0.0.0:9001" */)
       : out_ctx_(&ctx), acceptor_(ctx), check_timer_(ctx) {
+    out_executor_ =
+        std::make_unique<coro_io::ExecutorWrapper<>>(out_ctx_->get_executor());
     init_address(std::move(address));
   }
 
@@ -659,6 +669,67 @@ class coro_http_server {
     return {};
   }
 
+ public:
+  void transfer_connection(coro_io::socket_wrapper_t &&soc,
+                           std::string_view head_msg) {
+    auto conn = accept_impl(std::move(soc), true);
+    conn->add_head(head_msg);
+    conn->start(true).via(conn->get_executor()).detach();
+  }
+
+ private:
+  std::shared_ptr<coro_http_connection> accept_impl(
+      coro_io::socket_wrapper_t &&socket, bool is_transfer_connect = false) {
+    uint64_t conn_id = ++conn_id_;
+    CINATRA_LOG_DEBUG << "new connection comming, id: " << conn_id;
+    auto conn = std::make_shared<coro_http_connection>(
+        socket.get_executor(), std::move(socket), router_);
+    if (no_delay_) {
+      conn->tcp_socket().set_option(asio::ip::tcp::no_delay(true));
+    }
+    conn->set_max_http_body_size(max_http_body_len_);
+    if (need_shrink_every_time_) {
+      conn->set_shrink_to_fit(true);
+    }
+    if (need_check_) {
+      conn->set_check_timeout(true);
+    }
+    if (default_handler_) {
+      conn->set_default_handler(default_handler_);
+    }
+
+#ifdef INJECT_FOR_HTTP_SEVER_TEST
+    if (write_failed_forever_) {
+      conn->set_write_failed_forever(write_failed_forever_);
+    }
+    if (read_failed_forever_) {
+      conn->set_read_failed_forever(read_failed_forever_);
+    }
+#endif
+
+#ifdef CINATRA_ENABLE_SSL
+    if (!is_transfer_connect && use_ssl_) {
+      conn->init_ssl(cert_file_, key_file_, passwd_);
+    }
+#endif
+    std::weak_ptr<std::mutex> weak(conn_mtx_);
+    conn->set_quit_callback(
+        [this, weak](const uint64_t &id) {
+          auto mtx = weak.lock();
+          if (mtx) {
+            std::scoped_lock lock(*mtx);
+            if (!connections_.empty())
+              connections_.erase(id);
+          }
+        },
+        conn_id);
+    {
+      std::scoped_lock lock(*conn_mtx_);
+      connections_.emplace(conn_id, conn);
+    }
+    return std::move(conn);
+  }
+
   async_simple::coro::Lazy<std::error_code> accept() {
     for (;;) {
       coro_io::ExecutorWrapper<> *executor;
@@ -670,8 +741,8 @@ class coro_http_server {
             out_ctx_->get_executor());
         executor = out_executor_.get();
       }
-
       asio::ip::tcp::socket socket(executor->get_asio_executor());
+
       auto error = co_await coro_io::async_accept(acceptor_, socket);
       if (error) {
         CINATRA_LOG_INFO << "accept failed, error: " << error.message();
@@ -682,60 +753,11 @@ class coro_http_server {
         }
         continue;
       }
-
-      uint64_t conn_id = ++conn_id_;
-      CINATRA_LOG_DEBUG << "new connection comming, id: " << conn_id;
-      auto conn = std::make_shared<coro_http_connection>(
-          executor, std::move(socket), router_);
-      if (no_delay_) {
-        conn->tcp_socket().set_option(asio::ip::tcp::no_delay(true));
-      }
-      conn->set_max_http_body_size(max_http_body_len_);
-      if (need_shrink_every_time_) {
-        conn->set_shrink_to_fit(true);
-      }
-      if (need_check_) {
-        conn->set_check_timeout(true);
-      }
-      if (default_handler_) {
-        conn->set_default_handler(default_handler_);
-      }
-
-#ifdef INJECT_FOR_HTTP_SEVER_TEST
-      if (write_failed_forever_) {
-        conn->set_write_failed_forever(write_failed_forever_);
-      }
-      if (read_failed_forever_) {
-        conn->set_read_failed_forever(read_failed_forever_);
-      }
-#endif
-
-#ifdef CINATRA_ENABLE_SSL
-      if (use_ssl_) {
-        conn->init_ssl(cert_file_, key_file_, passwd_);
-      }
-#endif
-      std::weak_ptr<std::mutex> weak(conn_mtx_);
-      conn->set_quit_callback(
-          [this, weak](const uint64_t &id) {
-            auto mtx = weak.lock();
-            if (mtx) {
-              std::scoped_lock lock(*mtx);
-              if (!connections_.empty())
-                connections_.erase(id);
-            }
-          },
-          conn_id);
-
-      {
-        std::scoped_lock lock(*conn_mtx_);
-        connections_.emplace(conn_id, conn);
-      }
-
+      auto conn =
+          accept_impl(coro_io::socket_wrapper_t{std::move(socket), executor});
       start_one(conn).via(conn->get_executor()).detach();
     }
   }
-
   async_simple::coro::Lazy<void> start_one(
       std::shared_ptr<coro_http_connection> conn) noexcept {
     co_await conn->start();

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -2,10 +2,6 @@
 
 #include <memory>
 
-#include "asio/basic_stream_socket.hpp"
-#include "asio/bind_executor.hpp"
-#include "asio/executor.hpp"
-#include "asio/ip/tcp.hpp"
 #include "cinatra/coro_http_client.hpp"
 #include "cinatra/coro_http_response.hpp"
 #include "cinatra/coro_http_router.hpp"

--- a/src/coro_rpc/examples/base_examples/server.cpp
+++ b/src/coro_rpc/examples/base_examples/server.cpp
@@ -16,9 +16,6 @@
 #include <ylt/coro_http/coro_http_server.hpp>
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 
-#include "cinatra/coro_http_request.hpp"
-#include "cinatra/coro_http_response.hpp"
-#include "cinatra/response_cv.hpp"
 #include "rpc_service.h"
 using namespace coro_rpc;
 using namespace async_simple;

--- a/src/coro_rpc/examples/base_examples/server.cpp
+++ b/src/coro_rpc/examples/base_examples/server.cpp
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <ylt/coro_http/coro_http_server.hpp>
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 
+#include "cinatra/coro_http_request.hpp"
+#include "cinatra/coro_http_response.hpp"
+#include "cinatra/response_cv.hpp"
 #include "rpc_service.h"
 using namespace coro_rpc;
 using namespace async_simple;
@@ -41,6 +45,30 @@ int main() {
   // async start server
   auto res = server2.async_start();
   assert(!res.hasResult());
+
+  // start an http server in same port(8801) of rpc server. you can open
+  // http://localhost:8801/ to visit it.
+  auto http_server = std::make_unique<coro_http::coro_http_server>(0, 0);
+  http_server->set_http_handler<coro_http::GET>(
+      "/", [](coro_http::coro_http_request& req,
+              coro_http::coro_http_response& resp) {
+        resp.set_status_and_content(coro_http::status_type::ok,
+                                    R"(<!DOCTYPE html>
+<html>
+    <head>
+        <title>Example</title>
+    </head>
+    <body>
+        <p>This is an example of a simple HTML page with one paragraph.</p>
+    </body>
+</html>)");
+      });
+  std::function dispatcher = [](coro_io::socket_wrapper_t&& soc,
+                                std::string_view magic_number,
+                                coro_http::coro_http_server& server) {
+    server.transfer_connection(std::move(soc), magic_number);
+  };
+  server.add_subserver(std::move(dispatcher), std::move(http_server));
 
   // sync start server & sync await server stop
   return !server.start();

--- a/src/coro_rpc/examples/user_defined_rpc_protocol/rest_rpc/config/rest_rpc_protocol.hpp
+++ b/src/coro_rpc/examples/user_defined_rpc_protocol/rest_rpc/config/rest_rpc_protocol.hpp
@@ -55,13 +55,16 @@ struct rest_rpc_protocol {
 
   template <typename Socket>
   static async_simple::coro::Lazy<std::error_code> read_head(
-      Socket& socket, req_header& req_head) {
+      Socket& socket, req_header& req_head, std::string& magic) {
     auto [ec, _] = co_await coro_io::async_read(
         socket, asio::buffer((char*)&req_head, sizeof(req_header)));
     if (ec)
       AS_UNLIKELY { co_return std::move(ec); }
     else if (req_head.magic != magic_number)
-      AS_UNLIKELY { co_return std::make_error_code(std::errc::protocol_error); }
+      AS_UNLIKELY {
+        magic = (char)req_head.magic;
+        co_return std::make_error_code(std::errc::protocol_error);
+      }
     co_return std::error_code{};
   }
 

--- a/website/docs/zh/coro_rpc/coro_rpc_server.md
+++ b/website/docs/zh/coro_rpc/coro_rpc_server.md
@@ -38,6 +38,46 @@ int start_server() {
 }
 ```
 
+### 在rpc端口添加http服务或其他服务
+我们可以通过调用`add_subserver()`方法，添加一个子服务器。
+
+例如，如果想要同时监听http server，可以调用如下代码。
+```cpp
+coro_rpc_server server(/*thread=*/std::thread::hardware_concurrency(),
+                       /*port=*/8801);
+auto http_server = std::make_unique<coro_http::coro_http_server>(0, 0);
+std::function dispatcher = [](coro_io::socket_wrapper_t&& soc,
+                              std::string_view magic_number,
+                              coro_http::coro_http_server& server) {
+  server.transfer_connection(std::move(soc), magic_number);
+};
+server.add_subserver(std::move(dispatcher), std::move(http_server));
+```
+
+`magic_number`是客户端发来的第一个字节，当客户段建立连接发起首次请求时，rpc server会检查第一个字节是否是coro_rpc是魔数`21`,如果魔数不正确则会释放连接并调用用户注册的dispatcher方法。用户应当在dispatcher函数内根据魔数进行分发，将连接转发到正确的服务器。
+
+特别的是，`add_subserver()`方法可以添加多个子服务器, 这允许我们在同一个端口启动多个服务器。
+
+```cpp
+coro_rpc_server server(/*thread=*/std::thread::hardware_concurrency(),
+                       /*port=*/8801);
+auto rest_server = std::make_unique<coro_rest_server>(0, 0);
+auto http_server = std::make_unique<coro_http::coro_http_server>(0, 0);
+std::function dispatcher = [](coro_io::socket_wrapper_t&& soc,
+                              std::string_view magic_number,
+                              coro_http::coro_http_server& server, coro_rest_server& rest_server) {
+  if (magic_number == (char)16) { // rest server
+    server.transfer_connection(std::move(soc), magic_number);
+  }
+  else { //http
+    rest_server.transfer_connection(std::move(soc), magic_number);
+  }
+};
+server.add_subserver(std::move(dispatcher), std::move(http_server), std::move(rest_server));
+```
+
+
+
 coro_rpc支持注册并调用的rpc函数有三种：
 1. 普通函数
 2. 协程函数


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

## What is changing

1. support multi protocol (for example: start http server & rpc server in same address)
2. coro_rpc support big-endian platform.

## Example

This example add an http subserver for rpc server, we can support multi protocol now.
```cpp
coro_rpc_server server(/*thread=*/std::thread::hardware_concurrency(),
                       /*port=*/8801);
server.register_handler<echo>();
auto http_server = std::make_unique<coro_http::coro_http_server>(0, 0);
  http_server->set_http_handler<coro_http::GET>(
      "/", [](coro_http::coro_http_request& req,
              coro_http::coro_http_response& resp) {
        resp.set_status_and_content(coro_http::status_type::ok,
                                    R"(<!DOCTYPE html>
<html>
    <head>
        <title>Example</title>
    </head>
    <body>
        <p>This is an example of a simple HTML page with one paragraph.</p>
    </body>
</html>)");
      });
  std::function dispatcher = [](coro_io::socket_wrapper_t&& soc,
                                std::string_view magic_number,
                                coro_http::coro_http_server& server) {
    server.transfer_connection(std::move(soc), magic_number);
  };
  server.add_subserver(std::move(dispatcher), std::move(http_server));
```