### PR TITLE
fix: enable dual-stack IPv4/IPv6 listening on Linux

### DIFF
--- a/include/ylt/coro_io/listen_endpoint.hpp
+++ b/include/ylt/coro_io/listen_endpoint.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "asio/error_code.hpp"
+#include "asio/ip/address.hpp"
+#include "asio/ip/tcp.hpp"
+#include "asio/ip/v6_only.hpp"
+
+namespace coro_io::detail {
+
+// Resolve a string address into a TCP endpoint.
+// - If `address` is a numeric IP literal (e.g. "::", "0.0.0.0", "127.0.0.1"),
+//   it is parsed directly via `asio::ip::make_address` to avoid the ambiguity
+//   of `getaddrinfo()` on different glibc versions / container environments.
+// - Otherwise (e.g. "localhost"), falls back to `asio::ip::tcp::resolver`.
+//
+// On success `ec` is cleared and the resulting endpoint is returned.
+// On failure `ec` carries the resolver error and `std::nullopt` is returned.
+template <typename Executor>
+inline std::optional<asio::ip::tcp::endpoint> resolve_listen_endpoint(
+    const Executor& executor, const std::string& address, uint16_t port,
+    asio::error_code& ec) {
+  using asio::ip::tcp;
+
+  auto addr = asio::ip::make_address(address, ec);
+  if (!ec) {
+    return tcp::endpoint(addr, port);
+  }
+
+  ec.clear();
+  tcp::resolver resolver(executor);
+  auto it = resolver.resolve(
+      tcp::resolver::query(address, std::to_string(port)), ec);
+  if (ec || it == tcp::resolver::iterator{}) {
+    return std::nullopt;
+  }
+
+  return it->endpoint();
+}
+
+// Disable IPV6_V6ONLY on a TCP acceptor so that an IPv6 socket also accepts
+// IPv4-mapped connections (i.e. dual-stack listening).
+//
+// Only applied when the endpoint protocol is IPv6; for IPv4 endpoints this is
+// a no-op. The returned `error_code` is non-zero only when the socket option
+// cannot be set (e.g. on platforms that disallow toggling V6ONLY at runtime).
+// Callers are expected to log a warning on failure rather than abort, since
+// the listen socket can still serve IPv6 connections.
+inline asio::error_code set_ipv6_only_false(
+    asio::ip::tcp::acceptor& acceptor,
+    const asio::ip::tcp::endpoint& endpoint) {
+  asio::error_code ec;
+  if (endpoint.protocol() == asio::ip::tcp::v6()) {
+    acceptor.set_option(asio::ip::v6_only(false), ec);
+  }
+  return ec;
+}
+
+}  // namespace coro_io::detail

--- a/include/ylt/coro_io/listen_endpoint.hpp
+++ b/include/ylt/coro_io/listen_endpoint.hpp
@@ -32,8 +32,8 @@ inline std::optional<asio::ip::tcp::endpoint> resolve_listen_endpoint(
 
   ec.clear();
   tcp::resolver resolver(executor);
-  auto it = resolver.resolve(
-      tcp::resolver::query(address, std::to_string(port)), ec);
+  auto it =
+      resolver.resolve(tcp::resolver::query(address, std::to_string(port)), ec);
   if (ec || it == tcp::resolver::iterator{}) {
     return std::nullopt;
   }

--- a/include/ylt/coro_io/server_acceptor.hpp
+++ b/include/ylt/coro_io/server_acceptor.hpp
@@ -3,14 +3,13 @@
 #include <async_simple/coro/Lazy.h>
 
 #include <asio/ip/tcp.hpp>
-#include <asio/ip/v6_only.hpp>
 #include <charconv>
 #include <cstdint>
 #include <optional>
 #include <string>
 #include <system_error>
 
-#include "asio/ip/address.hpp"
+#include "listen_endpoint.hpp"
 #include "socket_wrapper.hpp"
 #include "ylt/coro_io/coro_io.hpp"
 #include "ylt/coro_io/io_context_pool.hpp"
@@ -83,26 +82,15 @@ struct tcp_server_acceptor : public server_acceptor_base {
     using asio::ip::tcp;
     asio::error_code ec;
 
-    asio::ip::tcp::endpoint endpoint;
-    auto addr = asio::ip::make_address(address_, ec);
-    if (!ec) {
-      endpoint = tcp::endpoint(addr, port_);
-    }
-    else {
-      ec.clear();
-      asio::ip::tcp::resolver::query query(address_, std::to_string(port_));
-      asio::ip::tcp::resolver resolver(acceptor_->get_executor());
-      asio::ip::tcp::resolver::iterator it = resolver.resolve(query, ec);
-      asio::ip::tcp::resolver::iterator it_end;
-      if (ec || it == it_end) {
-        ELOG_ERROR << "resolve address " << address_
-                   << " error: " << ec.message();
-        return listen_errc::bad_address;
-      }
-      endpoint = it->endpoint();
+    auto endpoint = detail::resolve_listen_endpoint(
+        acceptor_->get_executor(), address_, port_, ec);
+    if (!endpoint) {
+      ELOG_ERROR << "resolve address " << address_
+                 << " error: " << ec.message();
+      return listen_errc::bad_address;
     }
 
-    acceptor_->open(endpoint.protocol(), ec);
+    acceptor_->open(endpoint->protocol(), ec);
     if (ec) {
       ELOG_ERROR << "open failed, error: " << ec.message();
       return listen_errc::open_error;
@@ -110,14 +98,11 @@ struct tcp_server_acceptor : public server_acceptor_base {
 #ifdef __GNUC__
     acceptor_->set_option(tcp::acceptor::reuse_address(true), ec);
 #endif
-    if (endpoint.protocol() == tcp::v6()) {
-      acceptor_->set_option(asio::ip::v6_only(false), ec);
-      if (ec) {
-        ELOG_WARN << "set v6_only(false) failed: " << ec.message();
-        ec.clear();
-      }
+    if (auto opt_ec = detail::set_ipv6_only_false(*acceptor_, *endpoint);
+        opt_ec) {
+      ELOG_WARN << "set v6_only(false) failed: " << opt_ec.message();
     }
-    acceptor_->bind(endpoint, ec);
+    acceptor_->bind(*endpoint, ec);
     if (ec) {
       ELOG_ERROR << "bind port " << port_ << " error: " << ec.message();
       acceptor_->cancel(ec);

--- a/include/ylt/coro_io/server_acceptor.hpp
+++ b/include/ylt/coro_io/server_acceptor.hpp
@@ -82,8 +82,8 @@ struct tcp_server_acceptor : public server_acceptor_base {
     using asio::ip::tcp;
     asio::error_code ec;
 
-    auto endpoint = detail::resolve_listen_endpoint(
-        acceptor_->get_executor(), address_, port_, ec);
+    auto endpoint = detail::resolve_listen_endpoint(acceptor_->get_executor(),
+                                                    address_, port_, ec);
     if (!endpoint) {
       ELOG_ERROR << "resolve address " << address_
                  << " error: " << ec.message();

--- a/include/ylt/coro_io/server_acceptor.hpp
+++ b/include/ylt/coro_io/server_acceptor.hpp
@@ -3,6 +3,7 @@
 #include <async_simple/coro/Lazy.h>
 
 #include <asio/ip/tcp.hpp>
+#include <asio/ip/v6_only.hpp>
 #include <charconv>
 #include <cstdint>
 #include <optional>
@@ -81,18 +82,26 @@ struct tcp_server_acceptor : public server_acceptor_base {
     ELOG_INFO << "begin to listen";
     using asio::ip::tcp;
     asio::error_code ec;
-    asio::ip::tcp::resolver::query query(address_, std::to_string(port_));
-    asio::ip::tcp::resolver resolver(acceptor_->get_executor());
-    asio::ip::tcp::resolver::iterator it = resolver.resolve(query, ec);
 
-    asio::ip::tcp::resolver::iterator it_end;
-    if (ec || it == it_end) {
-      ELOG_ERROR << "resolve address " << address_
-                 << " error: " << ec.message();
-      return listen_errc::bad_address;
+    asio::ip::tcp::endpoint endpoint;
+    auto addr = asio::ip::make_address(address_, ec);
+    if (!ec) {
+      endpoint = tcp::endpoint(addr, port_);
+    }
+    else {
+      ec.clear();
+      asio::ip::tcp::resolver::query query(address_, std::to_string(port_));
+      asio::ip::tcp::resolver resolver(acceptor_->get_executor());
+      asio::ip::tcp::resolver::iterator it = resolver.resolve(query, ec);
+      asio::ip::tcp::resolver::iterator it_end;
+      if (ec || it == it_end) {
+        ELOG_ERROR << "resolve address " << address_
+                   << " error: " << ec.message();
+        return listen_errc::bad_address;
+      }
+      endpoint = it->endpoint();
     }
 
-    auto endpoint = it->endpoint();
     acceptor_->open(endpoint.protocol(), ec);
     if (ec) {
       ELOG_ERROR << "open failed, error: " << ec.message();
@@ -101,6 +110,13 @@ struct tcp_server_acceptor : public server_acceptor_base {
 #ifdef __GNUC__
     acceptor_->set_option(tcp::acceptor::reuse_address(true), ec);
 #endif
+    if (endpoint.protocol() == tcp::v6()) {
+      acceptor_->set_option(asio::ip::v6_only(false), ec);
+      if (ec) {
+        ELOG_WARN << "set v6_only(false) failed: " << ec.message();
+        ec.clear();
+      }
+    }
     acceptor_->bind(endpoint, ec);
     if (ec) {
       ELOG_ERROR << "bind port " << port_ << " error: " << ec.message();

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -757,7 +757,8 @@ class coro_http_server {
 #ifdef __GNUC__
     acceptor_.set_option(tcp::acceptor::reuse_address(true), ec);
 #endif
-    if (auto opt_ec = coro_io::detail::set_ipv6_only_false(acceptor_, *endpoint);
+    if (auto opt_ec =
+            coro_io::detail::set_ipv6_only_false(acceptor_, *endpoint);
         opt_ec) {
       CINATRA_LOG_WARNING << "set v6_only(false) failed: " << opt_ec.message();
     }

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "asio/ip/v6_only.hpp"
 #include "cinatra/coro_http_client.hpp"
 #include "cinatra/coro_http_response.hpp"
 #include "cinatra/coro_http_router.hpp"
@@ -736,21 +737,28 @@ class coro_http_server {
     using asio::ip::tcp;
     asio::error_code ec;
 
-    asio::ip::tcp::resolver::query query(address_, std::to_string(port_));
-    asio::ip::tcp::resolver resolver(acceptor_.get_executor());
-    asio::ip::tcp::resolver::iterator it = resolver.resolve(query, ec);
-
-    asio::ip::tcp::resolver::iterator it_end;
-    if (ec || it == it_end) {
-      CINATRA_LOG_ERROR << "bad address: " << address_
-                        << " error: " << ec.message();
-      if (ec) {
-        return ec;
+    asio::ip::tcp::endpoint endpoint;
+    auto addr = asio::ip::make_address(address_, ec);
+    if (!ec) {
+      endpoint = tcp::endpoint(addr, port_);
+    }
+    else {
+      ec.clear();
+      asio::ip::tcp::resolver::query query(address_, std::to_string(port_));
+      asio::ip::tcp::resolver resolver(acceptor_.get_executor());
+      asio::ip::tcp::resolver::iterator it = resolver.resolve(query, ec);
+      asio::ip::tcp::resolver::iterator it_end;
+      if (ec || it == it_end) {
+        CINATRA_LOG_ERROR << "invalid address: " << address_
+                          << " error: " << ec.message();
+        if (ec) {
+          return ec;
+        }
+        return std::make_error_code(std::errc::address_not_available);
       }
-      return std::make_error_code(std::errc::address_not_available);
+      endpoint = it->endpoint();
     }
 
-    auto endpoint = it->endpoint();
     acceptor_.open(endpoint.protocol(), ec);
     if (ec) {
       CINATRA_LOG_ERROR << "acceptor open failed"
@@ -760,6 +768,13 @@ class coro_http_server {
 #ifdef __GNUC__
     acceptor_.set_option(tcp::acceptor::reuse_address(true), ec);
 #endif
+    if (endpoint.protocol() == tcp::v6()) {
+      acceptor_.set_option(asio::ip::v6_only(false), ec);
+      if (ec) {
+        CINATRA_LOG_WARNING << "set v6_only(false) failed: " << ec.message();
+        ec.clear();
+      }
+    }
     acceptor_.bind(endpoint, ec);
     if (ec) {
       CINATRA_LOG_ERROR << "bind port: " << port_ << " error: " << ec.message();

--- a/include/ylt/standalone/cinatra/coro_http_server.hpp
+++ b/include/ylt/standalone/cinatra/coro_http_server.hpp
@@ -2,7 +2,6 @@
 
 #include <memory>
 
-#include "asio/ip/v6_only.hpp"
 #include "cinatra/coro_http_client.hpp"
 #include "cinatra/coro_http_response.hpp"
 #include "cinatra/coro_http_router.hpp"
@@ -13,6 +12,7 @@
 #include "ylt/coro_io/coro_file.hpp"
 #include "ylt/coro_io/coro_io.hpp"
 #include "ylt/coro_io/io_context_pool.hpp"
+#include "ylt/coro_io/listen_endpoint.hpp"
 #include "ylt/coro_io/load_balancer.hpp"
 
 namespace cinatra {
@@ -737,29 +737,18 @@ class coro_http_server {
     using asio::ip::tcp;
     asio::error_code ec;
 
-    asio::ip::tcp::endpoint endpoint;
-    auto addr = asio::ip::make_address(address_, ec);
-    if (!ec) {
-      endpoint = tcp::endpoint(addr, port_);
-    }
-    else {
-      ec.clear();
-      asio::ip::tcp::resolver::query query(address_, std::to_string(port_));
-      asio::ip::tcp::resolver resolver(acceptor_.get_executor());
-      asio::ip::tcp::resolver::iterator it = resolver.resolve(query, ec);
-      asio::ip::tcp::resolver::iterator it_end;
-      if (ec || it == it_end) {
-        CINATRA_LOG_ERROR << "invalid address: " << address_
-                          << " error: " << ec.message();
-        if (ec) {
-          return ec;
-        }
-        return std::make_error_code(std::errc::address_not_available);
+    auto endpoint = coro_io::detail::resolve_listen_endpoint(
+        acceptor_.get_executor(), address_, port_, ec);
+    if (!endpoint) {
+      CINATRA_LOG_ERROR << "invalid address: " << address_
+                        << " error: " << ec.message();
+      if (ec) {
+        return ec;
       }
-      endpoint = it->endpoint();
+      return std::make_error_code(std::errc::address_not_available);
     }
 
-    acceptor_.open(endpoint.protocol(), ec);
+    acceptor_.open(endpoint->protocol(), ec);
     if (ec) {
       CINATRA_LOG_ERROR << "acceptor open failed"
                         << " error: " << ec.message();
@@ -768,14 +757,11 @@ class coro_http_server {
 #ifdef __GNUC__
     acceptor_.set_option(tcp::acceptor::reuse_address(true), ec);
 #endif
-    if (endpoint.protocol() == tcp::v6()) {
-      acceptor_.set_option(asio::ip::v6_only(false), ec);
-      if (ec) {
-        CINATRA_LOG_WARNING << "set v6_only(false) failed: " << ec.message();
-        ec.clear();
-      }
+    if (auto opt_ec = coro_io::detail::set_ipv6_only_false(acceptor_, *endpoint);
+        opt_ec) {
+      CINATRA_LOG_WARNING << "set v6_only(false) failed: " << opt_ec.message();
     }
-    acceptor_.bind(endpoint, ec);
+    acceptor_.bind(*endpoint, ec);
     if (ec) {
       CINATRA_LOG_ERROR << "bind port: " << port_ << " error: " << ec.message();
       std::error_code ignore_ec;


### PR DESCRIPTION
## Summary

Fixes #1185

Linux下绑定IPv6地址(如`::`)时，由于两个原因导致IPv4客户端连不上：

1. `getaddrinfo`解析字面量IP在不同glibc版本/容器环境下结果不稳定（`AI_ADDRCONFIG`标志的影响）
2. 没有显式设置`IPV6_V6ONLY=false`，在`net.ipv6.bindv6only=1`的环境下IPv6 socket拒绝IPv4连接

## Changes

- 新建 `include/ylt/coro_io/listen_endpoint.hpp`，提取公共的地址解析和dual-stack设置逻辑
  - `resolve_listen_endpoint()`：字面量IP用`make_address`直接解析，hostname才走resolver
  - `set_ipv6_only_false()`：IPv6 endpoint时关闭v6_only，失败只warn不abort
- `server_acceptor.hpp` 和 `coro_http_server.hpp` 改为调用上述公共函数，消除重复代码

## Testing

Windows MSVC 14.50 本地全量回归：

| Test Suite | Cases | Assertions | Result |
|-----------|-------|-----------|--------|
| coro_io_test | 40 | 1,171,517 | PASS |
| coro_http_test | 121 | 108,657 | PASS |
| coro_rpc_test | 41 | 200,315 | PASS |
| easylog_test | 9 | 28 | PASS |
| metric_test | 44 | 461 | PASS |