### PR TITLE
[metric][coro_http] fix dynamic summary refresh & set default http body size to no limit

### DIFF
--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -1071,7 +1071,7 @@ class coro_http_server {
   std::function<async_simple::coro::Lazy<void>(coro_http_request &,
                                                coro_http_response &)>
       default_handler_ = nullptr;
-  int64_t max_http_body_len_ = MAX_HTTP_BODY_SIZE;
+  int64_t max_http_body_len_ = INT64_MAX;
 #ifdef INJECT_FOR_HTTP_SEVER_TEST
   bool write_failed_forever_ = false;
   bool read_failed_forever_ = false;

--- a/include/ylt/standalone/cinatra/define.h
+++ b/include/ylt/standalone/cinatra/define.h
@@ -279,8 +279,6 @@ inline std::unordered_map<std::string, std::string> g_content_type_map = {
 struct NonSSL {};
 struct SSL {};
 
-inline constexpr int64_t MAX_HTTP_BODY_SIZE = 4294967296;  // 4GB
-
 enum class time_format {
   http_format,
   utc_format,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

## What is changing

1. fix dynamic summary `max_age` time for refresh data not work
2. set default summary `max_age` time as 0 seconds (never refresh)
3. add test

## Example