### PR TITLE
[codex] avoid blocking PRs on missing RDMA self-hosted runner

### DIFF
--- a/.github/workflows/rdma.yml
+++ b/.github/workflows/rdma.yml
@@ -9,6 +9,7 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: '17 17 * * *'   # daily ~01:15 CST, off-the-hour
   workflow_dispatch:
@@ -26,6 +27,9 @@ env:
 
 jobs:
   rdma_software:
+    # Self-hosted RDMA capacity is opt-in on PRs so missing runners do not
+    # block unrelated changes for 24h while the job waits in queue.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-rdma-ci') }}
     runs-on: [self-hosted, linux, x64, rdma-rxe]
     timeout-minutes: 30
 


### PR DESCRIPTION
## What changed

- gate the `rdma_software` self-hosted job on pull requests behind a `run-rdma-ci` label
- add the `labeled` pull request event so maintainers can opt in to the RDMA run explicitly

## Why

The RDMA workflow currently requires a self-hosted runner with labels `self-hosted`, `linux`, `x64`, and `rdma-rxe`.
For PR #1201, that runner was not available, so the job never started, waited in queue for 24 hours, and was then cancelled by GitHub.

This change makes the RDMA workflow non-blocking for normal PR updates while preserving a clear opt-in path for RDMA validation once the self-hosted runner is online.

## Impact

- ordinary PR updates no longer get stuck waiting for an unavailable RDMA runner
- maintainers can still trigger the RDMA PR job by adding the `run-rdma-ci` label
- push, schedule, and manual dispatch behavior remain unchanged

## Root cause

The failing check was infrastructure-related rather than test-related: the job had no assigned runner (`runner_id=0`, no steps executed) and GitHub reported that it exceeded the maximum wait time while awaiting a runner.

## Validation

- `git diff --check`
- YAML parse check with PyYAML
