### PR TITLE
[ci] fix easylog/benchmark build

### DIFF
--- a/src/easylog/benchmark/main.cpp
+++ b/src/easylog/benchmark/main.cpp
@@ -59,7 +59,6 @@ void test_glog() {
   std::filesystem::remove("glog.txt");
   FLAGS_log_dir = ".";
   FLAGS_minloglevel = google::GLOG_INFO;
-  FLAGS_timestamp_in_logfile_name = false;
   google::SetLogDestination(google::INFO, "glog.txt");
   google::InitGoogleLogging("glog");
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

fix #1101 , the recommended OS ubuntu 22.04 and the default glog on it seems no FLAGS_timestamp_in_logfile_name

