### PR TITLE
fix: add missing #include <csignal> in coro_io.hpp

### DIFF
--- a/include/ylt/coro_io/coro_io.hpp
+++ b/include/ylt/coro_io/coro_io.hpp
@@ -22,6 +22,7 @@
 #include <async_simple/coro/SyncAwait.h>
 
 #include <atomic>
+#include <csignal>
 #include <cstddef>
 #include <cstdint>
 #include <memory>


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why

coro_io.hpp uses std::signal(), SIGPIPE and SIG_IGN (line 769, inside #ifdef __linux__) but does not include <csignal>. When no other transitively-included header happens to bring in <csignal>, compilation fails.

This was discovered while building other library which depends on yalantinglibs. The full error log:

```
/usr/local/include/ylt/coro_io/coro_io.hpp: In lambda function:
/usr/local/include/ylt/coro_io/coro_io.hpp:769:8: error: 'signal' is not a member of 'std'
  769 |   std::signal(SIGPIPE, SIG_IGN);
      |        ^~~~~~
/usr/local/include/ylt/coro_io/coro_io.hpp:769:15: error: 'SIGPIPE' was not declared in this scope
  769 |   std::signal(SIGPIPE, SIG_IGN);
      |               ^~~~~~~
/usr/local/include/ylt/coro_io/coro_io.hpp:769:24: error: 'SIG_IGN' was not declared in this scope
  769 |   std::signal(SIGPIPE, SIG_IGN);
      |                        ^~~~~~~
```

The pipe_signal_handler lambda inside #ifdef __linux__ calls std::signal(SIGPIPE, SIG_IGN), which requires <csignal>. Previously this worked by accident because some other header in the include chain transitively pulled in <csignal>. When the downstream project's include order differs, this implicit dependency breaks.

## What is changing

Add #include <csignal> to coro_io.hpp.