### PR TITLE
[metric] add ylt::metric::stop_system_metric

### DIFF
--- a/include/ylt/metric/system_metric.hpp
+++ b/include/ylt/metric/system_metric.hpp
@@ -395,10 +395,11 @@ inline void start_stat(std::weak_ptr<coro_io::period_timer> weak, auto manager,
 }
 }  // namespace detail
 
-static std::shared_ptr<coro_io::io_context_pool> g_system_metric_exucutor;
-static std::shared_ptr<coro_io::period_timer> g_system_metric_timer;
-static std::once_flag g_start_system_metric_flag;
-static std::once_flag g_stop_system_metric_flag;
+inline static std::shared_ptr<coro_io::io_context_pool>
+    g_system_metric_exucutor;
+inline static std::shared_ptr<coro_io::period_timer> g_system_metric_timer;
+inline static std::once_flag g_start_system_metric_flag;
+inline static std::once_flag g_stop_system_metric_flag;
 
 inline bool start_system_metric() {
   system_metric_manager::instance()->create_metric_static<gauge_t>(

--- a/src/metric/tests/test_metric.cpp
+++ b/src/metric/tests/test_metric.cpp
@@ -1817,6 +1817,7 @@ TEST_CASE("test system metric") {
   std::cout << json << "\n";
   CHECK(!json.empty());
 #endif
+  stop_system_metric();
 }
 
 TEST_CASE("test metric capacity") {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

当使用 ylt::metric::start_system_metric 开启系统指标监控后，在程序退出时使用 valgrind 检测到内存泄漏

## What is changing

添加一个 ylt::metric::stop_system_metric 方法来主动停止系统指标监控，保证资源正常释放

## Example

```bash
==41685== HEAP SUMMARY:
==41685==     in use at exit: 10,598 bytes in 156 blocks
==41685==   total heap usage: 15,929 allocs, 15,773 frees, 5,022,634 bytes allocated
==41685== 
==41685== 136 bytes in 1 blocks are possibly lost in loss record 70 of 101
==41685==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==41685==    by 0x3F0C6B: std::__new_allocator<std::_Sp_counted_ptr_inplace<coro_io::period_timer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) (new_allocator.h:151)
==41685==    by 0x3E4E36: allocate (allocator.h:198)
==41685==    by 0x3E4E36: allocate (alloc_traits.h:482)
==41685==    by 0x3E4E36: std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<coro_io::period_timer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<coro_io::period_timer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<coro_io::period_timer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >&) (allocated_ptr.h:98)
==41685==    by 0x3E07F3: std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<coro_io::period_timer, std::allocator<void>, coro_io::ExecutorWrapper<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >*>(coro_io::period_timer*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, coro_io::ExecutorWrapper<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >*&&) (shared_ptr_base.h:969)
==41685==    by 0x3DD14F: std::__shared_ptr<coro_io::period_timer, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, coro_io::ExecutorWrapper<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >*>(std::_Sp_alloc_shared_tag<std::allocator<void> >, coro_io::ExecutorWrapper<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >*&&) (shared_ptr_base.h:1712)
==41685==    by 0x3D80B8: std::shared_ptr<coro_io::period_timer>::shared_ptr<std::allocator<void>, coro_io::ExecutorWrapper<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >*>(std::_Sp_alloc_shared_tag<std::allocator<void> >, coro_io::ExecutorWrapper<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >*&&) (shared_ptr.h:464)
==41685==    by 0x3D2FBB: std::shared_ptr<coro_io::period_timer> std::make_shared<coro_io::period_timer, coro_io::ExecutorWrapper<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >*>(coro_io::ExecutorWrapper<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >*&&) (shared_ptr.h:1010)
==41685==    by 0x3CBA93: ylt::metric::start_system_metric() (system_metric.hpp:451)
==41685==    by 0x39CCFB: MqttExposer::run() (MqttExposer.cpp:75)
==41685==    by 0x14F7CC: main (main.cpp:14)
==41685== 
==41685== 160 bytes in 1 blocks are possibly lost in loss record 71 of 101
==41685==    at 0x484E65C: aligned_alloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==41685==    by 0x177B40: asio::aligned_new(unsigned long, unsigned long) (memory.hpp:101)
==41685==    by 0x1A89C8: void* asio::detail::thread_info_base::allocate<asio::detail::thread_info_base::default_tag>(asio::detail::thread_info_base::default_tag, asio::detail::thread_info_base*, unsigned long, unsigned long) (thread_info_base.hpp:169)
==41685==    by 0x177D69: asio::detail::thread_info_base::allocate(asio::detail::thread_info_base*, unsigned long, unsigned long) (thread_info_base.hpp:122)
==41685==    by 0x178072: asio::asio_handler_allocate(unsigned long, ...) (handler_alloc_hook.ipp:35)
==41685==    by 0x3F0DB4: void* asio_handler_alloc_helpers::allocate<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}>(unsigned long, ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}&, unsigned long) (handler_alloc_helpers.hpp:73)
==41685==    by 0x3EDA88: asio::detail::hook_allocator<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}, asio::detail::wait_handler<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}, asio::any_io_executor> >::allocate(unsigned long) (handler_alloc_helpers.hpp:130)
==41685==    by 0x3EA145: asio::detail::wait_handler<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}, asio::any_io_executor>::ptr::allocate(ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}&) (wait_handler.hpp:35)
==41685==    by 0x3E5080: void asio::detail::deadline_timer_service<asio::detail::chrono_time_traits<std::chrono::_V2::steady_clock, asio::wait_traits<std::chrono::_V2::steady_clock> > >::async_wait<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}, asio::any_io_executor>(asio::detail::deadline_timer_service<asio::detail::chrono_time_traits<std::chrono::_V2::steady_clock, asio::wait_traits<std::chrono::_V2::steady_clock> > >::implementation_type&, ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}&, asio::any_io_executor const&) (deadline_timer_service.hpp:256)
==41685==    by 0x3E09F0: void asio::basic_waitable_timer<std::chrono::_V2::steady_clock, asio::wait_traits<std::chrono::_V2::steady_clock>, asio::any_io_executor>::initiate_async_wait::operator()<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}>(ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}&&) const (basic_waitable_timer.hpp:814)
==41685==    by 0x3DD1F8: void asio::detail::completion_handler_async_result<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}, void (std::error_code)>::initiate<asio::basic_waitable_timer<std::chrono::_V2::steady_clock, asio::wait_traits<std::chrono::_V2::steady_clock>, asio::any_io_executor>::initiate_async_wait, ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}>(asio::basic_waitable_timer<std::chrono::_V2::steady_clock, asio::wait_traits<std::chrono::_V2::steady_clock>, asio::any_io_executor>::initiate_async_wait&&, ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}&&) (async_result.hpp:481)
==41685==    by 0x3D8196: asio::constraint<asio::detail::async_result_has_initiate_memfn<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}, void (std::error_code)>::value, decltype (asio::async_result<std::decay<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}>::type, void (std::error_code)>::initiate((declval<asio::basic_waitable_timer<std::chrono::_V2::steady_clock, asio::wait_traits<std::chrono::_V2::steady_clock>, asio::any_io_executor>::initiate_async_wait&&>)(), (declval<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}&&>)()))>::type asio::async_initiate<ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}, void (std::error_code), asio::basic_waitable_timer<std::chrono::_V2::steady_clock, asio::wait_traits<std::chrono::_V2::steady_clock>, asio::any_io_executor>::initiate_async_wait>(asio::basic_waitable_timer<std::chrono::_V2::steady_clock, asio::wait_traits<std::chrono::_V2::steady_clock>, asio::any_io_executor>::initiate_async_wait&&, ylt::metric::detail::start_stat<std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> > >(std::weak_ptr<coro_io::period_timer>, std::shared_ptr<ylt::metric::static_metric_manager<ylt::metric::ylt_system_tag_t> >, std::shared_ptr<ylt::metric::thread_local_value<long> >)::{lambda(std::error_code)#1}&) (async_result.hpp:895)
==41685== 
==41685== 320 bytes in 1 blocks are possibly lost in loss record 98 of 101
==41685==    at 0x484D953: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==41685==    by 0x40145AB: calloc (rtld-malloc.h:44)
==41685==    by 0x40145AB: allocate_dtv (dl-tls.c:370)
==41685==    by 0x40145AB: _dl_allocate_tls (dl-tls.c:629)
==41685==    by 0x5252616: allocate_stack (allocatestack.c:429)
==41685==    by 0x5252616: pthread_create@@GLIBC_2.34 (pthread_create.c:655)
==41685==    by 0x4F0AEB0: std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
==41685==    by 0x3D8002: std::thread::thread<coro_io::create_io_context_pool<coro_io::io_context_pool>(unsigned int)::{lambda()#1}, , void>(coro_io::create_io_context_pool<coro_io::io_context_pool>(unsigned int)::{lambda()#1}&&) (std_thread.h:164)
==41685==    by 0x3D2EDA: std::shared_ptr<coro_io::io_context_pool> coro_io::create_io_context_pool<coro_io::io_context_pool>(unsigned int) (io_context_pool.hpp:335)
==41685==    by 0x3CBA30: ylt::metric::start_system_metric() (system_metric.hpp:449)
==41685==    by 0x39CCFB: MqttExposer::run() (MqttExposer.cpp:75)
==41685==    by 0x14F7CC: main (main.cpp:14)
==41685== 
==41685== 320 bytes in 1 blocks are possibly lost in loss record 99 of 101
==41685==    at 0x484D953: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==41685==    by 0x40145AB: calloc (rtld-malloc.h:44)
==41685==    by 0x40145AB: allocate_dtv (dl-tls.c:370)
==41685==    by 0x40145AB: _dl_allocate_tls (dl-tls.c:629)
==41685==    by 0x5252616: allocate_stack (allocatestack.c:429)
==41685==    by 0x5252616: pthread_create@@GLIBC_2.34 (pthread_create.c:655)
==41685==    by 0x4F0AEB0: std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
==41685==    by 0x234624: std::thread::thread<coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}, std::shared_ptr<asio::io_context>&, void>(coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}&&, std::shared_ptr<asio::io_context>&) (std_thread.h:164)
==41685==    by 0x228EF2: void std::_Construct<std::thread, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}, std::shared_ptr<asio::io_context>&>(std::thread*, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}&&, std::shared_ptr<asio::io_context>&) (stl_construct.h:119)
==41685==    by 0x20BC64: construct<std::thread, coro_io::io_context_pool::run()::<lambda(coro_io::io_context_pool::io_context_ptr)>, std::shared_ptr<asio::io_context>&> (alloc_traits.h:661)
==41685==    by 0x20BC64: std::_Sp_counted_ptr_inplace<std::thread, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}, std::shared_ptr<asio::io_context>&>(std::allocator<void>, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}&&, std::shared_ptr<asio::io_context>&) (shared_ptr_base.h:604)
==41685==    by 0x1F2541: std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<std::thread, std::allocator<void>, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}, std::shared_ptr<asio::io_context>&>(std::thread*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}&&, std::shared_ptr<asio::io_context>&) (shared_ptr_base.h:971)
==41685==    by 0x1DBAC7: std::__shared_ptr<std::thread, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}, std::shared_ptr<asio::io_context>&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}&&, std::shared_ptr<asio::io_context>&) (shared_ptr_base.h:1712)
==41685==    by 0x1C3384: std::shared_ptr<std::thread>::shared_ptr<std::allocator<void>, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}, std::shared_ptr<asio::io_context>&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}&&, std::shared_ptr<asio::io_context>&) (shared_ptr.h:464)
==41685==    by 0x1AE927: std::shared_ptr<std::thread> std::make_shared<std::thread, coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}, std::shared_ptr<asio::io_context>&>(coro_io::io_context_pool::run()::{lambda(std::shared_ptr<asio::io_context>)#1}&&, std::shared_ptr<asio::io_context>&) (shared_ptr.h:1010)
==41685==    by 0x1893F6: coro_io::io_context_pool::run() (io_context_pool.hpp:180)
==41685== 
==41685== LEAK SUMMARY:
==41685==    definitely lost: 0 bytes in 0 blocks
==41685==    indirectly lost: 0 bytes in 0 blocks
==41685==      possibly lost: 936 bytes in 4 blocks
==41685==    still reachable: 9,662 bytes in 152 blocks
==41685==         suppressed: 0 bytes in 0 blocks
==41685== Reachable blocks (those to which a pointer was found) are not shown.
==41685== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==41685== 
==41685== For lists of detected and suppressed errors, rerun with: -s
==41685== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```