### PR TITLE
[easylog] fix build when using clang

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -85,9 +85,9 @@ if (USE_CCACHE)
 endif ()
 
 # --------------------- GCC
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     link_libraries(dl)
-    if (ENABLE_CPP_20)
+    if (ENABLE_CPP_20 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines")
     endif()
     #-ftree-slp-vectorize with coroutine cause link error. disable it util gcc fix.

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,6 +1,6 @@
 message(STATUS "-------------YLT CONFIG SETTING-------------")
 target_link_libraries(yalantinglibs INTERFACE Threads::Threads)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(yalantinglibs INTERFACE dl)
 endif()
 option(YLT_ENABLE_SSL "Enable ssl support" OFF)


### PR DESCRIPTION
Failed to build with clang, error message is as below:
```
[ 83%] Linking CXX executable ../../../output/tests/reflection_test
make[1]: *** [CMakeFiles/Makefile2:1112: src/easylog/tests/CMakeFiles/easylog_test.dir/all] Error 2
ld.lld: error: undefined symbol: dladdr
>>> referenced by main.cpp
>>>               CMakeFiles/coro_io_example.dir/main.cpp.o:(ylt::util::b_stacktrace_to_string(ylt::util::b_stacktrace_tag*))
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/coro_io/examples/CMakeFiles/coro_io_example.dir/build.make:99: output/examples/coro_io_example] Error 1
make[1]: *** [CMakeFiles/Makefile2:644: src/coro_io/examples/CMakeFiles/coro_io_example.dir/all] Error 2
[ 83%] Built target reflection_test
[ 84%] Linking CXX executable ../../../output/tests/coro_rpc/coro_rpc_regist_test_2
ld.lld: error: undefined symbol: dladdr
[ 84%] Linking CXX executable ../../../output/benchmark/metric_benchmark
>>> referenced by rpc_api.cpp
>>>               CMakeFiles/coro_rpc_regist_test_2.dir/rpc_api.cpp.o:(ylt::util::b_stacktrace_to_string(ylt::util::b_stacktrace_tag*))
```