### PR TITLE
[coro_rpc_client]fix for rpc const ref arg

### DIFF
--- a/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
+++ b/include/ylt/coro_rpc/impl/coro_rpc_client.hpp
@@ -776,22 +776,12 @@ class coro_rpc_client {
     constexpr bool has_conn_v = requires { typename First::return_type; };
     return util::get_args<has_conn_v, FuncArgs>();
   }
-  template <typename T, typename U>
-  static decltype(auto) add_const(U &&u) {
-    if constexpr (std::is_const_v<std::remove_reference_t<U>>) {
-      return struct_pack::detail::declval<const T>();
-    }
-    else {
-      return struct_pack::detail::declval<T>();
-    }
-  }
 
   template <typename... FuncArgs, typename Buffer, typename... Args>
   void pack_to_impl(Buffer &buffer, std::size_t offset, Args &&...args) {
     struct_pack::serialize_to_with_offset(
         buffer, offset,
-        std::forward<decltype(add_const<FuncArgs>(args))>(
-            (std::forward<Args>(args)))...);
+        std::forward<const FuncArgs>((std::forward<Args>(args)))...);
   }
 
   template <typename Tuple, size_t... Is, typename Buffer, typename... Args>

--- a/src/coro_rpc/tests/test_coro_rpc_client.cpp
+++ b/src/coro_rpc/tests/test_coro_rpc_client.cpp
@@ -193,6 +193,21 @@ std::string get_first_local_ip() {
   return "localhost";
 }
 
+void foo(const size_t& i) {}
+
+TEST_CASE("testing const & args") {
+  coro_rpc_server server(1, 8901);
+  server.register_handler<foo>();
+  auto res = server.async_start();
+  REQUIRE_MESSAGE(!res.hasResult(), "server start failed");
+
+  coro_rpc_client client{};
+  syncAwait(client.connect("127.0.0.1:8901"));
+  const int& i = 0;
+  auto ret = syncAwait(client.call<foo>(i));
+  CHECK(ret.has_value());
+}
+
 TEST_CASE("testing client with local ip") {
   coro_rpc_server server(1, 8901);
   server.register_handler<hello>();


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Fix const reference arguments for rpc client call.

## What is changing

## Example