### PR TITLE
[struct_pack] support disable outer brace brace in type info

### DIFF
--- a/include/ylt/struct_pack.hpp
+++ b/include/ylt/struct_pack.hpp
@@ -94,6 +94,18 @@ constexpr std::uint32_t get_type_code() {
 template <typename... Args>
 constexpr decltype(auto) get_type_literal() {
   static_assert(sizeof...(Args) > 0);
+#ifdef STRUCT_PACK_DISABLE_OUTER_BRACE
+  if constexpr (sizeof...(Args) == 1) {
+    using Types = decltype(detail::get_types<Args...>());
+    return detail::get_types_literal_without_outer_brace<Args..., Types>(
+        std::make_index_sequence<std::tuple_size_v<Types>>());
+  }
+  else {
+    return detail::get_types_literal_without_outer_brace<
+        std::tuple<detail::remove_cvref_t<Args>...>,
+        detail::remove_cvref_t<Args>...>();
+  }
+#else
   if constexpr (sizeof...(Args) == 1) {
     using Types = decltype(detail::get_types<Args...>());
     return detail::get_types_literal<Args..., Types>(
@@ -104,6 +116,7 @@ constexpr decltype(auto) get_type_literal() {
         std::tuple<detail::remove_cvref_t<Args>...>,
         detail::remove_cvref_t<Args>...>();
   }
+#endif
 }
 
 /*!

--- a/src/struct_pack/tests/test_disable_outer_brace.cpp
+++ b/src/struct_pack/tests/test_disable_outer_brace.cpp
@@ -1,0 +1,22 @@
+#define STRUCT_PACK_DISABLE_OUTER_BRACE
+#include <ylt/struct_pack.hpp>
+
+#include "doctest.h"
+
+using namespace struct_pack;
+
+struct hi {
+  struct hi2 {
+    std::string a;
+  } a;
+};
+TEST_CASE("test disable outer brace in type info") {
+  static_assert(struct_pack::get_type_code<int>() ==
+                struct_pack::get_type_code<std::tuple<int>>());
+  static_assert(struct_pack::get_type_code<int>() ==
+                struct_pack::get_type_code<std::tuple<int, compatible<int>>>());
+  constexpr auto str = struct_pack::get_type_literal<hi>();
+  constexpr auto str2 = struct_pack::get_type_literal<hi::hi2>();
+  static_assert(str.size() == 4);
+  static_assert(str2.size() == 2);
+}

--- a/website/docs/en/coro_rpc/coro_rpc_server.md
+++ b/website/docs/en/coro_rpc/coro_rpc_server.md
@@ -499,8 +499,6 @@ void client_oldapi_server_newapi_ret_void();
 std::tuple<std::monostate,struct_pack::compatible<int>>  client_newapi_server_oldapi_ret_void();
 ```
 
-> TODO: For client versions earlier than `2025/11/26`, add new parameters to a single parameter / single return value function will cause a validation error. This will be fixed later by manually specifying that the function uses the old validation value.
-
 ### Registration and Invocation of Member Functions
 
 coro_rpc supports registering and invoking member functions:

--- a/website/docs/en/struct_pack/struct_pack_tips.md
+++ b/website/docs/en/struct_pack/struct_pack_tips.md
@@ -23,7 +23,8 @@ struct_pack will save the data as little-endian even if the arch is big-endian. 
 | ----------- | ------------------ |
 | STRUCT_PACK_OPTIMIZE               | Allow more extremed loop unrolling to get better performance, but it cost more compile time.    |
 | STRUCT_PACK_ENABLE_UNPORTABLE_TYPE | Enable serialize unportable type, such as wchar_t/std::wstring/std::bitset. Deserialize them in other platform maybe an undefined bevaior. |
-| STRUCT_PACK_ENABLE_INT128 | Enable serialize __int128 and __uint128. Not all compiler support it.
+| STRUCT_PACK_ENABLE_INT128 | Enable serialize __int128 and __uint128. Not all compiler support it. |
+| STRUCT_PACK_DISABLE_OUTER_BRACE | Disable outer brace in type info format, It means that `std::tuple<T>` & `T` could be same type. |
 ## How to speed up serialization/deserialization
 1. use string_view instead of string, use span instead of vector/array.
 2. move trivial field to a standlone struct, so that struct_pack could copy it faster. 

--- a/website/docs/zh/coro_rpc/coro_rpc_server.md
+++ b/website/docs/zh/coro_rpc/coro_rpc_server.md
@@ -500,9 +500,6 @@ void client_oldapi_server_newapi_ret_void();
 std::tuple<std::monostate,struct_pack::compatible<int>>  client_newapi_server_oldapi_ret_void();
 ```
 
-> TODO: 自`2025/11/26`之前的老版本客户端在向单参数/单返回值函数添加新参数/新返回值时，会出现校验错误，后续将通过手动指定函数使用老版本校验值来修复这一问题。
-
-
 
 ### 成员函数的注册与调用 
 

--- a/website/docs/zh/struct_pack/struct_pack_tips.md
+++ b/website/docs/zh/struct_pack/struct_pack_tips.md
@@ -24,7 +24,9 @@ struct_pack即使在大端架构下，也会将数据保存为小端格式。当
 | ----------- | ------------------ |
 | STRUCT_PACK_OPTIMIZE               |增加模板实例化的数量，通过牺牲编译时间和二进制体积来换取更好的性能    |
 |STRUCT_PACK_ENABLE_UNPORTABLE_TYPE |允许序列化无法跨平台的类型，如wchar_t/std::wstring/std::bitset，请注意，这些类型序列化出的二进制数据可能无法正常的在其他平台下反序列化|
-| STRUCT_PACK_ENABLE_INT128 | 允许序列化128位整数，包括__uint128和__int128类型。请注意，只有部分编译器在部分架构下支持该类型。
+| STRUCT_PACK_ENABLE_INT128 | 允许序列化128位整数，包括__uint128和__int128类型。请注意，只有部分编译器在部分架构下支持该类型。|
+| STRUCT_PACK_DISABLE_OUTER_BRACE | 类型信息将不包含最外侧的括号, 这意味着`std::tuple<T>` 和 `T` 将被认为是相同的类型。|
+
 ## 如何让序列化or反序列化更加高效
 1. 考虑使用string_view代替string, 使用span代替vector/array；
 2. 把平凡字段封装到一个单独的结构体中，优化拷贝速度；


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

Add marco `STRUCT_PACK_DISABLE_OUTER_BRACE` to disable outer brace in struct_pack meta info.

It means that `std::tuple<T>` & `T` could be same type in struct_pack type system when the marco is enabled.

## What is changing

## Example