### PR TITLE
fix(bench): 修复客户端池模式退出时的运行时异常

### DIFF
--- a/src/coro_rpc/benchmark/bench.cpp
+++ b/src/coro_rpc/benchmark/bench.cpp
@@ -497,5 +497,6 @@ int main(int argc, char** argv) {
     else {
       async_simple::coro::syncAwait(request_no_pool(conf));
     }
+    coro_io::g_io_context_pool().stop(true);
   }
 }


### PR DESCRIPTION
## 问题

Windows 下使用 bench 工具以客户端池模式 (`-g 1 -h 0`) 运行少量请求后退出时，
进程会触发运行时异常（abort / 非零退出码）。

根因：`client_pool` 在建立连接时会通过 `directlyStart` 在全局 `io_context_pool`
的 executor 上启动 `collect_idle_timeout_client` 后台协程（30s 定时器循环）。
当 `main()` 返回时，这些协程仍在后台线程的 `io_context::run()` 中 sleep，
导致 Windows 运行时在进程退出阶段检测到活跃线程/未释放资源而触发异常。

## 修复

在 bench 客户端模式的所有请求完成后，显式调用 `coro_io::g_io_context_pool().stop(true)`
强制停止全局 io_context_pool。`stop(true)` 会对每个 io_context 调用 `stop()`，
使 `run()` 立即返回，后台线程随即退出，进程可以干净地结束。

## 测试

在 Windows 上对修复后的 bench 进行了 3500+ 次压力测试，覆盖以下场景：
- 客户端池模式 (c=1/4, m=1/3, -g 1 -h 0): 1500 次
- 复用池模式 (c=1/4, m=1/5, -g 1 -h 1): 1500 次
- 无池模式 (c=2, m=2, -g 0 -h 0): 500 次

全部以退出码 0 正常退出，无任何运行时异常。

Closes #1151