### PR TITLE
[ibverbs][fix] fix cmake error with ibverbs support enabled

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -60,7 +60,7 @@ if (YLT_ENABLE_IBV)
         link_libraries(-libverbs)
     else ()
         target_compile_definitions(${ylt_target_name} INTERFACE "YLT_ENABLE_IBV")
-        target_link_libraries(${ylt_target_name} -libverbs)
+        target_link_libraries(${ylt_target_name} INTERFACE -libverbs)
     endif ()
 endif ()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

Closes #1090 

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

add INTERFACE keyword in target_link_libraries. 
```
diff --git a/cmake/config.cmake b/cmake/config.cmake
index e960ad0..9904d3a 100644
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -60,7 +60,7 @@ if (YLT_ENABLE_IBV)
         link_libraries(-libverbs)
     else ()
         target_compile_definitions(${ylt_target_name} INTERFACE "YLT_ENABLE_IBV")
-        target_link_libraries(${ylt_target_name} -libverbs)
+        target_link_libraries(${ylt_target_name} INTERFACE -libverbs)
     endif ()
 endif ()

```

## Example
None