### PR TITLE
[codex] restore coro_http_test coverage

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -85,7 +85,7 @@ runs:
         make -j$(($(nproc)/2 + 1))
         export LLVM_PROFILE_FILE="test_ylt-%m.profraw"
         cd output/tests
-        find . -maxdepth 1 -type f -executable ! -name coro_http_test | xargs -I {} sh -c '{}'
+        find . -maxdepth 1 -type f -executable | xargs -I {} sh -c '{}'
         llvm-profdata merge -sparse test_ylt-*.profraw -o test_ylt.profdata
         if [ -n "${{ inputs.reset-commit-id }}" ];then
           report=base-ylt-cov-report


### PR DESCRIPTION
## Summary

- Restore `coro_http_test` to the llvm coverage action test set.
- This reverts the temporary coverage exclusion used while the hang fix PR was landing.

## Rationale

The hang fix is now merged into `main`, so both `base-cov-test` and `cov-test` can run `coro_http_test` without hitting the old base-commit hang.

## Validation

- Parsed `.github/actions/coverage/action.yml` with PyYAML.
- Extracted the `Build and test` script and checked it with `bash -n`.
- Ran `git diff --check`.