### PR TITLE
[struct_pack][fix] fix error type calculate in is_triival_serializeab…

### DIFF
--- a/include/ylt/struct_pack/reflection.hpp
+++ b/include/ylt/struct_pack/reflection.hpp
@@ -834,6 +834,8 @@ struct memory_reader;
                                             ignore_compatible_field,parent_tag_>::value &&
                     ...);
       }
+    
+    public:
       static constexpr bool solve() {
         if constexpr (user_defined_serialization<T>) {
           return false;
@@ -893,8 +895,7 @@ struct memory_reader;
           return false;
       }
 
-    public:
-      static inline constexpr bool value = is_trivial_serializable::solve();
+      static inline constexpr bool value = is_trivial_serializable<std::remove_cv_t<T>,ignore_compatible_field,parent_tag>::solve();
   };
 
 }

--- a/src/struct_pack/tests/test_compile_time_calculate.cpp
+++ b/src/struct_pack/tests/test_compile_time_calculate.cpp
@@ -537,3 +537,23 @@ TEST_CASE("test fast varint tag") {
   static_assert(type_info3 != type_info4);
   static_assert(type_info1 == fast_varint_info);
 }
+
+struct int_key {
+  int kKey;
+  YLT_REFL(int_key, kKey);
+};
+
+struct int_key2 {
+  int kKey;
+};
+
+TEST_CASE("test const in trivial serializable") {
+  static_assert(!struct_pack::detail::is_trivial_serializable<
+                std::pair<int_key const, int>>::value);
+  static_assert(!struct_pack::detail::is_trivial_serializable<
+                std::pair<int_key, int>>::value);
+  static_assert(struct_pack::detail::is_trivial_serializable<
+                std::pair<int_key2 const, int>>::value);
+  static_assert(struct_pack::detail::is_trivial_serializable<
+                std::pair<int_key2, int>>::value);
+}


### PR DESCRIPTION
…le when struct contains a const field.

<!-- Thank you for your contribution! -->

## Why

Close #1074 


The type calculation code `is_trivial_serializable` forget remove const qualifier, which cause error type calculate result.

## What is changing

Add `remove_cv` for is_trivial_serializable

## Example