### PR TITLE
fix template_string wrong MSVC workaround

### DIFF
--- a/include/ylt/reflection/template_string.hpp
+++ b/include/ylt/reflection/template_string.hpp
@@ -34,7 +34,8 @@ inline constexpr std::string_view type_string() {
   constexpr size_t prefix_length = sample.find("int");
   constexpr std::string_view str = get_raw_name<T>();
   constexpr size_t suffix_length = sample.size() - prefix_length - 3;
-  auto name = str.substr(prefix_length, str.size() - prefix_length - suffix_length);
+  auto name =
+      str.substr(prefix_length, str.size() - prefix_length - suffix_length);
 #if defined(_MSC_VER) && !defined(__clang__)
   // remove msvc specific class/struct/union/enum prefix
   for (std::string_view prefix : {"class ", "struct ", "union ", "enum "}) {
@@ -108,7 +109,7 @@ constexpr std::pair<bool, std::string_view> try_get_enum_name() {
 // value
 template <typename E, std::int64_t... Is>
 constexpr inline auto get_enum_arr(
-    const std::integer_sequence<std::int64_t, Is...> &) {
+    const std::integer_sequence<std::int64_t, Is...>&) {
   constexpr std::size_t N = sizeof...(Is);
   std::array<std::string_view, N> enum_names = {};
   std::array<E, N> enum_values = {};
@@ -126,24 +127,24 @@ constexpr inline auto get_enum_arr(
   return std::make_tuple(num, enum_values, enum_names);
 }
 
-template <std::size_t N, const std::array<int, N> &arr, size_t... Is>
-constexpr auto array_to_seq(const std::index_sequence<Is...> &) {
+template <std::size_t N, const std::array<int, N>& arr, size_t... Is>
+constexpr auto array_to_seq(const std::index_sequence<Is...>&) {
   return std::integer_sequence<std::int64_t, arr[Is]...>();
 }
 
 // convert array to map
 template <typename E, size_t N, size_t... Is>
 constexpr inline auto get_enum_to_str_map(
-    const std::array<std::string_view, N> &enum_names,
-    const std::array<E, N> &enum_values, const std::index_sequence<Is...> &) {
+    const std::array<std::string_view, N>& enum_names,
+    const std::array<E, N>& enum_values, const std::index_sequence<Is...>&) {
   return frozen::unordered_map<E, frozen::string, sizeof...(Is)>{
       {enum_values[Is], enum_names[Is]}...};
 }
 
 template <typename E, size_t N, size_t... Is>
 constexpr inline auto get_str_to_enum_map(
-    const std::array<std::string_view, N> &enum_names,
-    const std::array<E, N> &enum_values, const std::index_sequence<Is...> &) {
+    const std::array<std::string_view, N>& enum_names,
+    const std::array<E, N>& enum_values, const std::index_sequence<Is...>&) {
   return frozen::unordered_map<frozen::string, E, sizeof...(Is)>{
       {enum_names[Is], enum_values[Is]}...};
 }
@@ -161,7 +162,7 @@ template <bool str_to_enum, typename E>
 constexpr inline auto get_enum_map() {
 #if defined(__clang__) || defined(_MSC_VER) || \
     (defined(__GNUC__) && __GNUC__ > 8)
-  constexpr auto &arr = enum_value<E>::value;
+  constexpr auto& arr = enum_value<E>::value;
   constexpr auto arr_size = arr.size();
   if constexpr (arr_size > 0) {
     // the user has defined a specialization template

--- a/include/ylt/reflection/template_string.hpp
+++ b/include/ylt/reflection/template_string.hpp
@@ -36,8 +36,8 @@ inline constexpr std::string_view type_string() {
   constexpr size_t suffix_length = sample.size() - prefix_length - 3;
   auto name = str.substr(prefix_length, str.size() - prefix_length - suffix_length);
 #if defined(_MSC_VER) && !defined(__clang__)
-  // remove msvc specific class/struct/union/enum prefix, enum struct/class must be before enum
-  for (std::string_view prefix : {"class ", "struct ", "union ", "enum class ", "enum struct ", "enum "}) {
+  // remove msvc specific class/struct/union/enum prefix
+  for (std::string_view prefix : {"class ", "struct ", "union ", "enum "}) {
     if (name.starts_with(prefix)) {
       name.remove_prefix(prefix.size());
       break;

--- a/include/ylt/reflection/template_string.hpp
+++ b/include/ylt/reflection/template_string.hpp
@@ -34,14 +34,13 @@ inline constexpr std::string_view type_string() {
   constexpr size_t prefix_length = sample.find("int");
   constexpr std::string_view str = get_raw_name<T>();
   constexpr size_t suffix_length = sample.size() - prefix_length - 3;
-  constexpr auto name =
-      str.substr(prefix_length, str.size() - prefix_length - suffix_length);
-#if defined(_MSC_VER)
-  constexpr size_t space_pos = name.find(" ");
-  if constexpr (space_pos != std::string_view::npos) {
-    constexpr auto prefix = name.substr(0, space_pos);
-    if constexpr (prefix != "const" && prefix != "volatile") {
-      return name.substr(space_pos + 1);
+  auto name = str.substr(prefix_length, str.size() - prefix_length - suffix_length);
+#if defined(_MSC_VER) && !defined(__clang__)
+  // remove msvc specific class/struct/union/enum prefix, enum struct/class must be before enum
+  for (std::string_view prefix : {"class ", "struct ", "union ", "enum class ", "enum struct ", "enum "}) {
+    if (name.starts_with(prefix)) {
+      name.remove_prefix(prefix.size());
+      break;
     }
   }
 #endif

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -470,12 +470,25 @@ namespace test_type_string {
 struct struct_test {};
 class class_test {};
 union union_test {};
+enum plain_enum { pe_a, pe_b };
+enum class scoped_enum { a, b };
+enum struct scoped_enum_struct { a, b };
+struct class_like {};    // name starts with "class", not the keyword
+struct structural {};    // name starts with "struct", not the keyword
+union union_attr {};     // name starts with "union", not the keyword
 }  // namespace test_type_string
 
 TEST_CASE("test type_string") {
   CHECK(type_string<int>() == "int");
   CHECK(type_string<const int>() == "const int");
   CHECK(type_string<volatile int>() == "volatile int");
+  CHECK(type_string<unsigned int>() == "unsigned int");
+  CHECK(type_string<long long>() == "long long");
+  CHECK(type_string<long double>() == "long double");
+  CHECK(type_string<const unsigned int>() == "const unsigned int");
+  CHECK(type_string<const long long>() == "const long long");
+  CHECK(type_string<const long double>() == "const long double");
+  CHECK(type_string<const volatile int>() == "const volatile int");
 
 #if defined(__clang__)
   CHECK(type_string<int&>() == "int &");
@@ -506,6 +519,31 @@ TEST_CASE("test type_string") {
         "test_type_string::union_test");
   CHECK(type_string<const test_type_string::union_test>() ==
         "const union test_type_string::union_test");
+  CHECK(type_string<test_type_string::plain_enum>() ==
+        "test_type_string::plain_enum");
+  CHECK(type_string<const test_type_string::plain_enum>() ==
+        "const enum test_type_string::plain_enum");
+  CHECK(type_string<test_type_string::scoped_enum>() ==
+        "test_type_string::scoped_enum");
+  CHECK(type_string<const test_type_string::scoped_enum>() ==
+        "const enum class test_type_string::scoped_enum");
+  CHECK(type_string<test_type_string::scoped_enum_struct>() ==
+        "test_type_string::scoped_enum_struct");
+  CHECK(type_string<const test_type_string::scoped_enum_struct>() ==
+        "const enum struct test_type_string::scoped_enum_struct");
+  // types whose names start with a keyword prefix (space-based matching)
+  CHECK(type_string<test_type_string::class_like>() ==
+        "test_type_string::class_like");
+  CHECK(type_string<const test_type_string::class_like>() ==
+        "const struct test_type_string::class_like");
+  CHECK(type_string<test_type_string::structural>() ==
+        "test_type_string::structural");
+  CHECK(type_string<const test_type_string::structural>() ==
+        "const struct test_type_string::structural");
+  CHECK(type_string<test_type_string::union_attr>() ==
+        "test_type_string::union_attr");
+  CHECK(type_string<const test_type_string::union_attr>() ==
+        "const union test_type_string::union_attr");
 #else
   CHECK(type_string<test_type_string::struct_test>() ==
         "test_type_string::struct_test");
@@ -519,6 +557,30 @@ TEST_CASE("test type_string") {
         "test_type_string::union_test");
   CHECK(type_string<const test_type_string::union_test>() ==
         "const test_type_string::union_test");
+  CHECK(type_string<test_type_string::plain_enum>() ==
+        "test_type_string::plain_enum");
+  CHECK(type_string<const test_type_string::plain_enum>() ==
+        "const test_type_string::plain_enum");
+  CHECK(type_string<test_type_string::scoped_enum>() ==
+        "test_type_string::scoped_enum");
+  CHECK(type_string<const test_type_string::scoped_enum>() ==
+        "const test_type_string::scoped_enum");
+  CHECK(type_string<test_type_string::scoped_enum_struct>() ==
+        "test_type_string::scoped_enum_struct");
+  CHECK(type_string<const test_type_string::scoped_enum_struct>() ==
+        "const test_type_string::scoped_enum_struct");
+  CHECK(type_string<test_type_string::class_like>() ==
+        "test_type_string::class_like");
+  CHECK(type_string<const test_type_string::class_like>() ==
+        "const test_type_string::class_like");
+  CHECK(type_string<test_type_string::structural>() ==
+        "test_type_string::structural");
+  CHECK(type_string<const test_type_string::structural>() ==
+        "const test_type_string::structural");
+  CHECK(type_string<test_type_string::union_attr>() ==
+        "test_type_string::union_attr");
+  CHECK(type_string<const test_type_string::union_attr>() ==
+        "const test_type_string::union_attr");
 #endif
 }
 

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -99,8 +99,7 @@ TEST_CASE("test member value") {
     ((out << "name: " << arr[Is] << ", value: " << std::get<Is>(ref_tp)
           << "\n"),
      ...);
-  }
-  (std::make_index_sequence<arr.size()>{});
+  }(std::make_index_sequence<arr.size()>{});
 
   std::string result = out.str();
   std::cout << out.str();
@@ -473,9 +472,9 @@ union union_test {};
 enum plain_enum { pe_a, pe_b };
 enum class scoped_enum { a, b };
 enum struct scoped_enum_struct { a, b };
-struct class_like {};    // name starts with "class", not the keyword
-struct structural {};    // name starts with "struct", not the keyword
-union union_attr {};     // name starts with "union", not the keyword
+struct class_like {};  // name starts with "class", not the keyword
+struct structural {};  // name starts with "struct", not the keyword
+union union_attr {};   // name starts with "union", not the keyword
 }  // namespace test_type_string
 
 TEST_CASE("test type_string") {

--- a/src/reflection/tests/test_reflection.cpp
+++ b/src/reflection/tests/test_reflection.cpp
@@ -483,12 +483,9 @@ TEST_CASE("test type_string") {
   CHECK(type_string<const int>() == "const int");
   CHECK(type_string<volatile int>() == "volatile int");
   CHECK(type_string<unsigned int>() == "unsigned int");
-  CHECK(type_string<long long>() == "long long");
   CHECK(type_string<long double>() == "long double");
   CHECK(type_string<const unsigned int>() == "const unsigned int");
-  CHECK(type_string<const long long>() == "const long long");
   CHECK(type_string<const long double>() == "const long double");
-  CHECK(type_string<const volatile int>() == "const volatile int");
 
 #if defined(__clang__)
   CHECK(type_string<int&>() == "int &");
@@ -526,11 +523,11 @@ TEST_CASE("test type_string") {
   CHECK(type_string<test_type_string::scoped_enum>() ==
         "test_type_string::scoped_enum");
   CHECK(type_string<const test_type_string::scoped_enum>() ==
-        "const enum class test_type_string::scoped_enum");
+        "const enum test_type_string::scoped_enum");
   CHECK(type_string<test_type_string::scoped_enum_struct>() ==
         "test_type_string::scoped_enum_struct");
   CHECK(type_string<const test_type_string::scoped_enum_struct>() ==
-        "const enum struct test_type_string::scoped_enum_struct");
+        "const enum test_type_string::scoped_enum_struct");
   // types whose names start with a keyword prefix (space-based matching)
   CHECK(type_string<test_type_string::class_like>() ==
         "test_type_string::class_like");


### PR DESCRIPTION
https://github.com/qicosmos/iguana/pull/344 去掉了template_string的MSVC的前缀，当时没发现，对`long double` `unsigned int` 这类的直接通过找空格来裁剪是有问题的，改成了显式的判断前缀。

注意对`long long`来说还是有问题的：
```cpp
ERROR: CHECK( type_string<long long>() == "long long" ) is NOT correct!
  values: CHECK( __int64 == long long )
```
`enum` `enum class` `enum struct`的输出则都是·`enum`前缀