### PR TITLE
[metric][fix] summary may segment fault by visit nullptr ,fix summary_impl::get_data() to avoid load unexpected data array.

### DIFF
--- a/include/ylt/metric/summary_impl.hpp
+++ b/include/ylt/metric/summary_impl.hpp
@@ -176,13 +176,14 @@ class summary_impl {
   };
 
   data_t& get_data() {
-    data_t* data = data_[frontend_data_index_];
+    auto index = frontend_data_index_.load();
+    data_t* data = data_[index];
     if (data == nullptr) [[unlikely]] {
       auto pointer = new data_t{};
-      if (!data_[frontend_data_index_].compare_exchange_strong(data, pointer)) {
+      if (!data_[index].compare_exchange_strong(data, pointer)) {
         delete pointer;
       }
-      return *data_[frontend_data_index_];
+      return *data_[index];
     }
     else {
       return *data;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

frontend_data_index_ may update by another thread, which may cause logic problem and return unexpected pointer.

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

add a local copy for index

## Example