### PR TITLE
Add support for direct I/O in file operations

### DIFF
--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -124,15 +124,16 @@ constexpr inline flags to_flags(std::ios::ios_base::openmode mode) {
 #if defined(ASIO_HAS_FILE)
 template <bool seq, typename File, typename Executor>
 inline bool open_native_async_file(File &file, Executor &executor,
-                                   std::string_view filepath,
-                                   flags open_flags, bool use_direct_io = false) {
+                                   std::string_view filepath, flags open_flags,
+                                   bool use_direct_io = false) {
   if (file && file->is_open()) {
     return true;
   }
 
   try {
-    asio::file_base::flags asio_flags = static_cast<asio::file_base::flags>(open_flags);
-    
+    asio::file_base::flags asio_flags =
+        static_cast<asio::file_base::flags>(open_flags);
+
     if (use_direct_io) {
 #if defined(ASIO_WINDOWS)
 #elif defined(__linux__)
@@ -140,7 +141,7 @@ inline bool open_native_async_file(File &file, Executor &executor,
           static_cast<int>(asio_flags) | O_DIRECT);
 #endif
     }
-    
+
     if constexpr (seq) {
       file = std::make_shared<asio::stream_file>(
           executor.get_asio_executor(), std::string(filepath), asio_flags);
@@ -149,7 +150,7 @@ inline bool open_native_async_file(File &file, Executor &executor,
       file = std::make_shared<asio::random_access_file>(
           executor.get_asio_executor(), std::string(filepath), asio_flags);
     }
-    
+
     // On macOS, use F_NOCACHE as an alternative to O_DIRECT
     if (use_direct_io && file && file->is_open()) {
 #if defined(__APPLE__) || defined(__MACH__)
@@ -423,8 +424,8 @@ class basic_random_coro_file {
     open(filepath, open_flags);
   }
 
-  bool open(std::string_view filepath,
-            std::ios::ios_base::openmode open_flags, bool use_direct_io = false) {
+  bool open(std::string_view filepath, std::ios::ios_base::openmode open_flags,
+            bool use_direct_io = false) {
     file_path_ = std::string{filepath};
     if constexpr (execute_type == execution_type::thread_pool) {
       return open_fd(filepath, to_flags(open_flags), use_direct_io);
@@ -538,7 +539,8 @@ class basic_random_coro_file {
   std::string_view file_path() const { return file_path_; }
 
  private:
-  bool open_fd(std::string_view filepath, int open_flags, bool use_direct_io = false) {
+  bool open_fd(std::string_view filepath, int open_flags,
+               bool use_direct_io = false) {
     if (prw_random_file_) {
       return true;
     }

--- a/src/coro_io/tests/test_corofile.cpp
+++ b/src/coro_io/tests/test_corofile.cpp
@@ -1001,8 +1001,9 @@ void test_direct_io_read_write(std::string_view filename) {
 
   std::error_code write_ec;
   size_t bytes_written;
-  std::tie(write_ec, bytes_written) = async_simple::coro::syncAwait(
-      file.async_write_at(aligned_offset, std::string_view(buf, aligned_read_size)));
+  std::tie(write_ec, bytes_written) =
+      async_simple::coro::syncAwait(file.async_write_at(
+          aligned_offset, std::string_view(buf, aligned_read_size)));
 
   CHECK(!write_ec);
   CHECK(bytes_written == aligned_read_size);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

support direct only mode read on lunux

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing

pass O_DIRECT flag to fd inlcude native and boost file


## Example

```
coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> file(executor);
bool opened = file.open(filename, std::ios::in | std::ios::binary, true);

```