### PR TITLE
fix(metric): emit histogram when count>0 even if sum==0

### DIFF
--- a/include/ylt/metric/histogram.hpp
+++ b/include/ylt/metric/histogram.hpp
@@ -62,7 +62,18 @@ class basic_static_histogram : public static_metric {
   void serialize(std::string &str) override {
     auto val = sum_->value();
 
-    if (val == 0) {
+    // Gate on observations (count > 0), not on sum: a histogram whose
+    // observations are all zero-valued (e.g. sub-microsecond latencies
+    // truncated to int64_t 0) still has a meaningful count and bucket
+    // distribution. Using sum==0 as "empty" silently drops real signal.
+    bool has_observations = false;
+    for (const auto &counter : bucket_counts_) {
+      if (counter->value() != 0) {
+        has_observations = true;
+        break;
+      }
+    }
+    if (!has_observations) {
       return;
     }
 
@@ -103,7 +114,16 @@ class basic_static_histogram : public static_metric {
 #ifdef CINATRA_ENABLE_METRIC_JSON
   void serialize_to_json(std::string &str) override {
     auto val = sum_->value();
-    if (val == 0) {
+
+    // Gate on observations (count > 0), not on sum — see serialize().
+    bool has_observations = false;
+    for (const auto &counter : bucket_counts_) {
+      if (counter->value() != 0) {
+        has_observations = true;
+        break;
+      }
+    }
+    if (!has_observations) {
       return;
     }
 
@@ -230,11 +250,7 @@ class basic_dynamic_histogram : public dynamic_metric {
 
   void serialize(std::string &str) override {
     auto value_map = sum_->copy();
-    auto has_non_zero_value =
-        std::any_of(value_map.begin(), value_map.end(), [](const auto &e) {
-          return e->value != 0;
-        });
-    if (!has_non_zero_value) {
+    if (value_map.empty()) {
       return;
     }
 
@@ -244,7 +260,18 @@ class basic_dynamic_histogram : public dynamic_metric {
     for (auto &e : value_map) {
       auto &labels_value = e->label;
       auto &value = e->value;
-      if (value == 0) {
+
+      // Gate per-label-combo on observations (count > 0), not on sum:
+      // a label combo observed with only zero-valued samples (e.g.
+      // sub-microsecond latencies truncated to int64_t 0) still has a
+      // meaningful count and bucket distribution. A non-empty value_map
+      // entry implies observe() was called, which always increments a
+      // bucket counter alongside sum_.
+      value_type total_count = 0;
+      for (size_t i = 0; i < bucket_counts.size(); i++) {
+        total_count += bucket_counts[i]->value(labels_value);
+      }
+      if (total_count == 0) {
         continue;
       }
 
@@ -306,8 +333,14 @@ class basic_dynamic_histogram : public dynamic_metric {
 
     for (auto &e : value_map) {
       auto &labels_value = e->label;
-      auto &value = e->value;
-      if (value == 0) {
+
+      // Gate per-label-combo on observations (count > 0), not on sum —
+      // see serialize().
+      size_t total_count = 0;
+      for (size_t i = 0; i < bucket_counts.size(); i++) {
+        total_count += bucket_counts[i]->value(labels_value);
+      }
+      if (total_count == 0) {
         continue;
       }
 

--- a/src/metric/tests/test_metric.cpp
+++ b/src/metric/tests/test_metric.cpp
@@ -1927,16 +1927,27 @@ TEST_CASE("test serialize with emptry metrics") {
 
   h1->observe({"GET"}, 0);
   h1->serialize(s1);
-  CHECK(s1.empty());
+  CHECK(!s1.empty());
+  CHECK(s1.find("get_count2_count") != std::string::npos);
+  CHECK(s1.find("get_count2_sum") != std::string::npos);
 
+  // #1206 regression still holds: a pre-existing buffer is preserved (not
+  // wiped), and the histogram is now appended to it rather than dropped.
   std::string existing = "previous_metric 1\n";
   h1->serialize(existing);
-  CHECK(existing == "previous_metric 1\n");
+  CHECK(existing.find("previous_metric 1\n") == 0);
+  CHECK(existing.find("get_count2") != std::string::npos);
 
 #ifdef CINATRA_ENABLE_METRIC_JSON
+  s1.clear();
   h1->serialize_to_json(s1);
-  CHECK(s1.empty());
+  CHECK(!s1.empty());
+  CHECK(s1.find("get_count2") != std::string::npos);
 #endif
+
+  // Earlier observed-h1 checks left content in s1; clear it so the
+  // unobserved-metric checks below start from a clean buffer.
+  s1.clear();
 
   auto h2 = std::make_shared<histogram_t>(
       "get_count2", "help",
@@ -2052,6 +2063,73 @@ TEST_CASE("test serialize with emptry metrics") {
 #ifdef CINATRA_ENABLE_METRIC_JSON
     c3->serialize_to_json(str);
     CHECK(!str.empty());
+#endif
+  }
+}
+
+TEST_CASE("histogram with zero-valued observations is emitted") {
+  // Regression for self-drop bug: a histogram whose observations are all
+  // zero-valued (sum==0, count>0) must still be emitted in both Prometheus
+  // and JSON output. Previously gated on sum!=0, which dropped real signal
+  // (e.g. sub-microsecond latencies truncated to int64_t 0). Sibling of
+  // the cross-metric wipe fixed in #1206.
+  std::vector<double> buckets{5.23, 10.54, 20.0, 50.0, 100.0};
+
+  // --- static histogram ---
+  {
+    histogram_t h("latency_us", "help", buckets);
+    h.observe(0);
+    h.observe(0);
+
+    std::string str;
+    h.serialize(str);
+    CHECK(!str.empty());
+    CHECK(str.find("# HELP latency_us") != std::string::npos);
+    CHECK(str.find("# TYPE latency_us histogram") != std::string::npos);
+    CHECK(str.find("latency_us_sum 0") != std::string::npos);
+    CHECK(str.find("latency_us_count 2") != std::string::npos);
+    // value 0 falls in the first bucket; cumulative +Inf bucket == count
+    CHECK(str.find("le=\"+Inf\"} 2") != std::string::npos);
+
+    // Pre-existing buffer is preserved (no cross-wipe), histogram appended.
+    std::string existing = "previous_metric 1\n";
+    h.serialize(existing);
+    CHECK(existing.find("previous_metric 1\n") == 0);
+    CHECK(existing.find("latency_us_count 2") != std::string::npos);
+
+#ifdef CINATRA_ENABLE_METRIC_JSON
+    std::string json;
+    h.serialize_to_json(json);
+    CHECK(!json.empty());
+    CHECK(json.find("latency_us") != std::string::npos);
+#endif
+  }
+
+  // --- dynamic histogram ---
+  {
+    dynamic_histogram_1t h("stage_latency_us", "help", buckets,
+                           std::array<std::string, 1>{"method"});
+    h.observe({"GET"}, 0);
+
+    std::string str;
+    h.serialize(str);
+    CHECK(!str.empty());
+    CHECK(str.find("stage_latency_us_sum") != std::string::npos);
+    CHECK(str.find("stage_latency_us_count") != std::string::npos);
+    CHECK(str.find("le=\"+Inf\"} 1") != std::string::npos);
+
+    // A second label combo with non-zero sum is unaffected.
+    h.observe({"POST"}, 10);
+    str.clear();
+    h.serialize(str);
+    CHECK(str.find("method=\"GET\"") != std::string::npos);
+    CHECK(str.find("method=\"POST\"") != std::string::npos);
+
+#ifdef CINATRA_ENABLE_METRIC_JSON
+    std::string json;
+    h.serialize_to_json(json);
+    CHECK(!json.empty());
+    CHECK(json.find("stage_latency_us") != std::string::npos);
 #endif
   }
 }


### PR DESCRIPTION
## Why

`basic_static_histogram` and `basic_dynamic_histogram` silently drop a histogram from Prometheus and JSON output when its `sum` is 0, even if it has been observed (`count > 0`). This is a sibling of #1205: PR #1206 fixed the cross-metric buffer wipe (`str.clear()` on a shared output string) but preserved the self-drop — the histogram itself still does not appear when `sum==0`.

`count>0` with `sum==0` is a legitimate, production-reachable state: sub-microsecond latencies cast to `int64_t` truncate to 0, so every observation is 0, `sum` stays 0, but `count` is the only surviving signal that the operation happened. Dropping the metric makes the operator see "no data" when thousands of operations occurred. This is the same root cause that [kvcache-ai/Mooncake#3126](https://github.com/kvcache-ai/Mooncake/pull/3126) had to work around in its own Prometheus serializer.

## What is changing

Gate emission on observations (`count > 0`), not on `sum`, in all four affected methods in `include/ylt/metric/histogram.hpp`:

- `basic_static_histogram::serialize()` / `serialize_to_json()` — walk `bucket_counts_` to detect any non-zero count; the existing `_sum` line already emits `std::to_string(val)`, which is `0` (correct).
- `basic_dynamic_histogram::serialize()` — replace the sum-based `has_non_zero_value` early-return with `value_map.empty()` (a non-empty entry implies `observe()` was called, which always increments a bucket counter); replace the per-label-combo `if (value == 0) continue;` with a count-based skip computed from `bucket_counts`.
- `basic_dynamic_histogram::serialize_to_json()` — replace the per-label-combo `if (value == 0) continue;` with the same count-based skip (its whole-histogram gate `value_map.empty()` was already correct).

Behavior change: histograms with only zero-valued observations now appear in output (with `_sum 0`, `_count N`, cumulative `+Inf` bucket `N`). Previously they were absent. Unobserved histograms (no `observe()` call) remain absent — no change for that case.

## Example

```cpp
basic_static_histogram<int64_t> h("latency_us", "help", {1, 5, 10});
h.observe(0);
h.observe(0);
std::string out;
h.serialize(out);
// Before: out is empty.
// After:
//   # HELP latency_us help
//   # TYPE latency_us histogram
//   latency_us_bucket{le="1"} 2
//   latency_us_bucket{le="5"} 2
//   latency_us_bucket{le="10"} 2
//   latency_us_bucket{le="+Inf"} 2
//   latency_us_sum 0
//   latency_us_count 2
```

## Tests

- Updated three assertions in `TEST_CASE("test serialize with emptry metrics")` that previously codified the self-drop as correct behavior (`CHECK(s1.empty())` after `observe({"GET"}, 0)`). They now verify the histogram is emitted with `_count`/`_sum` and that a pre-existing buffer is preserved (#1206 regression still holds — the histogram is appended, not wiped).
- Added `TEST_CASE("histogram with zero-valued observations is emitted")` covering static + dynamic histograms across Prometheus and JSON paths, including the shared-buffer preservation check.

`ctest -R '^metric_test$'` — 48/48 test cases pass, 495/495 assertions pass.

Fixes #1208.

---

AI assistance disclosure: AI tools were used to explore the codebase, implement the fix, and write the regression tests. The human submitter reviewed every changed line and re-ran the full `metric_test` suite independently to confirm all tests pass.