### PR TITLE
[coro_http_client][feat]callback chunked stream

### DIFF
--- a/include/ylt/standalone/cinatra/coro_http_client.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_client.hpp
@@ -1487,6 +1487,8 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
     chunked_cb_ = std::move(cb);
   }
 
+  bool has_chunked_callback() const { return chunked_cb_ != nullptr; }
+
 #ifdef CINATRA_ENABLE_SSL
   void enable_sni_hostname(bool r) { need_set_sni_host_ = r; }
 #endif

--- a/src/coro_http/tests/test_coro_http_server.cpp
+++ b/src/coro_http/tests/test_coro_http_server.cpp
@@ -444,6 +444,7 @@ TEST_CASE("test llm chunked stream api") {
           }
           co_return;
         });
+    CHECK(client.has_chunked_callback());
     auto r = co_await client.async_post(uri, req_json, req_content_type::json);
     CHECK(r.status == 200);
     CHECK(has_finished);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Close https://github.com/alibaba/yalantinglibs/issues/1117

## What is changing

## Example

参考https://github.com/alibaba/yalantinglibs/blob/7ecd0e4045943e4932b7858b786c661bb5ffed47/src/coro_http/tests/test_coro_http_server.cpp#L437

测试代码用coro_http_server 实现了一个简单的llm http server。

client增加了一个chunked stream的回调函数用于分段接收来自服务端的chunked stream。


