### PR TITLE
add separator charactor between host and port

### DIFF
--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -490,6 +490,7 @@ class coro_rpc_client {
     ELOG_TRACE << "start connect to endpoint lists. total endpoint count:"
                << eps->size()
                << ", the first endpoint is: " << (*eps)[0].address().to_string()
+               << ":"
                << std::to_string((*eps)[0].port());
     asio::ip::tcp::endpoint endpoint;
     std::tie(ec, endpoint) = co_await coro_io::async_connect(

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -490,8 +490,7 @@ class coro_rpc_client {
     ELOG_TRACE << "start connect to endpoint lists. total endpoint count:"
                << eps->size()
                << ", the first endpoint is: " << (*eps)[0].address().to_string()
-               << ":"
-               << std::to_string((*eps)[0].port());
+               << ":" << std::to_string((*eps)[0].port());
     asio::ip::tcp::endpoint endpoint;
     std::tie(ec, endpoint) = co_await coro_io::async_connect(
         &control_->executor_, control_->socket_, *eps);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Better display

Before:
the first endpoint is: 127.0.0.150052

After:
the first endpoint is: 127.0.0.1:50052

## What is changing
add ":" between host and port
## Example