### PR TITLE
[struct_pack] fix multi version compatible in unordered_map

### DIFF
--- a/include/ylt/struct_pack/compatible.hpp
+++ b/include/ylt/struct_pack/compatible.hpp
@@ -141,11 +141,14 @@ struct compatible : public std::optional<T> {
   constexpr compatible &operator=(const compatible &other) = default;
   constexpr compatible &operator=(compatible &&other) = default;
   using std::optional<T>::optional;
-  friend bool operator==(const compatible<T, version> &self,
-                         const compatible<T, version> &other) {
-    return static_cast<bool>(self) == static_cast<bool>(other) &&
-           (!self || *self == *other);
-  }
+
   static constexpr uint64_t version_number = version;
 };
+
+template <typename T, uint64_t version1, uint64_t version2>
+inline bool operator==(const compatible<T, version1> &lhs,
+                       const compatible<T, version2> &rhs) {
+  return static_cast<bool>(lhs) == static_cast<bool>(rhs) &&
+         (!lhs || *lhs == *rhs);
+}
 }  // namespace struct_pack

--- a/src/struct_pack/tests/test_compatible.cpp
+++ b/src/struct_pack/tests/test_compatible.cpp
@@ -1326,6 +1326,17 @@ struct compatible_in_unordered_map {
       int, struct_pack::compatible<std::unordered_map<int, std::string>>>
       values;
 };
+struct compatible_in_unordered_map2 {
+  struct nested {
+    struct_pack::compatible<int, 20140101> a;
+    struct_pack::compatible<int, 20140201> b;
+    friend inline bool operator==(const nested& lhs, const nested& rhs) {
+      return lhs.a == rhs.a && lhs.b == rhs.b;
+    }
+  };
+
+  std::unordered_map<int, nested> values;
+};
 TEST_CASE("test unordered_map_in_compatible") {
   {
     std::unordered_map<int, struct_pack::compatible<int>> map;
@@ -1355,6 +1366,16 @@ TEST_CASE("test unordered_map_in_compatible") {
       for (int j = 0; j < 100 - i % 100; ++j) {
         iter.first->second.value().insert({j, std::to_string(j)});
       }
+    }
+    auto buffer = struct_pack::serialize(m);
+    auto result = struct_pack::deserialize<decltype(m)>(buffer);
+    CHECK(result.value().values == m.values);
+  }
+  {
+    compatible_in_unordered_map2 m;
+    for (int i = 0; i < 1000; ++i) {
+      auto iter = m.values.insert(
+          {i, compatible_in_unordered_map2::nested{i, 1000 - i}});
     }
     auto buffer = struct_pack::serialize(m);
     auto result = struct_pack::deserialize<decltype(m)>(buffer);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

#1028  couldn't resolve multi compatible<T> which has different version number in unordered_map.

## What is changing

## Example