### PR TITLE
[cmake][improve]let cmake auto find openssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ if(CMAKE_PROJECT_NAME STREQUAL "yaLanTingLibs") # if ylt is top-level project
         include_directories(include/ylt/standalone)
         include_directories(src/include)
 
+        include(cmake/find_openssl.cmake)
         include(cmake/utils.cmake)
         include(cmake/build.cmake)
         include(cmake/develop.cmake)

--- a/cmake/find_openssl.cmake
+++ b/cmake/find_openssl.cmake
@@ -1,0 +1,7 @@
+check_library_exists(ssl SSL_new "" HAVE_SSL_LIB)
+if(HAVE_SSL_LIB)
+    message(STATUS "Found OpenSSL libraries")
+    set(YLT_ENABLE_SSL ON)
+else()
+    message(STATUS "OpenSSL libraries not found")
+endif()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Auto find openssl, avoid manual set `YLT_ENABLE_SSL` option.

## What is changing

## Example