### PR TITLE
Bump YLT_VERSION to 0.6.1

### DIFF
--- a/include/ylt/version.hpp
+++ b/include/ylt/version.hpp
@@ -20,4 +20,4 @@
 // YLT_VERSION % 100 is the sub-minor version
 // YLT_VERSION / 100 % 1000 is the minor version
 // YLT_VERSION / 100000 is the major version
-#define YLT_VERSION 600  // 0.6.0
+#define YLT_VERSION 601  // 0.6.1


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## Why

<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->

## What is changing
The 0.6.1 release was tagged without updating the version macro, so `YLT_VERSION` still reports 0.6.0 (600).

## Example