### PR TITLE
fix(metric): escape special characters in Prometheus label values

### DIFF
--- a/include/ylt/metric/counter.hpp
+++ b/include/ylt/metric/counter.hpp
@@ -119,7 +119,9 @@ class basic_static_counter : public static_metric {
   void build_string(std::string &str, const std::vector<std::string> &v1,
                     const std::vector<std::string> &v2) {
     for (size_t i = 0; i < v1.size(); i++) {
-      str.append(v1[i]).append("=\"").append(v2[i]).append("\",");
+      str.append(v1[i]).append("=\"");
+      append_escaped_label_value(str, v2[i]);
+      str.append("\",");
     }
     str.pop_back();
   }
@@ -340,7 +342,9 @@ class basic_dynamic_counter
       str.append(",");
     }
     for (size_t i = 0; i < v1.size(); i++) {
-      str.append(v1[i]).append("=\"").append(v2[i]).append("\",");
+      str.append(v1[i]).append("=\"");
+      append_escaped_label_value(str, v2[i]);
+      str.append("\",");
     }
     str.pop_back();
   }

--- a/include/ylt/metric/metric.hpp
+++ b/include/ylt/metric/metric.hpp
@@ -24,6 +24,29 @@ inline char* to_chars_float(T value, char* buffer) {
 #endif
 
 namespace ylt::metric {
+
+// Escapes a label value for the Prometheus text exposition format. Inside a
+// label value exactly three characters must be escaped: backslash, double
+// quote, and line feed.
+inline void append_escaped_label_value(std::string& str,
+                                       std::string_view value) {
+  for (char ch : value) {
+    switch (ch) {
+      case '\\':
+        str.append("\\\\");
+        break;
+      case '"':
+        str.append("\\\"");
+        break;
+      case '\n':
+        str.append("\\n");
+        break;
+      default:
+        str.push_back(ch);
+    }
+  }
+}
+
 enum class MetricType {
   Counter,
   Gauge,
@@ -159,11 +182,9 @@ class metric_t {
                           const std::vector<std::string>& label_name,
                           const auto& label_value) {
     for (size_t i = 0; i < label_name.size(); i++) {
-      str.append(label_name[i])
-          .append("=\"")
-          .append(label_value[i])
-          .append("\"")
-          .append(",");
+      str.append(label_name[i]).append("=\"");
+      append_escaped_label_value(str, label_value[i]);
+      str.append("\"").append(",");
     }
     str.pop_back();
   }
@@ -171,7 +192,9 @@ class metric_t {
   void build_label_string(std::string& str,
                           const std::map<std::string, std::string>& labels) {
     for (auto& [k, v] : labels) {
-      str.append(k).append("=\"").append(v).append("\",");
+      str.append(k).append("=\"");
+      append_escaped_label_value(str, v);
+      str.append("\",");
     }
     str.pop_back();
   }

--- a/src/metric/tests/test_metric.cpp
+++ b/src/metric/tests/test_metric.cpp
@@ -13,6 +13,26 @@ using namespace ylt::metric;
 struct metrc_tag {};
 
 struct test_tag {};
+
+TEST_CASE("test label value escaping in text serialization") {
+  // A label value can contain characters that are special in the Prometheus
+  // text format. They must be escaped: backslash, double quote, and line feed.
+  dynamic_counter_1t c("http_requests_total", "Total requests",
+                       std::array<std::string, 1>{"path"});
+  c.inc({std::string("/has") + '"' + "quote"}, 1);
+  c.inc({std::string("/has") + '\\' + "backslash"}, 2);
+  c.inc({std::string("/has") + '\n' + "newline"}, 3);
+
+  std::string str;
+  c.serialize(str);
+
+  CHECK(str.find("path=\"/has\\\"quote\"") != std::string::npos);
+  CHECK(str.find("path=\"/has\\\\backslash\"") != std::string::npos);
+  CHECK(str.find("path=\"/has\\nnewline\"") != std::string::npos);
+  // the escaped newline must not split the sample across two lines
+  CHECK(str.find("/has\nnewline") == std::string::npos);
+}
+
 TEST_CASE("test serialize with dynamic labels only") {
   auto verify_serialize = [](const std::string& str) {
     CHECK(str.find("method=\"GET\"") != std::string::npos);


### PR DESCRIPTION
## Why

Label values are written into the text exposition format without any escaping, so a value with a quote, backslash, or newline comes out malformed. The newline case is the worst one, because it splits a single sample across two lines and corrupts everything a scraper reads after it:

```
http_requests_total{path="/has"quote"} 2      <- the quote ends the value early
http_requests_total{path="/has\backslash"} 3  <- the backslash is not doubled
http_requests_total{path="/has
newline"} 4                                    <- the newline splits the line
```

The Prometheus text format asks for exactly three escapes inside a label value: `\` becomes `\`, `"` becomes `\"`, and a line feed becomes `\n`. The reference `prometheus_client` does this, and without it the output can't be parsed. Label values are often user influenced (URL paths, user agents, hostnames), so this turns up in normal use.

## What is changing

A small `append_escaped_label_value` helper, used everywhere a label value is written. It turned out there are four such places, not two: both `build_label_string` overloads in `metric.hpp` (histograms, summaries, and static labels) and both `build_string` methods in `counter.hpp` (counters and gauges, since gauges inherit from counters). Only the value is escaped, not the label name, since the format already constrains names to `[a-zA-Z_][a-zA-Z0-9_]*`.

## Example

With the fix, the same input serializes the way `prometheus_client` does:

```
http_requests_total{path="/has\"quote"} 2
http_requests_total{path="/has\backslash"} 3
http_requests_total{path="/has\nnewline"} 4
```

There's a new regression test in `test_metric.cpp` covering all three characters. The full metric test suite passes (43 cases, 473 assertions, up from 42/469).

One thing left out on purpose: the `# HELP` line has a related but separate issue, since HELP text uses a different escaping rule (backslash and newline, but not quote) and is set by the developer rather than user input. It felt better to keep this PR focused on label values and handle HELP separately.
