### PR TITLE
[coro_io][ibverbs] client pool/ibverbs support better client reuse

### DIFF
--- a/include/ylt/coro_io/client_pool.hpp
+++ b/include/ylt/coro_io/client_pool.hpp
@@ -88,7 +88,7 @@ class client_pool : public std::enable_shared_from_this<
         ELOG_TRACE << "start collect timeout client of pool{"
                    << self->host_name_
                    << "}, now client count: " << clients.size();
-        bool is_all_cleared = clients.clear_old(clear_cnt);
+        auto [is_all_cleared, _] = clients.clear_old(clear_cnt);
         auto free_client_cnt = clients.size();
         ELOG_WARN << "finish collect timeout client of pool{"
                   << self->host_name_

--- a/include/ylt/coro_io/client_pool.hpp
+++ b/include/ylt/coro_io/client_pool.hpp
@@ -272,7 +272,6 @@ class client_pool : public std::enable_shared_from_this<
       short_connect_clients_.try_dequeue(client);
     }
     if (client == nullptr) {
-      std::unique_ptr<client_t> cli;
       auto executor = io_context_pool_.get_executor();
       client = std::make_unique<client_t>(executor);
       if (!client->init_config(client_config))
@@ -441,12 +440,20 @@ class client_pool : public std::enable_shared_from_this<
   }
 
   /**
-   * @brief approx connection of client pools
+   * @brief approx free connection of client pools
    *
    * @return std::size_t
    */
   std::size_t free_client_count() const noexcept {
     return free_clients_.size() + short_connect_clients_.size();
+  }
+  /**
+   * @brief approx connection of client pools
+   *
+   * @return std::size_t
+   */
+  std::size_t total_client_count() const noexcept {
+    return free_client_count() + unfree_client_cnt_;
   }
   /**
    * @brief if host may not useable now.

--- a/include/ylt/coro_io/client_pool.hpp
+++ b/include/ylt/coro_io/client_pool.hpp
@@ -88,7 +88,7 @@ class client_pool : public std::enable_shared_from_this<
         ELOG_TRACE << "start collect timeout client of pool{"
                    << self->host_name_
                    << "}, now client count: " << clients.size();
-        std::size_t is_all_cleared = clients.clear_old(clear_cnt);
+        bool is_all_cleared = clients.clear_old(clear_cnt);
         auto free_client_cnt = clients.size();
         ELOG_WARN << "finish collect timeout client of pool{"
                   << self->host_name_
@@ -97,7 +97,7 @@ class client_pool : public std::enable_shared_from_this<
                   << self->unfree_client_cnt_.load(std::memory_order::relaxed) + free_client_cnt
                   << " parallel request cnt:"
                   << self->parallel_request_cnt_.load(std::memory_order::relaxed);
-        if (is_all_cleared != 0) [[unlikely]] {
+        if (!is_all_cleared) [[unlikely]] {
           try {
             co_await async_simple::coro::Yield{};
           } catch (std::exception& e) {

--- a/include/ylt/coro_io/client_pool.hpp
+++ b/include/ylt/coro_io/client_pool.hpp
@@ -357,7 +357,7 @@ class client_pool : public std::enable_shared_from_this<
         enqueue(free_clients_, std::move(client), pool_config_.idle_timeout);
       }
       else {
-        ELOG_TRACE << "out of max connection limit <<"
+        ELOG_TRACE << "out of max connection limit "
                    << pool_config_.max_connection << ", collect free client{"
                    << client.get() << "} enqueue short connect queue";
         enqueue(short_connect_clients_, std::move(client),

--- a/include/ylt/coro_io/client_pool.hpp
+++ b/include/ylt/coro_io/client_pool.hpp
@@ -392,7 +392,7 @@ class client_pool : public std::enable_shared_from_this<
     uint32_t idle_queue_per_max_clear_count = 1000;
     int32_t reuse_limit = -1; // -1 means auto limit
     std::chrono::milliseconds reconnect_wait_time{1000};
-    std::chrono::milliseconds idle_timeout{3000};
+    std::chrono::milliseconds idle_timeout{30000};
     std::chrono::milliseconds short_connect_idle_timeout{1000};
     std::chrono::milliseconds host_alive_detect_duration{
         30000}; /* zero means wont detect */

--- a/include/ylt/coro_io/client_pool.hpp
+++ b/include/ylt/coro_io/client_pool.hpp
@@ -500,7 +500,7 @@ public:
   template<typename T>
   async_simple::coro::Lazy<async_simple::coro::Lazy<T>> client_reuse_limiter(async_simple::coro::Lazy<T>&& lazy,client_t& cli) {
     auto limit = get_pool_config().reuse_limit;
-    constexpr int rdma_reuse_limit = 32;
+    constexpr int rdma_reuse_limit = 24;
     constexpr int tcp_reuse_limit = 160;
     if (limit<0) {
       // rdma

--- a/include/ylt/coro_io/client_pool.hpp
+++ b/include/ylt/coro_io/client_pool.hpp
@@ -494,13 +494,14 @@ public:
     constexpr int tcp_use_limit = 160;
     if (limit<0) {
       // rdma
-      if (get_pool_config().client_config.socket_config.index()==2) {
+      ELOG_INFO << get_pool_config().client_config.socket_config.index();
+      // if (get_pool_config().client_config.socket_config.index()==2) {
         limit=rdma_use_limit;
-      }
-      // tcp
-      else {
-        limit=tcp_use_limit;
-      }
+      // }
+      // // tcp
+      // else {
+      //   limit=tcp_use_limit;
+      // }
     }
     // watcher_weak<uint64_t, std::remove_cvref_t<decltype(*this)>,std::memory_order_release>(parallel_request_cnt_,this->weak_from_this())
     if (limit < parallel_request_cnt_.load(std::memory_order_acquire)) {

--- a/include/ylt/coro_io/coro_io.hpp
+++ b/include/ylt/coro_io/coro_io.hpp
@@ -644,9 +644,10 @@ inline async_simple::coro::Lazy<bool> sleep_for(Duration d) {
     }
     co_return true;
   }
-  else if (auto ioc=coro_io::get_current();ioc!=nullptr&&*ioc!=nullptr) {
+  else if (auto ioc = coro_io::get_current();
+           ioc != nullptr && *ioc != nullptr) {
     coro_io::ExecutorWrapper<> e((**ioc).get_executor());
-    co_return co_await sleep_for(d,&e);
+    co_return co_await sleep_for(d, &e);
   }
   else {
     co_return co_await sleep_for(d,

--- a/include/ylt/coro_io/coro_io.hpp
+++ b/include/ylt/coro_io/coro_io.hpp
@@ -644,6 +644,10 @@ inline async_simple::coro::Lazy<bool> sleep_for(Duration d) {
     }
     co_return true;
   }
+  else if (auto ioc=coro_io::get_current();ioc!=nullptr&&*ioc!=nullptr) {
+    coro_io::ExecutorWrapper<> e((**ioc).get_executor());
+    co_return co_await sleep_for(d,&e);
+  }
   else {
     co_return co_await sleep_for(d,
                                  coro_io::g_io_context_pool().get_executor());

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -78,15 +78,15 @@ class client_queue {
               queue_[index ^ 1].enqueue(std::move(c2));
             }
           }
-          else if (size_[index]> 1 && queue_[index].try_dequeue(c2)) {
-            if (c2->waiting_request_count() < c->waiting_request_count()) {
-              queue_[index].enqueue(std::move(c));
-              c = std::move(c2);
-            }
-            else {
-              queue_[index].enqueue(std::move(c2));
-            }
-          }
+          // else if (size_[index]> 1 && queue_[index].try_dequeue(c2)) {
+          //   if (c2->waiting_request_count() < c->waiting_request_count()) {
+          //     queue_[index].enqueue(std::move(c));
+          //     c = std::move(c2);
+          //   }
+          //   else {
+          //     queue_[index].enqueue(std::move(c2));
+          //   }
+          // }
         }
       }
       --size_[index];

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -62,12 +62,12 @@ class client_queue {
     }
   }
   void try_dequeue_connect_reuse_impl(client_t&c, std::size_t index) {
-    if constexpr (requires { c->waiting_request_count(); }) {
-      auto waiting_count = c->waiting_request_count();
+    if constexpr (requires { c->get_pipeline_size(); }) {
+      auto waiting_count = c->get_pipeline_size();
       if (waiting_count>=10) {
         client_t c2;
         if (size_[index]> 1 && queue_[index].try_dequeue(c2)) {
-          if (c2->waiting_request_count() < c->waiting_request_count()) {
+          if (c2->get_pipeline_size() < c->get_pipeline_size()) {
             queue_[index].enqueue(std::move(c));
             c = std::move(c2);
           }
@@ -98,8 +98,8 @@ class client_queue {
     for (;clear_cnt<max_clear_cnt;++clear_cnt) {
       client_t c;
       if (queue_[index].try_dequeue(c)) {
-        if constexpr (requires { c->waiting_request_count(); }) {
-          auto waiting_count = c->waiting_request_count();
+        if constexpr (requires { c->get_pipeline_size(); }) {
+          auto waiting_count = c->get_pipeline_size();
           if (waiting_count) {
             using_clients.push_back(std::move(c));
           }

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -83,12 +83,10 @@ class client_queue {
     const int_fast16_t index = selected_index_;
     if (queue_[index].try_dequeue(c)) {
       try_dequeue_connect_reuse_impl(c, index);
-      --size_[index ^ 1];
       return true;
     }
     else if (queue_[index ^ 1].try_dequeue(c)) {
       try_dequeue_connect_reuse_impl(c, index ^ 1);
-      --size_[index ^ 1];
       return true;
     }
     return false;

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -68,7 +68,8 @@ class client_queue {
         auto waiting_count =c->waiting_request_count();
         if (waiting_count>=10) {
           client_t c2;
-          if (size_[index ^ 1] && queue_[index ^ 1].try_dequeue(c2)) {
+          std::size_t size_now=size_[index];
+          if (size_[index ^ 1] >= size_now && queue_[index ^ 1].try_dequeue(c2)) {
             if (c2->waiting_request_count() < waiting_count) {
               queue_[index].enqueue(std::move(c));
               --size_[index ^ 1];
@@ -79,7 +80,7 @@ class client_queue {
               queue_[index ^ 1].enqueue(std::move(c2));
             }
           }
-          else if (size_[index]> 1 && queue_[index].try_dequeue(c2)) {
+          else if (size_now> 1 && queue_[index].try_dequeue(c2)) {
             if (c2->waiting_request_count() < c->waiting_request_count()) {
               queue_[index].enqueue(std::move(c));
               c = std::move(c2);

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -61,12 +61,12 @@ class client_queue {
       return 0;
     }
   }
-  void try_dequeue_connect_reuse_impl(client_t&c, std::size_t index) {
+  void try_dequeue_connect_reuse_impl(client_t& c, std::size_t index) {
     if constexpr (requires { c->get_pipeline_size(); }) {
       auto waiting_count = c->get_pipeline_size();
-      if (waiting_count>=10) {
+      if (waiting_count >= 10) {
         client_t c2;
-        if (size_[index]> 1 && queue_[index].try_dequeue(c2)) {
+        if (size_[index] > 1 && queue_[index].try_dequeue(c2)) {
           if (c2->get_pipeline_size() < c->get_pipeline_size()) {
             queue_[index].enqueue(std::move(c));
             c = std::move(c2);
@@ -91,11 +91,11 @@ class client_queue {
     }
     return false;
   }
-  std::pair<bool,std::size_t> clear_old(std::size_t max_clear_cnt) {
+  std::pair<bool, std::size_t> clear_old(std::size_t max_clear_cnt) {
     const int_fast16_t index = selected_index_ ^ 1;
     std::vector<client_t> using_clients;
     std::size_t clear_cnt = 0;
-    for (;clear_cnt<max_clear_cnt;++clear_cnt) {
+    for (; clear_cnt < max_clear_cnt; ++clear_cnt) {
       client_t c;
       if (queue_[index].try_dequeue(c)) {
         if constexpr (requires { c->get_pipeline_size(); }) {
@@ -109,12 +109,12 @@ class client_queue {
         break;
       }
     }
-    for (auto &cli: using_clients) {
+    for (auto& cli : using_clients) {
       queue_[index].enqueue(std::move(cli));
     }
     std::size_t real_clear_cnt = clear_cnt - using_clients.size();
-    size_[selected_index_]-=real_clear_cnt;
-    return {clear_cnt<max_clear_cnt,real_clear_cnt}; // all cleared
+    size_[selected_index_] -= real_clear_cnt;
+    return {clear_cnt < max_clear_cnt, real_clear_cnt};  // all cleared
   }
 };
 };  // namespace coro_io::detail

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -112,7 +112,9 @@ class client_queue {
     for (auto &cli: using_clients) {
       queue_[index].enqueue(std::move(cli));
     }
-    return {clear_cnt<max_clear_cnt,clear_cnt-using_clients.size()}; // all cleared
+    std::size_t real_clear_cnt = clear_cnt - using_clients.size();
+    size_[selected_index_]-=real_clear_cnt;
+    return {clear_cnt<max_clear_cnt,real_clear_cnt}; // all cleared
   }
 };
 };  // namespace coro_io::detail

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -78,6 +78,15 @@ class client_queue {
               queue_[index ^ 1].enqueue(std::move(c2));
             }
           }
+          else if (size_[index]> 1 && queue_[index].try_dequeue(c2)) {
+            if (c2->waiting_request_count() < c->waiting_request_count()) {
+              queue_[index].enqueue(std::move(c));
+              c = std::move(c2);
+            }
+            else {
+              queue_[index].enqueue(std::move(c2));
+            }
+          }
         }
       }
       --size_[index];

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -91,7 +91,7 @@ class client_queue {
     }
     return false;
   }
-  bool clear_old(std::size_t max_clear_cnt) {
+  std::pair<bool,std::size_t> clear_old(std::size_t max_clear_cnt) {
     const int_fast16_t index = selected_index_ ^ 1;
     std::vector<client_t> using_clients;
     std::size_t clear_cnt = 0;
@@ -112,7 +112,7 @@ class client_queue {
     for (auto &cli: using_clients) {
       queue_[index].enqueue(std::move(cli));
     }
-    return clear_cnt<max_clear_cnt; // all cleared
+    return {clear_cnt<max_clear_cnt,clear_cnt-using_clients.size()}; // all cleared
   }
 };
 };  // namespace coro_io::detail

--- a/include/ylt/coro_io/detail/client_queue.hpp
+++ b/include/ylt/coro_io/detail/client_queue.hpp
@@ -69,18 +69,19 @@ class client_queue {
         if (waiting_count>=10) {
           client_t c2;
           std::size_t size_now=size_[index];
-          if (size_[index ^ 1] >= size_now && queue_[index ^ 1].try_dequeue(c2)) {
-            if (c2->waiting_request_count() < waiting_count) {
-              queue_[index].enqueue(std::move(c));
-              --size_[index ^ 1];
-              c = std::move(c2);
-              return true;
-            }
-            else {
-              queue_[index ^ 1].enqueue(std::move(c2));
-            }
-          }
-          else if (size_now> 1 && queue_[index].try_dequeue(c2)) {
+          // if (size_[index ^ 1] >= size_now && queue_[index ^ 1].try_dequeue(c2)) {
+          //   if (c2->waiting_request_count() < waiting_count) {
+          //     queue_[index].enqueue(std::move(c));
+          //     --size_[index ^ 1];
+          //     c = std::move(c2);
+          //     return true;
+          //   }
+          //   else {
+          //     queue_[index ^ 1].enqueue(std::move(c2));
+          //   }
+          // }
+          // else 
+          if (size_now> 1 && queue_[index].try_dequeue(c2)) {
             if (c2->waiting_request_count() < c->waiting_request_count()) {
               queue_[index].enqueue(std::move(c));
               c = std::move(c2);

--- a/include/ylt/coro_io/ibverbs/ib_buffer.hpp
+++ b/include/ylt/coro_io/ibverbs/ib_buffer.hpp
@@ -166,7 +166,7 @@ class ib_buffer_pool_t : public std::enable_shared_from_this<ib_buffer_pool_t> {
       while (true) {
         ELOG_TRACE << "start ib_buffer timeout free of pool{" << self.get()
                    << "}, now ib_buffer count: " << self->free_buffers_.size();
-        auto [is_all_cleared,clear_cnt] = self->free_buffers_.clear_old(1000);
+        auto [is_all_cleared, clear_cnt] = self->free_buffers_.clear_old(1000);
         self->modify_memory_usage(-1 * (ssize_t)clear_cnt *
                                   (ssize_t)self->buffer_size());
         ELOG_TRACE << "finish ib_buffer timeout free of pool{" << self.get()

--- a/include/ylt/coro_io/ibverbs/ib_buffer.hpp
+++ b/include/ylt/coro_io/ibverbs/ib_buffer.hpp
@@ -166,7 +166,7 @@ class ib_buffer_pool_t : public std::enable_shared_from_this<ib_buffer_pool_t> {
       while (true) {
         ELOG_TRACE << "start ib_buffer timeout free of pool{" << self.get()
                    << "}, now ib_buffer count: " << self->free_buffers_.size();
-        std::size_t clear_cnt = self->free_buffers_.clear_old(1000);
+        auto [is_all_cleared,clear_cnt] = self->free_buffers_.clear_old(1000);
         self->modify_memory_usage(-1 * (ssize_t)clear_cnt *
                                   (ssize_t)self->buffer_size());
         ELOG_TRACE << "finish ib_buffer timeout free of pool{" << self.get()
@@ -175,7 +175,7 @@ class ib_buffer_pool_t : public std::enable_shared_from_this<ib_buffer_pool_t> {
                    << (int64_t)(std::round(self->memory_usage() /
                                            (1.0 * 1024 * 1024)))
                    << " MB";
-        if (clear_cnt != 0) {
+        if (!is_all_cleared) {
           try {
             co_await async_simple::coro::Yield{};
           } catch (std::exception& e) {

--- a/include/ylt/coro_io/ibverbs/ib_io.hpp
+++ b/include/ylt/coro_io/ibverbs/ib_io.hpp
@@ -194,8 +194,9 @@ async_simple::coro::
   assert(len == io_size);
   auto now_buffer_data =
       ib_socket.get_buffer_size() - ib_socket.get_free_send_buffer_size();
-  if (now_buffer_data < 64 * 1024 && !send_buffer_full && prev_op &&
-      !prev_op->hasResult()) {
+  if (now_buffer_data <
+          std::min<std::size_t>(2 * 1024 * 1024, ib_socket.get_buffer_size()) &&
+      !send_buffer_full && prev_op && !prev_op->hasResult()) {
     ELOG_INFO << "combine small message, now buffer size:" << now_buffer_data;
     co_return std::pair{std::error_code{}, io_size};
   }

--- a/include/ylt/coro_io/ibverbs/ib_socket.hpp
+++ b/include/ylt/coro_io/ibverbs/ib_socket.hpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <exception>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <stdexcept>
 #include <system_error>
@@ -20,6 +21,7 @@
 #include "asio/ip/tcp.hpp"
 #include "asio/posix/stream_descriptor.hpp"
 #include "async_simple/Signal.h"
+#include "async_simple/Future.h"
 #include "async_simple/coro/Lazy.h"
 #include "async_simple/util/move_only_function.h"
 #include "ib_device.hpp"
@@ -674,6 +676,8 @@ class ib_socket_t {
       });
     }
   }
+  auto& write_waiter() noexcept { return write_waiter_; }
+  const auto& write_waiter() const noexcept { return write_waiter_; }
 
   async_simple::coro::Lazy<std::error_code> connect(
       const std::string& host, const std::string& port) noexcept {
@@ -901,6 +905,7 @@ class ib_socket_t {
   uint32_t remote_qp_num_{};
   std::string_view remain_data_;
   std::shared_ptr<detail::ib_socket_shared_state_t> state_;
+  std::optional<async_simple::Future<std::error_code>> write_waiter_;
   coro_io::ExecutorWrapper<>* executor_;
   config_t conf_;
   uint32_t buffer_size_ = 0;

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -311,7 +311,7 @@ class coro_rpc_client {
    *
    * @return std::size_t, the waiting request count. zero if not request waiting
    */
-  [[nodiscard]] std::size_t waiting_request_count() const noexcept { return control_->table_cnt_.load(std::memory_order_relaxed); }
+  [[nodiscard]] std::size_t waiting_request_count() const noexcept { return control_->table_cnt_.load(std::memory_order_acquire); }
 
   /*!
    * Connect server
@@ -950,7 +950,7 @@ class coro_rpc_client {
       e.second.local_error(errc);
     }
     controller->response_handler_table_.clear();
-    controller->table_cnt_.store(0,std::memory_order_relaxed);
+    controller->table_cnt_.store(0,std::memory_order_release);
   }
   template <typename Socket>
   static async_simple::coro::Lazy<void> recv(
@@ -1031,9 +1031,9 @@ class coro_rpc_client {
       file.close();
 #endif
       --controller->recving_cnt_;
+      controller->table_cnt_.fetch_sub(1,std::memory_order_release);
       iter->second(std::move(controller->resp_buffer_), header.err_code);
       controller->response_handler_table_.erase(iter);
-      controller->table_cnt_.fetch_sub(1,std::memory_order_relaxed);
       if (controller->response_handler_table_.empty()) {
         co_return;
       }
@@ -1161,7 +1161,7 @@ class coro_rpc_client {
             rpc_error{coro_rpc::errc::serial_number_conflict});
       }
       else {
-        control_->table_cnt_.fetch_add(1,std::memory_order_relaxed);
+        control_->table_cnt_.fetch_add(1,std::memory_order_release);
         if (is_empty) {
           control_->socket_wrapper_.visit([control_ = control_](auto &socket) {
             recv(control_, socket).start([](auto &&) {

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -1175,7 +1175,7 @@ class coro_rpc_client {
     }
   }
 
-  uint32_t get_pipeline_size() { return control_->recving_cnt_.load(std::memory_order_acquire); }
+  uint32_t get_pipeline_size() const noexcept { return control_->recving_cnt_.load(std::memory_order_acquire); }
 
  private:
   bool& reuse_client_hint() noexcept {

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -1306,4 +1306,10 @@ class coro_rpc_client {
 #endif
   std::chrono::time_point<std::chrono::steady_clock> create_tp_;
 };
+
+// template<auto func, template<typename> typename client_pool, typename... Args>
+// async_simple::coro::Lazy<async_rpc_result<decltype(get_return_type<func>())>> send_request(client_pool<coro_rpc_client> &pool, const coro_rpc_client::config& config, std::string_view attachment, std::chrono::steady_clock::duration timeout_duration, Args&&... args) {
+//   pool.send_
+// }
+
 }  // namespace coro_rpc

--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -1181,6 +1181,10 @@ class coro_rpc_client {
   uint32_t get_pipeline_size() { return control_->recving_cnt_; }
 
  private:
+  bool& reuse_client_hint() noexcept {
+    return reuse_client_hint_;
+  }
+
   template <auto func, typename Socket, typename... Args>
   async_simple::coro::Lazy<rpc_error> send_impl(Socket &socket, uint32_t &id,
                                                 std::string_view req_attachment,
@@ -1288,7 +1292,7 @@ class coro_rpc_client {
   }
 
  private:
-  bool should_reset_ = false;
+  bool should_reset_ = false, reuse_client_hint_ = false;
   async_simple::coro::Mutex connect_mutex_;
   std::atomic<bool> write_mutex_ = false;
   std::atomic<uint32_t> request_id_{0};

--- a/include/ylt/standalone/cinatra/coro_http_client.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_client.hpp
@@ -367,6 +367,8 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
   bool has_closed() { return socket_->has_closed_; }
 
+  [[nodiscard]] std::size_t waiting_request_count() const noexcept { return 0; }
+
   const auto &get_headers() { return req_headers_; }
 
   void set_headers(std::unordered_map<std::string, std::string> req_headers) {

--- a/include/ylt/standalone/cinatra/coro_http_client.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_client.hpp
@@ -367,7 +367,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
   bool has_closed() { return socket_->has_closed_; }
 
-  [[nodiscard]] std::size_t waiting_request_count() const noexcept { return 0; }
+  [[nodiscard]] std::size_t get_pipeline_size() const noexcept { return 0; }
 
   const auto &get_headers() { return req_headers_; }
 

--- a/src/coro_io/tests/ibverbs/test_ib_socket.cpp
+++ b/src/coro_io/tests/ibverbs/test_ib_socket.cpp
@@ -456,10 +456,10 @@ TEST_CASE("test socket io") {
                        echo_connect({test(test_write, 2 * 1024, true)})),
             coro_io::sleep_for(std::chrono::milliseconds{100})));
     auto& ec1 = std::get<0>(std::get<0>(result).value());
-    auto& ec2 = std::get<1>(std::get<0>(result).value());
+    // auto& ec2 = std::get<1>(std::get<0>(result).value());
     auto& ec3 = std::get<1>(result);
     CHECK_MESSAGE(ec1.value(), ec1.value().message());
-    CHECK_MESSAGE(ec2.value(), ec2.value().message());
+    // CHECK_MESSAGE(ec2.value(), ec2.value().message());
     CHECK_MESSAGE(ec3.value(), "time out failed");
   }
   {

--- a/src/coro_io/tests/ibverbs/test_ib_socket.cpp
+++ b/src/coro_io/tests/ibverbs/test_ib_socket.cpp
@@ -163,7 +163,6 @@ async_simple::coro::Lazy<std::error_code> test_write(coro_io::ib_socket_t& soc,
   }
   std::tie(ec, len) = co_await coro_io::async_write(
       soc, asio::buffer(buffer.data(), data_size));
-  ELOG_TRACE << "END WRITE";
   if (!ec) {
     CHECK(len == data_size);
   }
@@ -559,18 +558,22 @@ TEST_CASE("test rpc-like io") {
   }
 }
 
-async_simple::coro::Lazy<std::error_code> sleep(coro_io::ib_socket_t& soc, std::chrono::milliseconds ms) {
-  co_await coro_io::sleep_for(ms,soc.get_coro_executor());
-  co_return std::error_code{}; 
+async_simple::coro::Lazy<std::error_code> sleep(coro_io::ib_socket_t& soc,
+                                                std::chrono::milliseconds ms) {
+  co_await coro_io::sleep_for(ms, soc.get_coro_executor());
+  co_return std::error_code{};
 }
 
 TEST_CASE("test small package combine write") {
   {
     ELOG_WARN << "test small package combine write1";
     auto result = async_simple::coro::syncAwait(collectAll(
-        echo_accept({test(test_read_some, 3 * 1024), test(test_read_some, 8 * 1024),test(test_read_some, 1 * 1024)}),
+        echo_accept({test(test_read_some, 3 * 1024),
+                     test(test_read_some, 8 * 1024),
+                     test(test_read_some, 1 * 1024)}),
         echo_connect({test(test_write, 3 * 1024), test(test_write, 3 * 1024),
-                      test(test_write, 3 * 1024),test(test_write, 3 * 1024)})));
+                      test(test_write, 3 * 1024),
+                      test(test_write, 3 * 1024)})));
     auto& ec1 = std::get<0>(result);
     auto& ec2 = std::get<1>(result);
     CHECK_MESSAGE(!ec1.value(), ec1.value().message());
@@ -579,7 +582,8 @@ TEST_CASE("test small package combine write") {
   {
     ELOG_WARN << "test small package combine write2";
     auto result = async_simple::coro::syncAwait(collectAll(
-        echo_accept({test(test_read_some, 3 * 1024), test(test_read_some, 6 * 1024)}),
+        echo_accept(
+            {test(test_read_some, 3 * 1024), test(test_read_some, 6 * 1024)}),
         echo_connect({test(test_write, 3 * 1024), test(test_write, 3 * 1024),
                       test(test_write, 3 * 1024)})));
     auto& ec1 = std::get<0>(result);
@@ -589,9 +593,12 @@ TEST_CASE("test small package combine write") {
   }
   {
     ELOG_WARN << "test small package combine write3";
-    auto result = async_simple::coro::syncAwait(collectAll(
-        echo_accept({test(test_read_some, 8 * 1024), test(test_read_some, 8 * 1024),test(test_read_some, 8 * 1024)}),
-        echo_connect({test(test_write, 11 * 1024), test(test_write, 13 * 1024)})));
+    auto result = async_simple::coro::syncAwait(
+        collectAll(echo_accept({test(test_read_some, 8 * 1024),
+                                test(test_read_some, 8 * 1024),
+                                test(test_read_some, 8 * 1024)}),
+                   echo_connect({test(test_write, 11 * 1024),
+                                 test(test_write, 13 * 1024)})));
     auto& ec1 = std::get<0>(result);
     auto& ec2 = std::get<1>(result);
     CHECK_MESSAGE(!ec1.value(), ec1.value().message());

--- a/src/coro_io/tests/ibverbs/test_ib_socket.cpp
+++ b/src/coro_io/tests/ibverbs/test_ib_socket.cpp
@@ -449,17 +449,14 @@ TEST_CASE("test socket io") {
   }
   {
     ELOG_WARN << "test read time out";
-    // TODO: sometimes hang, will fix
     auto result = async_simple::coro::syncAwait(
         collectAll<async_simple::SignalType::Terminate>(
             collectAll(echo_accept({test(test_read, 2 * 1024)}),
                        echo_connect({test(test_write, 2 * 1024, true)})),
             coro_io::sleep_for(std::chrono::milliseconds{100})));
     auto& ec1 = std::get<0>(std::get<0>(result).value());
-    // auto& ec2 = std::get<1>(std::get<0>(result).value());
     auto& ec3 = std::get<1>(result);
     CHECK_MESSAGE(ec1.value(), ec1.value().message());
-    // CHECK_MESSAGE(ec2.value(), ec2.value().message());
     CHECK_MESSAGE(ec3.value(), "time out failed");
   }
   {

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -1,5 +1,6 @@
 #include <atomic>
 #include <chrono>
+#include <ctime>
 #include <system_error>
 #include <vector>
 #include <ylt/coro_io/client_pool.hpp>
@@ -12,6 +13,7 @@
 #include "async_simple/coro/Lazy.h"
 #include "cmdline.h"
 #include "ylt/coro_io/coro_io.hpp"
+#include "ylt/coro_rpc/impl/coro_rpc_client.hpp"
 #include "ylt/coro_rpc/impl/protocol/coro_rpc_protocol.hpp"
 
 struct bench_config {
@@ -28,6 +30,7 @@ struct bench_config {
   uint32_t min_recv_buf_count;
   uint32_t max_recv_buf_count;
   bool use_client_pool;
+  bool reuse_client_pool;
 };
 
 bench_config init_conf(const cmdline::parser& parser) {
@@ -45,6 +48,7 @@ bench_config init_conf(const cmdline::parser& parser) {
   conf.min_recv_buf_count = parser.get<uint32_t>("min_recv_buf_count");
   conf.max_recv_buf_count = parser.get<uint32_t>("max_recv_buf_count");
   conf.use_client_pool = parser.get<bool>("use_client_pool");
+  conf.reuse_client_pool = parser.get<bool>("reuse_client_pool");
 
   if (conf.client_concurrency == 0) {
     ELOG_WARN << "port: " << conf.port << ", "
@@ -56,6 +60,7 @@ bench_config init_conf(const cmdline::parser& parser) {
   }
   else {
     ELOG_WARN << "url: " << conf.url << ", "
+              << "reuse_client_pool: " << conf.reuse_client_pool << ", "
               << "use_client_pool: " << conf.use_client_pool << ", "
               << "buffer_size: " << conf.buffer_size << ", "
               << "client concurrency: " << conf.client_concurrency << ", "
@@ -160,7 +165,6 @@ async_simple::coro::Lazy<void> watcher(const bench_config& conf) {
 
 async_simple::coro::Lazy<std::error_code> request(const bench_config& conf) {
   ELOG_INFO << "bench_config buffer size " << conf.buffer_size;
-
   coro_io::client_pool<coro_rpc::coro_rpc_client>::pool_config pool_conf{};
 #ifdef YLT_ENABLE_IBV
   if (conf.enable_ib) {
@@ -177,28 +181,83 @@ async_simple::coro::Lazy<std::error_code> request(const bench_config& conf) {
     std::string send_str(conf.send_data_len, 'A');
     std::string_view send_str_view(send_str);
     for (size_t i = 0; i < conf.max_request_count; i++) {
+      auto start = std::chrono::steady_clock::now();
       auto ec =
           co_await pool->send_request([&](coro_rpc::coro_rpc_client& client)
                                           -> async_simple::coro::Lazy<bool> {
             client.set_req_attachment(send_str_view);
-            auto start = std::chrono::steady_clock::now();
             auto result = co_await client.call<echo>();
             if (!result.has_value()) {
               ELOG_WARN << result.error().msg;
               co_return false;
             }
-            auto now = std::chrono::steady_clock::now();
-            g_latency.observe(
-                std::chrono::duration_cast<std::chrono::microseconds>(now -
-                                                                      start)
-                    .count());
-            g_throughput_count.fetch_add(send_str_view.length(),
-                                         std::memory_order_relaxed);
-            g_qps_count.fetch_add(1, std::memory_order_relaxed);
             co_return true;
           });
       if (!ec.has_value()) {
+        std::cout<<"BREAK"<<std::endl;
         break;
+      }
+      if (ec.value()) {
+        auto now = std::chrono::steady_clock::now();
+        g_latency.observe(
+            std::chrono::duration_cast<std::chrono::microseconds>(now -
+                                                                  start)
+                .count());
+        g_throughput_count.fetch_add(send_str_view.length(),
+                                      std::memory_order_relaxed);
+        g_qps_count.fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+  };
+  std::vector<async_simple::coro::Lazy<void>> works;
+  works.reserve(conf.client_concurrency);
+  for (size_t i = 0; i < conf.client_concurrency; i++) {
+    works.push_back(lazy());
+  }
+  co_await async_simple::coro::collectAll<async_simple::SignalType::Terminate>(
+      async_simple::coro::collectAll(std::move(works)), watcher(conf));
+
+  co_return std::error_code{};
+}
+
+async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config& conf) {
+  ELOG_INFO << "bench_config buffer size " << conf.buffer_size;
+  coro_io::client_pool<coro_rpc::coro_rpc_client>::pool_config pool_conf{};
+#ifdef YLT_ENABLE_IBV
+  if (conf.enable_ib) {
+    coro_io::ib_socket_t::config_t ib_conf{};
+    ib_conf.recv_buffer_cnt = conf.min_recv_buf_count;
+    ib_conf.cap.max_recv_wr = conf.max_recv_buf_count;
+    pool_conf.client_config.socket_config = ib_conf;
+  }
+#endif
+
+  auto pool = coro_io::client_pool<coro_rpc::coro_rpc_client>::create(
+      conf.url, pool_conf);
+  auto lazy = [pool, conf]() -> async_simple::coro::Lazy<void> {
+    std::string send_str(conf.send_data_len, 'A');
+    std::string_view send_str_view(send_str);
+    for (size_t i = 0; i < conf.max_request_count; i++) {
+      auto start = std::chrono::steady_clock::now();
+      auto ret =
+          co_await pool->send_request([&](coro_rpc::coro_rpc_client& client)
+                                          -> async_simple::coro::Lazy<async_simple::coro::Lazy<coro_rpc::async_rpc_result<std::string_view>>> {
+            auto result = co_await client.send_request_with_attachment<echo>(send_str_view);
+            co_return std::move(result);
+          });
+      if (!ret.has_value()) {
+        break;
+      }
+      auto result =co_await std::move(ret.value());
+      if (result.has_value()) {
+        auto now = std::chrono::steady_clock::now();
+        g_latency.observe(
+            std::chrono::duration_cast<std::chrono::microseconds>(now -
+                                                                  start)
+                .count());
+        g_throughput_count.fetch_add(send_str_view.length(),
+                                      std::memory_order_relaxed);
+        g_qps_count.fetch_add(1, std::memory_order_relaxed);
       }
     }
   };
@@ -293,6 +352,7 @@ int main(int argc, char** argv) {
   parser.add<uint32_t>("max_recv_buf_count", 'f', "min recieve buffer count",
                        false, 32);
   parser.add<bool>("use_client_pool", 'g', "use client pool", false, true);
+  parser.add<bool>("reuse_client_pool", 'h', "reuse client pool", false, false);
 
   parser.parse_check(argc, argv);
   auto conf = init_conf(parser);
@@ -334,7 +394,10 @@ int main(int argc, char** argv) {
   }
   else {
     std::cout << "will start client\n";
-    if (conf.use_client_pool) {
+    if (conf.reuse_client_pool) {
+      async_simple::coro::syncAwait(request_with_reuse(conf));
+    }
+    else if (conf.use_client_pool) {
       async_simple::coro::syncAwait(request(conf));
     }
     else {

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -360,7 +360,7 @@ int main(int argc, char** argv) {
   parser.add<uint32_t>("max_recv_buf_count", 'f', "min recieve buffer count",
                        false, 32);
   parser.add<bool>("use_client_pool", 'g', "use client pool", false, true);
-  parser.add<bool>("reuse_client_pool", 'h', "reuse client pool", false, false);
+  parser.add<bool>("reuse_client_pool", 'h', "reuse client pool", false, true);
 
   parser.parse_check(argc, argv);
   auto conf = init_conf(parser);

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -250,7 +250,7 @@ async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config&
           co_await pool->send_request([&](coro_rpc::coro_rpc_client& client)
                                           -> async_simple::coro::Lazy<async_simple::coro::Lazy<coro_rpc::async_rpc_result<std::string_view>>> {
             auto result = co_await client.send_request_with_attachment<echo>(send_str_view);
-            co_return co_await pool->client_reuse_limiter(std::move(result));
+            co_return co_await pool->client_reuse_limiter(std::move(result),                                               client);
           });
       if (ret.has_value()) {
         auto result = co_await std::move(ret.value());

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -179,10 +179,6 @@ async_simple::coro::Lazy<std::error_code> request(const bench_config& conf) {
     pool_conf.client_config.socket_config = ib_conf;
   }
 #endif
-  if (pool_conf.client_config.socket_config.index()==0) {
-    ELOG_WARN<<"enable tcp pipeline speedup";
-    std::get<coro_rpc::coro_rpc_client::tcp_config>(pool_conf.client_config.socket_config).enable_tcp_no_delay=false;
-  }
 
   auto pool = coro_io::client_pool<coro_rpc::coro_rpc_client>::create(
       conf.url, pool_conf);
@@ -241,10 +237,6 @@ async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config&
     pool_conf.client_config.socket_config = ib_conf;
   }
 #endif
-  if (pool_conf.client_config.socket_config.index()==0) {
-    ELOG_WARN<<"enable tcp pipeline speedup";
-    std::get<coro_rpc::coro_rpc_client::tcp_config>(pool_conf.client_config.socket_config).enable_tcp_no_delay=false;
-  }
 
   auto pool = coro_io::client_pool<coro_rpc::coro_rpc_client>::create(
       conf.url, pool_conf);

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -228,6 +228,7 @@ async_simple::coro::Lazy<std::error_code> request(const bench_config& conf) {
 async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config& conf) {
   ELOG_INFO << "bench_config buffer size " << conf.buffer_size;
   coro_io::client_pool<coro_rpc::coro_rpc_client>::pool_config pool_conf{};
+  pool_conf.max_connection=1024;
 #ifdef YLT_ENABLE_IBV
   if (conf.enable_ib) {
     coro_io::ib_socket_t::config_t ib_conf{};

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -179,6 +179,10 @@ async_simple::coro::Lazy<std::error_code> request(const bench_config& conf) {
     pool_conf.client_config.socket_config = ib_conf;
   }
 #endif
+  if (pool_conf.client_config.socket_config.index()==0) {
+    ELOG_WARN<<"enable tcp pipeline speedup";
+    std::get<coro_rpc::coro_rpc_client::tcp_config>(pool_conf.client_config.socket_config).enable_tcp_no_delay=false;
+  }
 
   auto pool = coro_io::client_pool<coro_rpc::coro_rpc_client>::create(
       conf.url, pool_conf);
@@ -237,9 +241,9 @@ async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config&
     pool_conf.client_config.socket_config = ib_conf;
   }
 #endif
-  if (pool_conf.client_config.socket_config==coro_rpc_client::tcp_config{}) {
-    ELOG_INFO<<"enable tcp pipeline speedup";
-    std::get<coro_rpc_client::tcp_config>(pool_conf.client_config.socket_config).enable_tcp_no_delay=false;
+  if (pool_conf.client_config.socket_config.index()==0) {
+    ELOG_WARN<<"enable tcp pipeline speedup";
+    std::get<coro_rpc::coro_rpc_client::tcp_config>(pool_conf.client_config.socket_config).enable_tcp_no_delay=false;
   }
 
   auto pool = coro_io::client_pool<coro_rpc::coro_rpc_client>::create(

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -1,5 +1,6 @@
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <system_error>
 #include <vector>
@@ -14,7 +15,9 @@
 #include "cmdline.h"
 #include "ylt/coro_io/coro_io.hpp"
 #include "ylt/coro_rpc/impl/coro_rpc_client.hpp"
+#include "ylt/coro_rpc/impl/errno.h"
 #include "ylt/coro_rpc/impl/protocol/coro_rpc_protocol.hpp"
+#include "ylt/util/tl/expected.hpp"
 
 struct bench_config {
   std::string url;
@@ -234,22 +237,40 @@ async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config&
 
   auto pool = coro_io::client_pool<coro_rpc::coro_rpc_client>::create(
       conf.url, pool_conf);
-  auto lazy = [pool, conf]() -> async_simple::coro::Lazy<void> {
+  std::atomic<uint64_t> cnter;
+  auto lazy = [pool, conf,&cnter]() -> async_simple::coro::Lazy<void> {
     std::string send_str(conf.send_data_len, 'A');
     std::string_view send_str_view(send_str);
     for (size_t i = 0; i < conf.max_request_count; i++) {
       auto start = std::chrono::steady_clock::now();
-      auto ret =
-          co_await pool->send_request([&](coro_rpc::coro_rpc_client& client)
-                                          -> async_simple::coro::Lazy<async_simple::coro::Lazy<coro_rpc::async_rpc_result<std::string_view>>> {
-            auto result = co_await client.send_request_with_attachment<echo>(send_str_view);
-            co_return std::move(result);
-          });
-      if (!ret.has_value()) {
-        break;
+      auto old_value = cnter.fetch_add(1,std::memory_order_acquire);
+      std::string_view result="";
+      if (old_value<32) {
+        auto ret =
+            co_await pool->send_request([&](coro_rpc::coro_rpc_client& client)
+                                            -> async_simple::coro::Lazy<async_simple::coro::Lazy<coro_rpc::async_rpc_result<std::string_view>>> {
+              auto result = co_await client.send_request_with_attachment<echo>(send_str_view);
+              co_return std::move(result);
+            });
+        if (ret.has_value()) {
+          result = (co_await std::move(ret.value()))->result();
+        }
       }
-      auto result =co_await std::move(ret.value());
-      if (result.has_value()) {
+      else {
+        auto ret =  co_await pool->send_request([&](coro_rpc::coro_rpc_client& client)
+                                          -> async_simple::coro::Lazy<std::string_view> {
+            client.set_req_attachment(send_str_view);
+            auto result = co_await client.call<echo>();
+            if (!result.has_value()) {
+              ELOG_WARN << result.error().msg;
+              co_return "";
+            }
+            co_return result.value();
+          });
+        result = ret.value_or("");
+      }
+      cnter.fetch_sub(1,std::memory_order_acquire);
+      if (result.size()) {
         auto now = std::chrono::steady_clock::now();
         g_latency.observe(
             std::chrono::duration_cast<std::chrono::microseconds>(now -
@@ -258,6 +279,9 @@ async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config&
         g_throughput_count.fetch_add(send_str_view.length(),
                                       std::memory_order_relaxed);
         g_qps_count.fetch_add(1, std::memory_order_relaxed);
+      }
+      else {
+        break;
       }
     }
   };

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -245,7 +245,7 @@ async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config&
       auto start = std::chrono::steady_clock::now();
       auto old_value = cnter.fetch_add(1,std::memory_order_acquire);
       std::string_view result="";
-      if (old_value<32) {
+      if (old_value>32) {
         auto ret =
             co_await pool->send_request([&](coro_rpc::coro_rpc_client& client)
                                             -> async_simple::coro::Lazy<async_simple::coro::Lazy<coro_rpc::async_rpc_result<std::string_view>>> {

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -247,10 +247,9 @@ async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config&
     for (size_t i = 0; i < conf.max_request_count; i++) {
       auto start = std::chrono::steady_clock::now();
       auto ret =
-          co_await pool->send_request([&](coro_rpc::coro_rpc_client& client)
-                                          -> async_simple::coro::Lazy<async_simple::coro::Lazy<coro_rpc::async_rpc_result<std::string_view>>> {
-            auto result = co_await client.send_request_with_attachment<echo>(send_str_view);
-            co_return co_await pool->client_reuse_limiter(std::move(result),                                               client);
+          co_await pool->send_request([&](coro_io::client_reuse_hint, coro_rpc::coro_rpc_client& client)
+                                         {
+            return client.send_request_with_attachment<echo>(send_str_view);
           });
       if (ret.has_value()) {
         auto result = co_await std::move(ret.value());

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -237,6 +237,10 @@ async_simple::coro::Lazy<std::error_code> request_with_reuse(const bench_config&
     pool_conf.client_config.socket_config = ib_conf;
   }
 #endif
+  if (pool_conf.client_config.socket_config==coro_rpc_client::tcp_config{}) {
+    ELOG_INFO<<"enable tcp pipeline speedup";
+    std::get<coro_rpc_client::tcp_config>(pool_conf.client_config.socket_config).enable_tcp_no_delay=false;
+  }
 
   auto pool = coro_io::client_pool<coro_rpc::coro_rpc_client>::create(
       conf.url, pool_conf);

--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -170,6 +170,7 @@ async_simple::coro::Lazy<void> watcher(const bench_config& conf) {
 async_simple::coro::Lazy<std::error_code> request(const bench_config& conf) {
   ELOG_INFO << "bench_config buffer size " << conf.buffer_size;
   coro_io::client_pool<coro_rpc::coro_rpc_client>::pool_config pool_conf{};
+  pool_conf.max_connection=1024;
 #ifdef YLT_ENABLE_IBV
   if (conf.enable_ib) {
     coro_io::ib_socket_t::config_t ib_conf{};

--- a/src/struct_pack/benchmark/CMakeLists.txt
+++ b/src/struct_pack/benchmark/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output/benchmark)
-#find_package(Protobuf QUIET)
+find_package(Protobuf QUIET)
 add_executable(struct_pack_benchmark benchmark.cpp no_op.cpp)
 if (Protobuf_FOUND)
     message(STATUS "Protobuf_FOUND: ${Protobuf_FOUND}")

--- a/src/struct_pack/benchmark/CMakeLists.txt
+++ b/src/struct_pack/benchmark/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output/benchmark)
-find_package(Protobuf QUIET)
+#find_package(Protobuf QUIET)
 add_executable(struct_pack_benchmark benchmark.cpp no_op.cpp)
 if (Protobuf_FOUND)
     message(STATUS "Protobuf_FOUND: ${Protobuf_FOUND}")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

## What is changing

## Example


client pool support connect reuse mode:
```cpp
      auto ret =
          co_await pool->send_request([&](coro_io::client_reuse_hint, coro_rpc::coro_rpc_client& client) {
            return client.send_request_with_attachment<echo>(send_str_view);
          });
      if (ret.has_value()) {
        auto result = co_await std::move(ret.value());
      }
```

user could set `reuse_limit` in client_pool config. pipeline sending will be enabled if concurrency>reuse_limit. default value is -1, which means limit=24 in rdma mode or limit=160 in tcp mode.
