### PR TITLE
[struct_pack] use unsigned long long integer literal to silence gcc warnings

### DIFF
--- a/include/ylt/struct_pack/type_calculate.hpp
+++ b/include/ylt/struct_pack/type_calculate.hpp
@@ -37,53 +37,55 @@ constexpr decltype(auto) get_size_literal() {
     return string_literal<char, 3>{
         {static_cast<char>(size % 127 + 1),
          static_cast<char>(size / 127 % 127 + 1),
-         static_cast<char>(size / (127 * 127) + 129)}};
+         static_cast<char>(size / (127ull * 127) + 129)}};
   }
   else if constexpr (size < 1ull * 127 * 127 * 127 * 127) {
     return string_literal<char, 4>{
         {static_cast<char>(size % 127 + 1),
          static_cast<char>(size / 127 % 127 + 1),
-         static_cast<char>(size / (127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127) + 129)}};
+         static_cast<char>(size / (127ull * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127) + 129)}};
   }
   else if constexpr (size < 1ull * 127 * 127 * 127 * 127 * 127) {
     return string_literal<char, 5>{
         {static_cast<char>(size % 127 + 1),
          static_cast<char>(size / 127 % 127 + 1),
-         static_cast<char>(size / (127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127 * 127) + 129)}};
+         static_cast<char>(size / (127ull * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127 * 127) + 129)}};
   }
   else if constexpr (size < 1ull * 127 * 127 * 127 * 127 * 127 * 127) {
     return string_literal<char, 6>{
         {static_cast<char>(size % 127 + 1),
          static_cast<char>(size / 127 % 127 + 1),
-         static_cast<char>(size / (127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127 * 127 * 127) + 129)}};
+         static_cast<char>(size / (127ull * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127 * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127 * 127 * 127) + 129)}};
   }
   else if constexpr (size < 1ull * 127 * 127 * 127 * 127 * 127 * 127 * 127) {
     return string_literal<char, 7>{
         {static_cast<char>(size % 127 + 1),
          static_cast<char>(size / 127 % 127 + 1),
-         static_cast<char>(size / (127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127 * 127 * 127) % 127 + 1),
-         static_cast<char>(size / (127 * 127 * 127 * 127 * 127 * 127) + 129)}};
+         static_cast<char>(size / (127ull * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127 * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127 * 127 * 127) % 127 + 1),
+         static_cast<char>(size / (127ull * 127 * 127 * 127 * 127 * 127) +
+                           129)}};
   }
   else if constexpr (size <
                      1ull * 127 * 127 * 127 * 127 * 127 * 127 * 127 * 127) {
     return string_literal<char, 8>{{
         static_cast<char>(size % 127 + 1),
         static_cast<char>(size / 127 % 127 + 1),
-        static_cast<char>(size / (127 * 127) % 127 + 1),
-        static_cast<char>(size / (127 * 127 * 127) % 127 + 1),
-        static_cast<char>(size / (127 * 127 * 127 * 127) % 127 + 1),
-        static_cast<char>(size / (127 * 127 * 127 * 127 * 127) % 127 + 1),
-        static_cast<char>(size / (127 * 127 * 127 * 127 * 127 * 127) % 127 + 1),
-        static_cast<char>(size / (127 * 127 * 127 * 127 * 127 * 127 * 127) +
+        static_cast<char>(size / (127ull * 127) % 127 + 1),
+        static_cast<char>(size / (127ull * 127 * 127) % 127 + 1),
+        static_cast<char>(size / (127ull * 127 * 127 * 127) % 127 + 1),
+        static_cast<char>(size / (127ull * 127 * 127 * 127 * 127) % 127 + 1),
+        static_cast<char>(size / (127ull * 127 * 127 * 127 * 127 * 127) % 127 +
+                          1),
+        static_cast<char>(size / (127ull * 127 * 127 * 127 * 127 * 127 * 127) +
                           129),
     }};
   }


### PR DESCRIPTION
when building the tree using GCC-15, we have following warnings:

```
/home/kefu/dev/yalantinglibs/include/ylt/struct_pack/type_calculate.hpp: In function ‘constexpr decltype(auto) struct_pack::detail::get_size_literal()’:
/home/kefu/dev/yalantinglibs/include/ylt/struct_pack/type_calculate.hpp:64:58: warning: integer overflow in expression of type ‘int’ results in ‘-1321368961’ [-Woverflow]
   64 |          static_cast<char>(size / (127 * 127 * 127 * 127 * 127) + 129)}};
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```

because `127` is an `int`, if the expression evaluates to an constant with cannot be represented with `int`, the compiler warns. in order to silence the warnings, let's use the `ull` prefix.

<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

## Example