### PR TITLE
feat(coro_io): add shared file handle support

### DIFF
--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -594,8 +594,7 @@ class basic_random_coro_file {
   }
 
   void close() noexcept {
-    (void)std::atomic_exchange_explicit(
-        &state_, std::shared_ptr<file_state>{}, std::memory_order_acq_rel);
+    (void)state_.exchange({}, std::memory_order_acq_rel);
   }
 
   size_t file_size(std::error_code ec) const noexcept {
@@ -633,8 +632,7 @@ class basic_random_coro_file {
         }
       }
 #endif
-      std::atomic_store_explicit(&state_, std::move(state),
-                                 std::memory_order_release);
+      state_.store(std::move(state), std::memory_order_release);
       return true;
     } catch (...) {
       return false;
@@ -642,7 +640,7 @@ class basic_random_coro_file {
   }
 
   std::shared_ptr<file_state> load_state() const noexcept {
-    return std::atomic_load_explicit(&state_, std::memory_order_acquire);
+    return state_.load(std::memory_order_acquire);
   }
 
   static std::pair<std::error_code, size_t> bad_file_descriptor_result() {
@@ -769,7 +767,7 @@ class basic_random_coro_file {
 #endif
 
   coro_io::ExecutorWrapper<> executor_wrapper_;
-  std::shared_ptr<file_state> state_;
+  std::atomic<std::shared_ptr<file_state>> state_;
   std::string file_path_;
 };
 

--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -547,17 +547,6 @@ class basic_random_coro_file {
     }
   }
 
-#if defined(ASIO_HAS_FILE)
-  std::shared_ptr<asio::random_access_file> get_async_stream_file() {
-    auto state = load_state();
-    if (!state || !state->async_random_file) {
-      return {};
-    }
-    auto *async_random_file = state->async_random_file.get();
-    return {state, async_random_file};
-  }
-#endif
-
   bool is_open() {
     auto state = load_state();
     if (!state || !state->handle.valid()) {

--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -450,13 +450,12 @@ class basic_random_coro_file {
     open(filepath, open_flags);
   }
 
-  basic_random_coro_file(
-      shared_file_handle handle,
-      coro_io::ExecutorWrapper<> *executor =
-          coro_io::get_global_block_executor(),
-      std::string_view file_path = "")
-      : basic_random_coro_file(std::move(handle),
-                               executor->get_asio_executor(), file_path) {}
+  basic_random_coro_file(shared_file_handle handle,
+                         coro_io::ExecutorWrapper<> *executor =
+                             coro_io::get_global_block_executor(),
+                         std::string_view file_path = "")
+      : basic_random_coro_file(std::move(handle), executor->get_asio_executor(),
+                               file_path) {}
 
   basic_random_coro_file(shared_file_handle handle,
                          asio::io_context::executor_type executor,
@@ -487,8 +486,7 @@ class basic_random_coro_file {
     }
 
 #if defined(__APPLE__) || defined(__MACH__)
-    if (use_direct_io &&
-        fcntl(handle.native_handle(), F_NOCACHE, 1) != 0) {
+    if (use_direct_io && fcntl(handle.native_handle(), F_NOCACHE, 1) != 0) {
       return false;
     }
 #endif
@@ -532,7 +530,7 @@ class basic_random_coro_file {
 
     if constexpr (execute_type == execution_type::thread_pool) {
       co_return co_await async_pwrite(std::move(state), offset, buf.data(),
-                                     buf.size());
+                                      buf.size());
     }
     else {
 #if defined(ASIO_HAS_FILE)
@@ -542,7 +540,7 @@ class basic_random_coro_file {
       co_return std::make_pair(ec, write_size);
 #else
       co_return co_await async_pwrite(std::move(state), offset, buf.data(),
-                                     buf.size());
+                                      buf.size());
 #endif
     }
   }
@@ -587,8 +585,8 @@ class basic_random_coro_file {
     __cpp_lib_atomic_shared_ptr >= 201711L
     (void)state_.exchange({}, std::memory_order_acq_rel);
 #else
-    (void)std::atomic_exchange_explicit(
-        &state_, std::shared_ptr<file_state>{}, std::memory_order_acq_rel);
+    (void)std::atomic_exchange_explicit(&state_, std::shared_ptr<file_state>{},
+                                        std::memory_order_acq_rel);
 #endif
   }
 
@@ -611,13 +609,13 @@ class basic_random_coro_file {
           std::move(handle), executor_wrapper_.get_asio_executor());
 #if defined(ASIO_HAS_FILE)
       if constexpr (execute_type == execution_type::native_async) {
-        state->async_random_file = std::make_unique<asio::random_access_file>(
-            state->executor);
+        state->async_random_file =
+            std::make_unique<asio::random_access_file>(state->executor);
         std::error_code ec;
 #if defined(ASIO_WINDOWS)
-        auto native_handle = reinterpret_cast<
-            asio::random_access_file::native_handle_type>(
-            _get_osfhandle(state->handle.native_handle()));
+        auto native_handle =
+            reinterpret_cast<asio::random_access_file::native_handle_type>(
+                _get_osfhandle(state->handle.native_handle()));
         state->async_random_file->assign(native_handle, ec);
 #else
         state->async_random_file->assign(state->handle.native_handle(), ec);
@@ -713,20 +711,19 @@ class basic_random_coro_file {
                                  const_cast<char *>(data), size);
   }
 
-  static async_simple::coro::Lazy<std::pair<std::error_code, size_t>>
-  async_prw(std::shared_ptr<file_state> state, auto io_func, bool is_read,
-            size_t offset, char *buf, size_t size) {
+  static async_simple::coro::Lazy<std::pair<std::error_code, size_t>> async_prw(
+      std::shared_ptr<file_state> state, auto io_func, bool is_read,
+      size_t offset, char *buf, size_t size) {
     auto executor = state->executor;
     std::function<std::pair<std::error_code, size_t>()> operation =
         [state, io_func, offset, buf, size]() {
-          auto length = io_func(state->handle.native_handle(), buf, size,
-                                offset);
+          auto length =
+              io_func(state->handle.native_handle(), buf, size, offset);
           if (length < 0) {
-            return std::make_pair(
-                std::make_error_code(std::errc::io_error), size_t{0});
+            return std::make_pair(std::make_error_code(std::errc::io_error),
+                                  size_t{0});
           }
-          return std::make_pair(std::error_code{},
-                                static_cast<size_t>(length));
+          return std::make_pair(std::error_code{}, static_cast<size_t>(length));
         };
     auto result =
         co_await coro_io::post(std::move(operation), std::move(executor));

--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -43,6 +43,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -407,13 +408,19 @@ template <execution_type execute_type = execution_type::native_async>
 class basic_random_coro_file {
  private:
   struct file_state {
+    explicit file_state(asio::io_context::executor_type file_executor)
+        : executor(file_executor) {}
+
     file_state(shared_file_handle file_handle,
                asio::io_context::executor_type file_executor)
         : handle(std::move(file_handle)), executor(file_executor) {}
 
     ~file_state() noexcept {
 #if defined(ASIO_HAS_FILE)
-      if (async_random_file && async_random_file->is_open()) {
+      // Only release (detach without closing) when a shared handle owns the
+      // fd. On Windows native_async there is no shared handle, so let the asio
+      // file's destructor CloseHandle the overlapped HANDLE it created itself.
+      if (handle.valid() && async_random_file && async_random_file->is_open()) {
         std::error_code ec;
         (void)async_random_file->release(ec);
       }
@@ -423,10 +430,16 @@ class basic_random_coro_file {
     shared_file_handle handle;
     asio::io_context::executor_type executor;
 #if defined(ASIO_HAS_FILE)
-    std::unique_ptr<asio::random_access_file> async_random_file;
+    std::shared_ptr<asio::random_access_file> async_random_file;
 #endif
     std::atomic<bool> eof{false};
   };
+
+#if defined(ASIO_WINDOWS)
+  static constexpr bool supports_shared_native_async = false;
+#else
+  static constexpr bool supports_shared_native_async = true;
+#endif
 
  public:
   basic_random_coro_file(coro_io::ExecutorWrapper<> *executor =
@@ -450,6 +463,13 @@ class basic_random_coro_file {
     open(filepath, open_flags);
   }
 
+  /// Constructs a random-access file that shares ownership of a native file
+  /// descriptor. On Windows this overload is unavailable for native_async;
+  /// use the path-based overload so Asio can create an overlapped HANDLE.
+  template <execution_type type = execute_type,
+            std::enable_if_t<type != execution_type::native_async ||
+                                 supports_shared_native_async,
+                             int> = 0>
   basic_random_coro_file(shared_file_handle handle,
                          coro_io::ExecutorWrapper<> *executor =
                              coro_io::get_global_block_executor(),
@@ -457,6 +477,12 @@ class basic_random_coro_file {
       : basic_random_coro_file(std::move(handle), executor->get_asio_executor(),
                                file_path) {}
 
+  /// Constructs a shared-handle file using the specified executor. On Windows
+  /// shared_file_handle is supported only by the thread_pool backend.
+  template <execution_type type = execute_type,
+            std::enable_if_t<type != execution_type::native_async ||
+                                 supports_shared_native_async,
+                             int> = 0>
   basic_random_coro_file(shared_file_handle handle,
                          asio::io_context::executor_type executor,
                          std::string_view file_path = "")
@@ -470,6 +496,13 @@ class basic_random_coro_file {
     if (load_state()) {
       return true;
     }
+
+#if defined(ASIO_WINDOWS) && defined(ASIO_HAS_FILE)
+    if constexpr (execute_type == execution_type::native_async) {
+      return initialize_native_async_state(filepath, to_flags(open_flags),
+                                           use_direct_io);
+    }
+#endif
 
     int native_flags = to_flags(open_flags);
 #if defined(ASIO_WINDOWS)
@@ -547,7 +580,7 @@ class basic_random_coro_file {
 
   bool is_open() {
     auto state = load_state();
-    if (!state || !state->handle.valid()) {
+    if (!state) {
       return false;
     }
 
@@ -556,7 +589,7 @@ class basic_random_coro_file {
       return state->async_random_file && state->async_random_file->is_open();
     }
 #endif
-    return true;
+    return state->handle.valid();
   }
 
   bool eof() {
@@ -609,33 +642,53 @@ class basic_random_coro_file {
           std::move(handle), executor_wrapper_.get_asio_executor());
 #if defined(ASIO_HAS_FILE)
       if constexpr (execute_type == execution_type::native_async) {
-        state->async_random_file =
-            std::make_unique<asio::random_access_file>(state->executor);
-        std::error_code ec;
 #if defined(ASIO_WINDOWS)
-        auto native_handle =
-            reinterpret_cast<asio::random_access_file::native_handle_type>(
-                _get_osfhandle(state->handle.native_handle()));
-        state->async_random_file->assign(native_handle, ec);
+        return false;
 #else
+        state->async_random_file =
+            std::make_shared<asio::random_access_file>(state->executor);
+        std::error_code ec;
         state->async_random_file->assign(state->handle.native_handle(), ec);
-#endif
         if (ec) {
           return false;
         }
+#endif
       }
 #endif
-#if defined(__cpp_lib_atomic_shared_ptr) && \
-    __cpp_lib_atomic_shared_ptr >= 201711L
-      state_.store(std::move(state), std::memory_order_release);
-#else
-      std::atomic_store_explicit(&state_, std::move(state),
-                                 std::memory_order_release);
-#endif
+      store_state(std::move(state));
       return true;
     } catch (...) {
       return false;
     }
+  }
+
+#if defined(ASIO_WINDOWS) && defined(ASIO_HAS_FILE)
+  bool initialize_native_async_state(std::string_view filepath,
+                                     flags open_flags, bool use_direct_io) {
+    try {
+      auto state =
+          std::make_shared<file_state>(executor_wrapper_.get_asio_executor());
+      if (!open_native_async_file<false>(state->async_random_file,
+                                         executor_wrapper_, filepath,
+                                         open_flags, use_direct_io)) {
+        return false;
+      }
+      store_state(std::move(state));
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }
+#endif
+
+  void store_state(std::shared_ptr<file_state> state) noexcept {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+    state_.store(std::move(state), std::memory_order_release);
+#else
+    std::atomic_store_explicit(&state_, std::move(state),
+                               std::memory_order_release);
+#endif
   }
 
   std::shared_ptr<file_state> load_state() const noexcept {

--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <span>
 
 #include "async_simple/coro/SyncAwait.h"
@@ -712,7 +713,7 @@ class basic_random_coro_file {
   async_prw(std::shared_ptr<file_state> state, auto io_func, bool is_read,
             size_t offset, char *buf, size_t size) {
     auto executor = state->executor;
-    auto result = co_await coro_io::post(
+    std::function<std::pair<std::error_code, size_t>()> operation =
         [state, io_func, offset, buf, size]() {
           auto length = io_func(state->handle.native_handle(), buf, size,
                                 offset);
@@ -722,8 +723,9 @@ class basic_random_coro_file {
           }
           return std::make_pair(std::error_code{},
                                 static_cast<size_t>(length));
-        },
-        executor);
+        };
+    auto result =
+        co_await coro_io::post(std::move(operation), std::move(executor));
 
     auto operation_result = result.value();
     if (is_read && !operation_result.first && operation_result.second == 0) {

--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -364,7 +364,7 @@ class basic_seq_coro_file {
     return execution_type::none;
   }
 
-  size_t file_size(std::error_code ec) const noexcept {
+  size_t file_size(std::error_code &ec) const noexcept {
     return std::filesystem::file_size(file_path_, ec);
   }
 
@@ -623,11 +623,27 @@ class basic_random_coro_file {
 #endif
   }
 
-  size_t file_size(std::error_code ec) const noexcept {
+  size_t file_size(std::error_code &ec) const noexcept {
+    auto state = load_state();
+    if (state && state->handle.valid()) {
+      return file_size_from_handle(state->handle.native_handle(), ec);
+    }
     return std::filesystem::file_size(file_path_, ec);
   }
 
-  size_t file_size() const { return std::filesystem::file_size(file_path_); }
+  size_t file_size() const {
+    auto state = load_state();
+    if (!state || !state->handle.valid()) {
+      return std::filesystem::file_size(file_path_);
+    }
+
+    std::error_code ec;
+    auto size = file_size_from_handle(state->handle.native_handle(), ec);
+    if (ec) {
+      throw std::system_error(ec);
+    }
+    return size;
+  }
 
   std::string_view file_path() const { return file_path_; }
 
@@ -702,6 +718,22 @@ class basic_random_coro_file {
 
   static std::pair<std::error_code, size_t> bad_file_descriptor_result() {
     return {std::make_error_code(std::errc::bad_file_descriptor), 0};
+  }
+
+  static size_t file_size_from_handle(int fd, std::error_code &ec) noexcept {
+#if defined(ASIO_WINDOWS)
+    struct _stat64 status;
+    int result = ::_fstat64(fd, &status);
+#else
+    struct stat status;
+    int result = ::fstat(fd, &status);
+#endif
+    if (result != 0) {
+      ec = std::error_code(errno, std::generic_category());
+      return static_cast<size_t>(-1);
+    }
+    ec.clear();
+    return static_cast<size_t>(status.st_size);
   }
 
   static async_simple::coro::Lazy<std::pair<std::error_code, size_t>>

--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -594,7 +594,13 @@ class basic_random_coro_file {
   }
 
   void close() noexcept {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
     (void)state_.exchange({}, std::memory_order_acq_rel);
+#else
+    (void)std::atomic_exchange_explicit(
+        &state_, std::shared_ptr<file_state>{}, std::memory_order_acq_rel);
+#endif
   }
 
   size_t file_size(std::error_code ec) const noexcept {
@@ -632,7 +638,13 @@ class basic_random_coro_file {
         }
       }
 #endif
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
       state_.store(std::move(state), std::memory_order_release);
+#else
+      std::atomic_store_explicit(&state_, std::move(state),
+                                 std::memory_order_release);
+#endif
       return true;
     } catch (...) {
       return false;
@@ -640,7 +652,12 @@ class basic_random_coro_file {
   }
 
   std::shared_ptr<file_state> load_state() const noexcept {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
     return state_.load(std::memory_order_acquire);
+#else
+    return std::atomic_load_explicit(&state_, std::memory_order_acquire);
+#endif
   }
 
   static std::pair<std::error_code, size_t> bad_file_descriptor_result() {
@@ -767,7 +784,12 @@ class basic_random_coro_file {
 #endif
 
   coro_io::ExecutorWrapper<> executor_wrapper_;
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
   std::atomic<std::shared_ptr<file_state>> state_;
+#else
+  std::shared_ptr<file_state> state_;
+#endif
   std::string file_path_;
 };
 

--- a/include/ylt/coro_io/coro_file.hpp
+++ b/include/ylt/coro_io/coro_file.hpp
@@ -18,6 +18,7 @@
 #include <async_simple/Traits.h>
 #include <async_simple/coro/FutureAwaiter.h>
 
+#include <atomic>
 #include <cstdint>
 #include <cstdio>
 #include <filesystem>
@@ -45,6 +46,7 @@
 #include <vector>
 
 #include "coro_io.hpp"
+#include "shared_file_handle.hpp"
 #if defined(ASIO_WINDOWS)
 #include <io.h>
 #endif
@@ -402,6 +404,29 @@ using coro_file = basic_seq_coro_file<>;
 
 template <execution_type execute_type = execution_type::native_async>
 class basic_random_coro_file {
+ private:
+  struct file_state {
+    file_state(shared_file_handle file_handle,
+               asio::io_context::executor_type file_executor)
+        : handle(std::move(file_handle)), executor(file_executor) {}
+
+    ~file_state() noexcept {
+#if defined(ASIO_HAS_FILE)
+      if (async_random_file && async_random_file->is_open()) {
+        std::error_code ec;
+        (void)async_random_file->release(ec);
+      }
+#endif
+    }
+
+    shared_file_handle handle;
+    asio::io_context::executor_type executor;
+#if defined(ASIO_HAS_FILE)
+    std::unique_ptr<asio::random_access_file> async_random_file;
+#endif
+    std::atomic<bool> eof{false};
+  };
+
  public:
   basic_random_coro_file(coro_io::ExecutorWrapper<> *executor =
                              coro_io::get_global_block_executor())
@@ -424,110 +449,152 @@ class basic_random_coro_file {
     open(filepath, open_flags);
   }
 
+  basic_random_coro_file(
+      shared_file_handle handle,
+      coro_io::ExecutorWrapper<> *executor =
+          coro_io::get_global_block_executor(),
+      std::string_view file_path = "")
+      : basic_random_coro_file(std::move(handle),
+                               executor->get_asio_executor(), file_path) {}
+
+  basic_random_coro_file(shared_file_handle handle,
+                         asio::io_context::executor_type executor,
+                         std::string_view file_path = "")
+      : executor_wrapper_(executor), file_path_(file_path) {
+    initialize_state(std::move(handle));
+  }
+
   bool open(std::string_view filepath, std::ios::ios_base::openmode open_flags,
             bool use_direct_io = false) {
     file_path_ = std::string{filepath};
-    if constexpr (execute_type == execution_type::thread_pool) {
-      return open_fd(filepath, to_flags(open_flags), use_direct_io);
+    if (load_state()) {
+      return true;
     }
-    else {
-#if defined(ASIO_HAS_FILE)
-      return open_native_async_file<false>(async_random_file_,
-                                           executor_wrapper_, filepath,
-                                           to_flags(open_flags), use_direct_io);
-#else
-      return open_fd(filepath, to_flags(open_flags), use_direct_io);
+
+    int native_flags = to_flags(open_flags);
+#if defined(ASIO_WINDOWS)
+    native_flags = adjust_flags(native_flags);
+#elif defined(__linux__)
+    if (use_direct_io) {
+      native_flags |= O_DIRECT;
+    }
 #endif
+
+    auto [ec, handle] = shared_file_handle::open(filepath, native_flags);
+    if (ec) {
+      return false;
     }
+
+#if defined(__APPLE__) || defined(__MACH__)
+    if (use_direct_io &&
+        fcntl(handle.native_handle(), F_NOCACHE, 1) != 0) {
+      return false;
+    }
+#endif
+
+    return initialize_state(std::move(handle));
   }
 
   async_simple::coro::Lazy<std::pair<std::error_code, size_t>> async_read_at(
       uint64_t offset, char *buf, size_t size) {
+    auto state = load_state();
+    if (!state) {
+      co_return bad_file_descriptor_result();
+    }
+
     if constexpr (execute_type == execution_type::thread_pool) {
-      co_return co_await async_pread(offset, buf, size);
+      co_return co_await async_pread(std::move(state), offset, buf, size);
     }
     else {
 #if defined(ASIO_HAS_FILE)
-      if (async_random_file_ == nullptr) {
-        co_return std::make_pair(
-            std::make_error_code(std::errc::invalid_argument), 0);
-      }
       auto [ec, read_size] = co_await coro_io::async_read_at(
-          offset, *async_random_file_, asio::buffer(buf, size));
+          offset, *state->async_random_file, asio::buffer(buf, size));
 
       if (ec == asio::error::eof) {
-        eof_ = true;
+        state->eof.store(true, std::memory_order_relaxed);
         co_return std::make_pair(std::error_code{}, read_size);
       }
 
       co_return std::make_pair(ec, read_size);
 #else
-      co_return co_await async_pread(offset, buf, size);
+      co_return co_await async_pread(std::move(state), offset, buf, size);
 #endif
     }
   }
 
   async_simple::coro::Lazy<std::pair<std::error_code, size_t>> async_write_at(
       uint64_t offset, std::string_view buf) {
+    auto state = load_state();
+    if (!state) {
+      co_return bad_file_descriptor_result();
+    }
+
     if constexpr (execute_type == execution_type::thread_pool) {
-      co_return co_await async_pwrite(offset, buf.data(), buf.size());
+      co_return co_await async_pwrite(std::move(state), offset, buf.data(),
+                                     buf.size());
     }
     else {
 #if defined(ASIO_HAS_FILE)
-      if (async_random_file_ == nullptr) {
-        co_return std::make_pair(
-            std::make_error_code(std::errc::invalid_argument), 0);
-      }
       auto [ec, write_size] = co_await coro_io::async_write_at(
-          offset, *async_random_file_, asio::buffer(buf));
+          offset, *state->async_random_file, asio::buffer(buf));
 
       co_return std::make_pair(ec, write_size);
 #else
-      co_return co_await async_pwrite(offset, buf.data(), buf.size());
+      co_return co_await async_pwrite(std::move(state), offset, buf.data(),
+                                     buf.size());
 #endif
     }
   }
 
 #if defined(ASIO_HAS_FILE)
   std::shared_ptr<asio::random_access_file> get_async_stream_file() {
-    return async_random_file_;
+    auto state = load_state();
+    if (!state || !state->async_random_file) {
+      return {};
+    }
+    auto *async_random_file = state->async_random_file.get();
+    return {state, async_random_file};
   }
 #endif
-
-  std::shared_ptr<int> get_pread_file() { return prw_random_file_; }
 
   bool is_open() {
+    auto state = load_state();
+    if (!state || !state->handle.valid()) {
+      return false;
+    }
+
 #if defined(ASIO_HAS_FILE)
-    if (async_random_file_ && async_random_file_->is_open()) {
-      return true;
+    if constexpr (execute_type == execution_type::native_async) {
+      return state->async_random_file && state->async_random_file->is_open();
     }
 #endif
-    return prw_random_file_ != nullptr;
+    return true;
   }
 
-  bool eof() { return eof_; }
+  bool eof() {
+    auto state = load_state();
+    return state && state->eof.load(std::memory_order_relaxed);
+  }
 
   execution_type get_execution_type() {
-#if defined(ASIO_HAS_FILE)
-    if (async_random_file_ && async_random_file_->is_open()) {
-      return execution_type::native_async;
-    }
-#endif
-    if (prw_random_file_ != nullptr) {
-      return execution_type::thread_pool;
+    auto state = load_state();
+    if (!state) {
+      return execution_type::none;
     }
 
-    return execution_type::none;
+#if defined(ASIO_HAS_FILE)
+    if constexpr (execute_type == execution_type::native_async) {
+      return state->async_random_file && state->async_random_file->is_open()
+                 ? execution_type::native_async
+                 : execution_type::none;
+    }
+#endif
+    return execution_type::thread_pool;
   }
 
-  void close() {
-#if defined(ASIO_HAS_FILE)
-    std::error_code ec;
-    if (async_random_file_) {
-      async_random_file_->close(ec);
-    }
-#endif
-    prw_random_file_ = nullptr;
+  void close() noexcept {
+    (void)std::atomic_exchange_explicit(
+        &state_, std::shared_ptr<file_state>{}, std::memory_order_acq_rel);
   }
 
   size_t file_size(std::error_code ec) const noexcept {
@@ -539,51 +606,51 @@ class basic_random_coro_file {
   std::string_view file_path() const { return file_path_; }
 
  private:
-  bool open_fd(std::string_view filepath, int open_flags,
-               bool use_direct_io = false) {
-    if (prw_random_file_) {
-      return true;
-    }
-
-    if (use_direct_io) {
-#if defined(ASIO_WINDOWS)
-#elif defined(__linux__)
-      open_flags |= O_DIRECT;
-#endif
-    }
-
-#if defined(ASIO_WINDOWS)
-    int fd = _open(filepath.data(), adjust_flags(open_flags));
-#else
-    int fd = ::open(filepath.data(), open_flags);
-#endif
-    if (fd < 0) {
+  bool initialize_state(shared_file_handle handle) {
+    if (!handle.valid()) {
       return false;
     }
 
-    // On macOS, use F_NOCACHE as an alternative to O_DIRECT
-    if (use_direct_io) {
-#if defined(__APPLE__) || defined(__MACH__)
-      if (fcntl(fd, F_NOCACHE, 1) != 0) {
-        ::close(fd);
-        return false;
+    try {
+      auto state = std::make_shared<file_state>(
+          std::move(handle), executor_wrapper_.get_asio_executor());
+#if defined(ASIO_HAS_FILE)
+      if constexpr (execute_type == execution_type::native_async) {
+        state->async_random_file = std::make_unique<asio::random_access_file>(
+            state->executor);
+        std::error_code ec;
+#if defined(ASIO_WINDOWS)
+        auto native_handle = reinterpret_cast<
+            asio::random_access_file::native_handle_type>(
+            _get_osfhandle(state->handle.native_handle()));
+        state->async_random_file->assign(native_handle, ec);
+#else
+        state->async_random_file->assign(state->handle.native_handle(), ec);
+#endif
+        if (ec) {
+          return false;
+        }
       }
 #endif
+      std::atomic_store_explicit(&state_, std::move(state),
+                                 std::memory_order_release);
+      return true;
+    } catch (...) {
+      return false;
     }
-
-    prw_random_file_ = std::shared_ptr<int>(new int(fd), [](int *ptr) {
-#if defined(ASIO_WINDOWS)
-      _close(*ptr);
-#else
-      ::close(*ptr);
-#endif
-      delete ptr;
-    });
-    return true;
   }
 
-  async_simple::coro::Lazy<std::pair<std::error_code, size_t>> async_pread(
-      size_t offset, char *data, size_t size) {
+  std::shared_ptr<file_state> load_state() const noexcept {
+    return std::atomic_load_explicit(&state_, std::memory_order_acquire);
+  }
+
+  static std::pair<std::error_code, size_t> bad_file_descriptor_result() {
+    return {std::make_error_code(std::errc::bad_file_descriptor), 0};
+  }
+
+  static async_simple::coro::Lazy<std::pair<std::error_code, size_t>>
+  async_pread(std::shared_ptr<file_state> state, size_t offset, char *data,
+              size_t size) {
 #if defined(ASIO_WINDOWS)
     auto pread = [](int fd, void *buf, uint64_t count,
                     uint64_t offset) -> int64_t {
@@ -601,12 +668,19 @@ class basic_random_coro_file {
 
       return bytes_read;
     };
+#else
+    auto pread = [](int fd, void *buf, uint64_t count,
+                    uint64_t offset) -> int64_t {
+      return ::pread(fd, buf, count, offset);
+    };
 #endif
-    co_return co_await async_prw(pread, true, offset, data, size);
+    co_return co_await async_prw(std::move(state), pread, true, offset, data,
+                                 size);
   }
 
-  async_simple::coro::Lazy<std::pair<std::error_code, size_t>> async_pwrite(
-      size_t offset, const char *data, size_t size) {
+  static async_simple::coro::Lazy<std::pair<std::error_code, size_t>>
+  async_pwrite(std::shared_ptr<file_state> state, size_t offset,
+               const char *data, size_t size) {
 #if defined(ASIO_WINDOWS)
     auto pwrite = [](int fd, const void *buf, uint64_t count,
                      uint64_t offset) -> int64_t {
@@ -624,36 +698,38 @@ class basic_random_coro_file {
 
       return bytes_write;
     };
+#else
+    auto pwrite = [](int fd, const void *buf, uint64_t count,
+                     uint64_t offset) -> int64_t {
+      return ::pwrite(fd, buf, count, offset);
+    };
 #endif
-    co_return co_await async_prw(pwrite, false, offset, (char *)data, size);
+    co_return co_await async_prw(std::move(state), pwrite, false, offset,
+                                 const_cast<char *>(data), size);
   }
 
-  async_simple::coro::Lazy<std::pair<std::error_code, size_t>> async_prw(
-      auto io_func, bool is_read, size_t offset, char *buf, size_t size) {
-    std::function<int()> func = [=, this] {
-      int fd = *prw_random_file_;
-      return io_func(fd, buf, size, offset);
-    };
+  static async_simple::coro::Lazy<std::pair<std::error_code, size_t>>
+  async_prw(std::shared_ptr<file_state> state, auto io_func, bool is_read,
+            size_t offset, char *buf, size_t size) {
+    auto executor = state->executor;
+    auto result = co_await coro_io::post(
+        [state, io_func, offset, buf, size]() {
+          auto length = io_func(state->handle.native_handle(), buf, size,
+                                offset);
+          if (length < 0) {
+            return std::make_pair(
+                std::make_error_code(std::errc::io_error), size_t{0});
+          }
+          return std::make_pair(std::error_code{},
+                                static_cast<size_t>(length));
+        },
+        executor);
 
-    std::error_code ec{};
-    size_t op_size = 0;
-
-    auto len_val = co_await coro_io::post(std::move(func), &executor_wrapper_);
-    int len = len_val.value();
-    if (len == 0) {
-      if (is_read) {
-        eof_ = true;
-      }
+    auto operation_result = result.value();
+    if (is_read && !operation_result.first && operation_result.second == 0) {
+      state->eof.store(true, std::memory_order_relaxed);
     }
-    else if (len > 0) {
-      op_size = len;
-    }
-    else {
-      ec = std::make_error_code(std::errc::io_error);
-      op_size = len;
-    }
-
-    co_return std::make_pair(ec, op_size);
+    co_return operation_result;
   }
 
 #if defined(ASIO_WINDOWS)
@@ -691,12 +767,8 @@ class basic_random_coro_file {
 #endif
 
   coro_io::ExecutorWrapper<> executor_wrapper_;
-#if defined(ASIO_HAS_FILE)
-  std::shared_ptr<asio::random_access_file> async_random_file_;  // random file
-#endif
-  std::shared_ptr<int> prw_random_file_ = nullptr;  // pread/pwrite random file
+  std::shared_ptr<file_state> state_;
   std::string file_path_;
-  bool eof_ = false;
 };
 
 using random_coro_file = basic_random_coro_file<>;

--- a/include/ylt/coro_io/shared_file_handle.hpp
+++ b/include/ylt/coro_io/shared_file_handle.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <cerrno>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+#include <fcntl.h>
+#if defined(_WIN32)
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+#include <sys/stat.h>
+
+namespace coro_io {
+
+class weak_file_handle;
+
+class shared_file_handle {
+ public:
+  using native_handle_type = int;
+
+  shared_file_handle() noexcept = default;
+
+  static std::pair<std::error_code, shared_file_handle> open(
+      std::string_view path, int flags) noexcept {
+    native_handle_type fd = -1;
+    try {
+      std::string null_terminated_path(path);
+#if defined(_WIN32)
+      fd = ::_open(null_terminated_path.c_str(), flags,
+                   _S_IREAD | _S_IWRITE);
+#else
+      fd = ::open(null_terminated_path.c_str(), flags,
+                  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+#endif
+    } catch (...) {
+      return {std::make_error_code(std::errc::not_enough_memory), {}};
+    }
+    if (fd < 0) {
+      return {std::error_code(errno, std::generic_category()), {}};
+    }
+
+    auto handle = adopt(fd);
+    if (!handle.valid()) {
+      close_native_handle(fd);
+      return {std::make_error_code(std::errc::not_enough_memory), {}};
+    }
+    return {{}, std::move(handle)};
+  }
+
+  static shared_file_handle adopt(native_handle_type fd) noexcept {
+    if (fd < 0) {
+      return {};
+    }
+
+    try {
+      return shared_file_handle(std::make_shared<control_block>(fd));
+    } catch (...) {
+      return {};
+    }
+  }
+
+  static std::pair<std::error_code, shared_file_handle> duplicate(
+      native_handle_type fd) noexcept {
+    if (fd < 0) {
+      return {std::make_error_code(std::errc::bad_file_descriptor), {}};
+    }
+
+#if defined(_WIN32)
+    native_handle_type duplicated_fd = ::_dup(fd);
+#else
+    native_handle_type duplicated_fd = ::dup(fd);
+#endif
+    if (duplicated_fd < 0) {
+      return {std::error_code(errno, std::generic_category()), {}};
+    }
+
+    auto handle = adopt(duplicated_fd);
+    if (!handle.valid()) {
+      close_native_handle(duplicated_fd);
+      return {std::make_error_code(std::errc::not_enough_memory), {}};
+    }
+    return {{}, std::move(handle)};
+  }
+
+  bool valid() const noexcept { return state_ && state_->fd >= 0; }
+
+  native_handle_type native_handle() const noexcept {
+    return valid() ? state_->fd : -1;
+  }
+
+  weak_file_handle weak() const noexcept;
+
+ private:
+  static void close_native_handle(native_handle_type fd) noexcept {
+#if defined(_WIN32)
+    ::_close(fd);
+#else
+    ::close(fd);
+#endif
+  }
+
+  struct control_block {
+    explicit control_block(native_handle_type value) noexcept : fd(value) {}
+
+    ~control_block() noexcept {
+      if (fd >= 0) {
+        close_native_handle(fd);
+      }
+    }
+
+    native_handle_type fd = -1;
+  };
+
+  explicit shared_file_handle(std::shared_ptr<control_block> state) noexcept
+      : state_(std::move(state)) {}
+
+  std::shared_ptr<control_block> state_;
+  friend class weak_file_handle;
+};
+
+class weak_file_handle {
+ public:
+  weak_file_handle() noexcept = default;
+
+  shared_file_handle lock() const noexcept {
+    return shared_file_handle(state_.lock());
+  }
+
+  bool expired() const noexcept { return state_.expired(); }
+
+ private:
+  explicit weak_file_handle(
+      std::weak_ptr<shared_file_handle::control_block> state) noexcept
+      : state_(std::move(state)) {}
+
+  std::weak_ptr<shared_file_handle::control_block> state_;
+  friend class shared_file_handle;
+};
+
+inline weak_file_handle shared_file_handle::weak() const noexcept {
+  return weak_file_handle(state_);
+}
+
+}  // namespace coro_io

--- a/include/ylt/coro_io/shared_file_handle.hpp
+++ b/include/ylt/coro_io/shared_file_handle.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
+#include <fcntl.h>
+
 #include <cerrno>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
-
-#include <fcntl.h>
 #if defined(_WIN32)
 #include <io.h>
 #else
@@ -31,8 +31,7 @@ class shared_file_handle {
     try {
       std::string null_terminated_path(path);
 #if defined(_WIN32)
-      fd = ::_open(null_terminated_path.c_str(), flags,
-                   _S_IREAD | _S_IWRITE);
+      fd = ::_open(null_terminated_path.c_str(), flags, _S_IREAD | _S_IWRITE);
 #else
       fd = ::open(null_terminated_path.c_str(), flags,
                   S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);

--- a/src/coro_io/tests/CMakeLists.txt
+++ b/src/coro_io/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output/tests)
 add_executable(coro_io_test
         test_io_context_pool.cpp
         test_corofile.cpp
+        test_shared_file_handle.cpp
         test_load_balancer.cpp
         test_client_pool.cpp
         test_rate_limiter.cpp
@@ -16,4 +17,3 @@ add_test(NAME coro_io_test COMMAND coro_io_test)
 
 add_subdirectory(ibverbs)
 add_subdirectory(networkdirect)
-

--- a/src/coro_io/tests/CMakeLists.txt
+++ b/src/coro_io/tests/CMakeLists.txt
@@ -15,5 +15,14 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_SYSTEM_NAME MATCHES "Windows"
 endif()
 add_test(NAME coro_io_test COMMAND coro_io_test)
 
+add_executable(coro_file_error_test
+        test_file_error_paths.cpp
+        main.cpp
+        )
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_SYSTEM_NAME MATCHES "Windows") # mingw-w64
+    target_link_libraries(coro_file_error_test PRIVATE ws2_32 mswsock)
+endif()
+add_test(NAME coro_file_error_test COMMAND coro_file_error_test)
+
 add_subdirectory(ibverbs)
 add_subdirectory(networkdirect)

--- a/src/coro_io/tests/CMakeLists.txt
+++ b/src/coro_io/tests/CMakeLists.txt
@@ -20,6 +20,17 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             test_file_error_paths.cpp
             main.cpp
             )
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+        target_link_options(coro_file_error_test PRIVATE
+                "-Wl,--wrap=_Znwm"
+                "-Wl,--wrap=_Znam"
+                )
+    elseif (CMAKE_SIZEOF_VOID_P EQUAL 4)
+        target_link_options(coro_file_error_test PRIVATE
+                "-Wl,--wrap=_Znwj"
+                "-Wl,--wrap=_Znaj"
+                )
+    endif()
     add_test(NAME coro_file_error_test COMMAND coro_file_error_test)
 endif()
 

--- a/src/coro_io/tests/CMakeLists.txt
+++ b/src/coro_io/tests/CMakeLists.txt
@@ -20,10 +20,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             test_file_error_paths.cpp
             main.cpp
             )
-    target_link_options(coro_file_error_test PRIVATE
-            "-Wl,--wrap=_Znwm"
-            "-Wl,--wrap=_Znam"
-            )
     add_test(NAME coro_file_error_test COMMAND coro_file_error_test)
 endif()
 

--- a/src/coro_io/tests/CMakeLists.txt
+++ b/src/coro_io/tests/CMakeLists.txt
@@ -15,14 +15,17 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_SYSTEM_NAME MATCHES "Windows"
 endif()
 add_test(NAME coro_io_test COMMAND coro_io_test)
 
-add_executable(coro_file_error_test
-        test_file_error_paths.cpp
-        main.cpp
-        )
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_SYSTEM_NAME MATCHES "Windows") # mingw-w64
-    target_link_libraries(coro_file_error_test PRIVATE ws2_32 mswsock)
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_executable(coro_file_error_test
+            test_file_error_paths.cpp
+            main.cpp
+            )
+    target_link_options(coro_file_error_test PRIVATE
+            "-Wl,--wrap=_Znwm"
+            "-Wl,--wrap=_Znam"
+            )
+    add_test(NAME coro_file_error_test COMMAND coro_file_error_test)
 endif()
-add_test(NAME coro_file_error_test COMMAND coro_file_error_test)
 
 add_subdirectory(ibverbs)
 add_subdirectory(networkdirect)

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -62,6 +62,14 @@ void *operator new[](std::size_t size) {
   throw std::bad_alloc{};
 }
 
+void operator delete(void *ptr) noexcept { std::free(ptr); }
+
+void operator delete[](void *ptr) noexcept { std::free(ptr); }
+
+void operator delete(void *ptr, std::size_t) noexcept { std::free(ptr); }
+
+void operator delete[](void *ptr, std::size_t) noexcept { std::free(ptr); }
+
 namespace {
 
 namespace fs = std::filesystem;

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -111,14 +111,23 @@ bool fd_is_open(int fd) {
 #endif
 }
 
+std::ios::openmode runtime_open_mode(std::ios::openmode mode) {
+  volatile auto value = mode;
+  return value;
+}
+
 TEST_CASE("file open modes cover every flag mapping") {
-  CHECK(coro_io::to_flags(std::ios::app) == coro_io::flags::append);
-  CHECK(coro_io::to_flags(std::ios::trunc) == coro_io::flags::truncate);
-  CHECK(coro_io::to_flags(std::ios::trunc | std::ios::out) ==
+  CHECK(coro_io::to_flags(runtime_open_mode(std::ios::app)) ==
+        coro_io::flags::append);
+  CHECK(coro_io::to_flags(runtime_open_mode(std::ios::trunc)) ==
+        coro_io::flags::truncate);
+  CHECK(coro_io::to_flags(runtime_open_mode(std::ios::trunc | std::ios::out)) ==
         coro_io::flags::create_write_trunc);
-  CHECK(coro_io::to_flags(std::ios::in | std::ios::out | std::ios::trunc) ==
+  CHECK(coro_io::to_flags(runtime_open_mode(std::ios::in | std::ios::out |
+                                            std::ios::trunc)) ==
         coro_io::flags::create_read_write_trunc);
-  CHECK(coro_io::to_flags(std::ios::in | std::ios::out | std::ios::app) ==
+  CHECK(coro_io::to_flags(
+            runtime_open_mode(std::ios::in | std::ios::out | std::ios::app)) ==
         coro_io::flags::create_read_write_append);
 }
 

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -2,6 +2,7 @@
 #include <doctest.h>
 #include <fcntl.h>
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -41,21 +42,24 @@ class fail_next_allocation {
 
 }  // namespace allocation_failure
 
-extern "C" void *__real__Znwm(std::size_t size);
-extern "C" void *__real__Znam(std::size_t size);
-
-extern "C" void *__wrap__Znwm(std::size_t size) {
+void *operator new(std::size_t size) {
   if (allocation_failure::consume_failure()) {
     throw std::bad_alloc{};
   }
-  return __real__Znwm(size);
+  if (auto *ptr = std::malloc(size == 0 ? 1 : size)) {
+    return ptr;
+  }
+  throw std::bad_alloc{};
 }
 
-extern "C" void *__wrap__Znam(std::size_t size) {
+void *operator new[](std::size_t size) {
   if (allocation_failure::consume_failure()) {
     throw std::bad_alloc{};
   }
-  return __real__Znam(size);
+  if (auto *ptr = std::malloc(size == 0 ? 1 : size)) {
+    return ptr;
+  }
+  throw std::bad_alloc{};
 }
 
 namespace {

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <string_view>
 #include <system_error>
-
 #include <ylt/coro_io/coro_file.hpp>
 #include <ylt/coro_io/shared_file_handle.hpp>
 
@@ -184,8 +183,8 @@ TEST_CASE("shared file handle rejects invalid descriptors") {
   CHECK(negative_duplicate.first == std::errc::bad_file_descriptor);
   CHECK_FALSE(negative_duplicate.second.valid());
 
-  auto closed_duplicate = coro_io::shared_file_handle::duplicate(
-      std::numeric_limits<int>::max());
+  auto closed_duplicate =
+      coro_io::shared_file_handle::duplicate(std::numeric_limits<int>::max());
   CHECK(closed_duplicate.first == std::errc::bad_file_descriptor);
   CHECK_FALSE(closed_duplicate.second.valid());
 }

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -134,7 +134,7 @@ TEST_CASE("sequential file reports failure states") {
       coro_io::basic_seq_coro_file<coro_io::execution_type::thread_pool>;
 
   seq_file unopened;
-  CHECK_FALSE(unopened.seek(0));
+  CHECK_FALSE(unopened.seek(0, std::ios::beg));
   CHECK(unopened.get_execution_type() == coro_io::execution_type::none);
 
   test_file source("seq_failure.tmp", "content");

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -2,7 +2,6 @@
 #include <doctest.h>
 #include <fcntl.h>
 
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -43,26 +42,21 @@ class fail_next_allocation {
 
 }  // namespace allocation_failure
 
-void *operator new(std::size_t size) {
+extern "C" void *__real__Znwm(std::size_t size);
+extern "C" void *__real__Znam(std::size_t size);
+
+extern "C" void *__wrap__Znwm(std::size_t size) {
   if (allocation_failure::consume_failure()) {
     throw std::bad_alloc{};
   }
-  if (void *memory = std::malloc(size == 0 ? 1 : size)) {
-    return memory;
-  }
-  throw std::bad_alloc{};
+  return __real__Znwm(size);
 }
 
-void *operator new[](std::size_t size) { return ::operator new(size); }
-
-void operator delete(void *memory) noexcept { std::free(memory); }
-
-void operator delete[](void *memory) noexcept { std::free(memory); }
-
-void operator delete(void *memory, std::size_t) noexcept { std::free(memory); }
-
-void operator delete[](void *memory, std::size_t) noexcept {
-  std::free(memory);
+extern "C" void *__wrap__Znam(std::size_t size) {
+  if (allocation_failure::consume_failure()) {
+    throw std::bad_alloc{};
+  }
+  return __real__Znam(size);
 }
 
 namespace {

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -2,7 +2,7 @@
 #include <doctest.h>
 #include <fcntl.h>
 
-#include <cstdlib>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -42,33 +42,41 @@ class fail_next_allocation {
 
 }  // namespace allocation_failure
 
-void *operator new(std::size_t size) {
+#if SIZE_MAX == UINT64_MAX
+extern "C" void *__real__Znwm(std::size_t size);
+extern "C" void *__real__Znam(std::size_t size);
+
+extern "C" void *__wrap__Znwm(std::size_t size) {
   if (allocation_failure::consume_failure()) {
     throw std::bad_alloc{};
   }
-  if (auto *ptr = std::malloc(size == 0 ? 1 : size)) {
-    return ptr;
-  }
-  throw std::bad_alloc{};
+  return __real__Znwm(size);
 }
 
-void *operator new[](std::size_t size) {
+extern "C" void *__wrap__Znam(std::size_t size) {
   if (allocation_failure::consume_failure()) {
     throw std::bad_alloc{};
   }
-  if (auto *ptr = std::malloc(size == 0 ? 1 : size)) {
-    return ptr;
+  return __real__Znam(size);
+}
+#elif SIZE_MAX == UINT32_MAX
+extern "C" void *__real__Znwj(std::size_t size);
+extern "C" void *__real__Znaj(std::size_t size);
+
+extern "C" void *__wrap__Znwj(std::size_t size) {
+  if (allocation_failure::consume_failure()) {
+    throw std::bad_alloc{};
   }
-  throw std::bad_alloc{};
+  return __real__Znwj(size);
 }
 
-void operator delete(void *ptr) noexcept { std::free(ptr); }
-
-void operator delete[](void *ptr) noexcept { std::free(ptr); }
-
-void operator delete(void *ptr, std::size_t) noexcept { std::free(ptr); }
-
-void operator delete[](void *ptr, std::size_t) noexcept { std::free(ptr); }
+extern "C" void *__wrap__Znaj(std::size_t size) {
+  if (allocation_failure::consume_failure()) {
+    throw std::bad_alloc{};
+  }
+  return __real__Znaj(size);
+}
+#endif
 
 namespace {
 

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -149,8 +149,11 @@ TEST_CASE("sequential file reports failure states") {
   CHECK(write_result.first == std::errc::io_error);
   CHECK(write_result.second == 0);
 
+  auto previous_severity = easylog::get_min_severity();
+  easylog::set_min_severity(easylog::Severity::INFO);
   seq_file missing;
   CHECK_FALSE(missing.open("missing_directory/file", std::ios::in));
+  easylog::set_min_severity(previous_severity);
 }
 
 TEST_CASE("random file reports invalid and failure states") {

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -1,0 +1,261 @@
+#include <async_simple/coro/SyncAwait.h>
+#include <doctest.h>
+#include <fcntl.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <new>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include <ylt/coro_io/coro_file.hpp>
+#include <ylt/coro_io/shared_file_handle.hpp>
+
+#if defined(ASIO_WINDOWS)
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace allocation_failure {
+
+thread_local bool fail_next = false;
+
+bool consume_failure() noexcept {
+  if (!fail_next) {
+    return false;
+  }
+  fail_next = false;
+  return true;
+}
+
+class fail_next_allocation {
+ public:
+  fail_next_allocation() noexcept { fail_next = true; }
+  ~fail_next_allocation() { fail_next = false; }
+
+  fail_next_allocation(const fail_next_allocation &) = delete;
+  fail_next_allocation &operator=(const fail_next_allocation &) = delete;
+};
+
+}  // namespace allocation_failure
+
+void *operator new(std::size_t size) {
+  if (allocation_failure::consume_failure()) {
+    throw std::bad_alloc{};
+  }
+  if (void *memory = std::malloc(size == 0 ? 1 : size)) {
+    return memory;
+  }
+  throw std::bad_alloc{};
+}
+
+void *operator new[](std::size_t size) { return ::operator new(size); }
+
+void operator delete(void *memory) noexcept { std::free(memory); }
+
+void operator delete[](void *memory) noexcept { std::free(memory); }
+
+void operator delete(void *memory, std::size_t) noexcept { std::free(memory); }
+
+void operator delete[](void *memory, std::size_t) noexcept {
+  std::free(memory);
+}
+
+namespace {
+
+namespace fs = std::filesystem;
+
+#if defined(ASIO_WINDOWS)
+constexpr int read_only_flag = _O_RDONLY;
+#else
+constexpr int read_only_flag = O_RDONLY;
+#endif
+
+class test_file {
+ public:
+  test_file(std::string path, std::string_view content)
+      : path_(std::move(path)) {
+    std::ofstream output(path_, std::ios::binary);
+    output.write(content.data(), static_cast<std::streamsize>(content.size()));
+  }
+
+  ~test_file() {
+    std::error_code ec;
+    fs::remove(path_, ec);
+  }
+
+  const std::string &path() const { return path_; }
+
+ private:
+  std::string path_;
+};
+
+int open_read_only(const std::string &path) {
+#if defined(ASIO_WINDOWS)
+  return ::_open(path.c_str(), read_only_flag);
+#else
+  return ::open(path.c_str(), read_only_flag);
+#endif
+}
+
+void close_fd(int fd) {
+#if defined(ASIO_WINDOWS)
+  ::_close(fd);
+#else
+  ::close(fd);
+#endif
+}
+
+bool fd_is_open(int fd) {
+#if defined(ASIO_WINDOWS)
+  return ::_get_osfhandle(fd) != -1;
+#else
+  return ::fcntl(fd, F_GETFD) != -1;
+#endif
+}
+
+TEST_CASE("file open modes cover every flag mapping") {
+  CHECK(coro_io::to_flags(std::ios::app) == coro_io::flags::append);
+  CHECK(coro_io::to_flags(std::ios::trunc) == coro_io::flags::truncate);
+  CHECK(coro_io::to_flags(std::ios::trunc | std::ios::out) ==
+        coro_io::flags::create_write_trunc);
+  CHECK(coro_io::to_flags(std::ios::in | std::ios::out | std::ios::trunc) ==
+        coro_io::flags::create_read_write_trunc);
+  CHECK(coro_io::to_flags(std::ios::in | std::ios::out | std::ios::app) ==
+        coro_io::flags::create_read_write_append);
+}
+
+TEST_CASE("sequential file reports failure states") {
+  using seq_file =
+      coro_io::basic_seq_coro_file<coro_io::execution_type::thread_pool>;
+
+  seq_file unopened;
+  CHECK_FALSE(unopened.seek(0));
+  CHECK(unopened.get_execution_type() == coro_io::execution_type::none);
+
+  test_file source("seq_failure.tmp", "content");
+  seq_file file(source.path(), std::ios::in);
+  REQUIRE(file.get_execution_type() == coro_io::execution_type::thread_pool);
+  CHECK(file.open(source.path(), std::ios::in));
+
+  auto write_result =
+      async_simple::coro::syncAwait(file.async_write("cannot write"));
+  CHECK(write_result.first == std::errc::io_error);
+  CHECK(write_result.second == 0);
+
+  seq_file missing;
+  CHECK_FALSE(missing.open("missing_directory/file", std::ios::in));
+}
+
+TEST_CASE("random file reports invalid and failure states") {
+  using random_file =
+      coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool>;
+
+  random_file unopened;
+  CHECK_FALSE(unopened.is_open());
+  CHECK_FALSE(unopened.eof());
+  CHECK(unopened.get_execution_type() == coro_io::execution_type::none);
+
+  auto write_result =
+      async_simple::coro::syncAwait(unopened.async_write_at(0, "x"));
+  CHECK(write_result.first == std::errc::bad_file_descriptor);
+  CHECK(write_result.second == 0);
+
+  CHECK_FALSE(unopened.open("missing_directory/file", std::ios::in));
+
+  coro_io::shared_file_handle invalid_handle;
+  random_file invalid_file(invalid_handle);
+  CHECK_FALSE(invalid_file.is_open());
+
+  test_file source("random_failure.tmp", "content");
+  random_file file;
+  REQUIRE(file.open(source.path(), std::ios::in));
+  CHECK(file.open(source.path(), std::ios::in));
+
+  auto read_only_write =
+      async_simple::coro::syncAwait(file.async_write_at(0, "x"));
+  CHECK(read_only_write.first == std::errc::io_error);
+  CHECK(read_only_write.second == 0);
+}
+
+TEST_CASE("shared file handle rejects invalid descriptors") {
+  auto adopted = coro_io::shared_file_handle::adopt(-1);
+  CHECK_FALSE(adopted.valid());
+
+  auto negative_duplicate = coro_io::shared_file_handle::duplicate(-1);
+  CHECK(negative_duplicate.first == std::errc::bad_file_descriptor);
+  CHECK_FALSE(negative_duplicate.second.valid());
+
+  auto closed_duplicate = coro_io::shared_file_handle::duplicate(
+      std::numeric_limits<int>::max());
+  CHECK(closed_duplicate.first == std::errc::bad_file_descriptor);
+  CHECK_FALSE(closed_duplicate.second.valid());
+}
+
+TEST_CASE("shared file handle reports allocation failures") {
+  std::pair<std::error_code, coro_io::shared_file_handle> open_path_failure;
+  std::string long_path(128, 'x');
+  {
+    allocation_failure::fail_next_allocation failure;
+    open_path_failure =
+        coro_io::shared_file_handle::open(long_path, read_only_flag);
+  }
+  CHECK(open_path_failure.first == std::errc::not_enough_memory);
+  CHECK_FALSE(open_path_failure.second.valid());
+
+  test_file source("oom.tmp", "content");
+  std::pair<std::error_code, coro_io::shared_file_handle> open_handle_failure;
+  {
+    allocation_failure::fail_next_allocation failure;
+    open_handle_failure =
+        coro_io::shared_file_handle::open(source.path(), read_only_flag);
+  }
+  CHECK(open_handle_failure.first == std::errc::not_enough_memory);
+  CHECK_FALSE(open_handle_failure.second.valid());
+
+  int adopted_fd = open_read_only(source.path());
+  REQUIRE(adopted_fd >= 0);
+  coro_io::shared_file_handle adopted;
+  {
+    allocation_failure::fail_next_allocation failure;
+    adopted = coro_io::shared_file_handle::adopt(adopted_fd);
+  }
+  CHECK_FALSE(adopted.valid());
+  CHECK(fd_is_open(adopted_fd));
+  close_fd(adopted_fd);
+
+  int source_fd = open_read_only(source.path());
+  REQUIRE(source_fd >= 0);
+  std::pair<std::error_code, coro_io::shared_file_handle> duplicate_failure;
+  {
+    allocation_failure::fail_next_allocation failure;
+    duplicate_failure = coro_io::shared_file_handle::duplicate(source_fd);
+  }
+  CHECK(duplicate_failure.first == std::errc::not_enough_memory);
+  CHECK_FALSE(duplicate_failure.second.valid());
+  CHECK(fd_is_open(source_fd));
+  close_fd(source_fd);
+}
+
+TEST_CASE("random file reports state allocation failure") {
+  test_file source("state_oom.tmp", "content");
+  auto open_result =
+      coro_io::shared_file_handle::open(source.path(), read_only_flag);
+  REQUIRE_FALSE(open_result.first);
+  auto handle = std::move(open_result.second);
+
+  asio::io_context io_context;
+  {
+    allocation_failure::fail_next_allocation failure;
+    coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> file(
+        handle, io_context.get_executor());
+    CHECK_FALSE(file.is_open());
+  }
+  CHECK(handle.valid());
+}
+
+}  // namespace

--- a/src/coro_io/tests/test_file_error_paths.cpp
+++ b/src/coro_io/tests/test_file_error_paths.cpp
@@ -150,8 +150,11 @@ TEST_CASE("sequential file reports failure states") {
   CHECK(write_result.second == 0);
 
   auto previous_severity = easylog::get_min_severity();
-  easylog::set_min_severity(easylog::Severity::INFO);
+  easylog::set_min_severity(easylog::Severity::WARN);
   seq_file missing;
+  CHECK_FALSE(missing.open("missing_directory/file", std::ios::in));
+
+  easylog::set_min_severity(easylog::Severity::INFO);
   CHECK_FALSE(missing.open("missing_directory/file", std::ios::in));
   easylog::set_min_severity(previous_severity);
 }

--- a/src/coro_io/tests/test_shared_file_handle.cpp
+++ b/src/coro_io/tests/test_shared_file_handle.cpp
@@ -2,8 +2,8 @@
 #include <async_simple/coro/SyncAwait.h>
 #include <doctest.h>
 
-#include <asio/io_context.hpp>
 #include <array>
+#include <asio/io_context.hpp>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -13,7 +13,6 @@
 #include <thread>
 #include <utility>
 #include <vector>
-
 #include <ylt/coro_io/coro_file.hpp>
 #include <ylt/coro_io/shared_file_handle.hpp>
 
@@ -52,7 +51,9 @@ class io_context_runner {
   explicit io_context_runner(asio::io_context &io_context)
       : io_context_(io_context),
         work_(std::make_unique<asio::io_context::work>(io_context_)),
-        thread_([this] { io_context_.run(); }) {}
+        thread_([this] {
+          io_context_.run();
+        }) {}
 
   ~io_context_runner() {
     work_.reset();
@@ -92,9 +93,9 @@ void check_inflight_operation_retains_handle() {
   test_file source("shared_file_handle_inflight.tmp", content);
   test_file pressure("shared_file_handle_pressure.tmp", "other file");
 
-  auto [open_ec, handle] =
-      coro_io::shared_file_handle::open(source.path(), O_RDONLY);
-  REQUIRE_FALSE(open_ec);
+  auto open_result = coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  REQUIRE_FALSE(open_result.first);
+  auto handle = std::move(open_result.second);
   REQUIRE(handle.valid());
   const int fd = handle.native_handle();
 
@@ -141,9 +142,10 @@ TEST_CASE("shared_file_handle lifetime and factories") {
   test_file source("shared_file_handle_factories.tmp", "shared handle");
 
   SUBCASE("open and weak handle") {
-    auto [ec, handle] =
+    auto open_result =
         coro_io::shared_file_handle::open(source.path(), O_RDONLY);
-    REQUIRE_FALSE(ec);
+    REQUIRE_FALSE(open_result.first);
+    auto handle = std::move(open_result.second);
     REQUIRE(handle.valid());
 
     const int fd = handle.native_handle();
@@ -174,8 +176,9 @@ TEST_CASE("shared_file_handle lifetime and factories") {
   SUBCASE("duplicate") {
     int fd = ::open(source.path().c_str(), O_RDONLY);
     REQUIRE(fd >= 0);
-    auto [ec, handle] = coro_io::shared_file_handle::duplicate(fd);
-    REQUIRE_FALSE(ec);
+    auto duplicate_result = coro_io::shared_file_handle::duplicate(fd);
+    REQUIRE_FALSE(duplicate_result.first);
+    auto handle = std::move(duplicate_result.second);
     REQUIRE(handle.valid());
     const int duplicated_fd = handle.native_handle();
     CHECK(duplicated_fd != fd);
@@ -187,19 +190,19 @@ TEST_CASE("shared_file_handle lifetime and factories") {
   }
 
   SUBCASE("open failure") {
-    auto [ec, handle] = coro_io::shared_file_handle::open(
+    auto open_result = coro_io::shared_file_handle::open(
         "shared_file_handle_missing/file", O_RDONLY);
-    CHECK(ec);
-    CHECK_FALSE(handle.valid());
+    CHECK(open_result.first);
+    CHECK_FALSE(open_result.second.valid());
   }
 }
 
 TEST_CASE("thread pool wrappers share one file descriptor") {
   const std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
   test_file source("shared_file_handle_thread_pool.tmp", content);
-  auto [open_ec, handle] =
-      coro_io::shared_file_handle::open(source.path(), O_RDONLY);
-  REQUIRE_FALSE(open_ec);
+  auto open_result = coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  REQUIRE_FALSE(open_result.first);
+  auto handle = std::move(open_result.second);
   const int fd = handle.native_handle();
 
   asio::io_context io_context;
@@ -236,19 +239,19 @@ TEST_CASE("thread pool wrappers share one file descriptor") {
 
 TEST_CASE("closed random_coro_file rejects new operations") {
   test_file source("shared_file_handle_closed.tmp", "closed");
-  auto [open_ec, handle] =
-      coro_io::shared_file_handle::open(source.path(), O_RDONLY);
-  REQUIRE_FALSE(open_ec);
+  auto open_result = coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  REQUIRE_FALSE(open_result.first);
+  auto handle = std::move(open_result.second);
 
   coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> file(
       handle);
   file.close();
 
   char buffer{};
-  auto [read_ec, read_size] =
+  auto read_result =
       async_simple::coro::syncAwait(file.async_read_at(0, &buffer, 1));
-  CHECK(read_ec == std::errc::bad_file_descriptor);
-  CHECK(read_size == 0);
+  CHECK(read_result.first == std::errc::bad_file_descriptor);
+  CHECK(read_result.second == 0);
 }
 
 TEST_CASE("thread pool operation retains handle after wrapper destruction") {
@@ -266,9 +269,9 @@ TEST_CASE("native async wrappers share one file descriptor") {
   }
   test_file source("shared_file_handle_native_async.tmp", content);
 
-  auto [open_ec, handle] =
-      coro_io::shared_file_handle::open(source.path(), O_RDONLY);
-  REQUIRE_FALSE(open_ec);
+  auto open_result = coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  REQUIRE_FALSE(open_result.first);
+  auto handle = std::move(open_result.second);
   const int fd = handle.native_handle();
 
   asio::io_context io_context;
@@ -277,10 +280,8 @@ TEST_CASE("native async wrappers share one file descriptor") {
   using random_file =
       coro_io::basic_random_coro_file<coro_io::execution_type::native_async>;
   std::vector<std::unique_ptr<random_file>> files;
-  std::vector<std::string> buffers(wrapper_count,
-                                   std::string(read_size, '\0'));
-  std::vector<
-      async_simple::coro::Lazy<std::pair<std::error_code, size_t>>>
+  std::vector<std::string> buffers(wrapper_count, std::string(read_size, '\0'));
+  std::vector<async_simple::coro::Lazy<std::pair<std::error_code, size_t>>>
       operations;
   for (size_t index = 0; index < wrapper_count; ++index) {
     files.push_back(std::make_unique<random_file>(
@@ -293,14 +294,13 @@ TEST_CASE("native async wrappers share one file descriptor") {
   CHECK(count_file_descriptors_for_file(fd) == 1);
 #endif
 
-  auto results =
-      async_simple::coro::syncAwait(async_simple::coro::collectAll(
-          std::move(operations)));
+  auto results = async_simple::coro::syncAwait(
+      async_simple::coro::collectAll(std::move(operations)));
   REQUIRE(results.size() == wrapper_count);
   for (size_t index = 0; index < wrapper_count; ++index) {
-    auto [read_ec, bytes_read] = results[index].value();
-    CHECK_FALSE(read_ec);
-    CHECK(bytes_read == read_size);
+    auto read_result = results[index].value();
+    CHECK_FALSE(read_result.first);
+    CHECK(read_result.second == read_size);
     CHECK(buffers[index] ==
           std::string(read_size, static_cast<char>('A' + index)));
   }

--- a/src/coro_io/tests/test_shared_file_handle.cpp
+++ b/src/coro_io/tests/test_shared_file_handle.cpp
@@ -1,0 +1,323 @@
+#include <async_simple/coro/Collect.h>
+#include <async_simple/coro/SyncAwait.h>
+#include <doctest.h>
+
+#include <asio/io_context.hpp>
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <ylt/coro_io/coro_file.hpp>
+#include <ylt/coro_io/shared_file_handle.hpp>
+
+#if !defined(ASIO_WINDOWS)
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+class test_file {
+ public:
+  test_file(std::string path, std::string_view content)
+      : path_(std::move(path)) {
+    std::ofstream output(path_, std::ios::binary);
+    output.write(content.data(), static_cast<std::streamsize>(content.size()));
+  }
+
+  ~test_file() {
+    std::error_code ec;
+    fs::remove(path_, ec);
+  }
+
+  const std::string &path() const { return path_; }
+
+ private:
+  std::string path_;
+};
+
+bool is_fd_open(int fd) { return ::fcntl(fd, F_GETFD) != -1; }
+
+class io_context_runner {
+ public:
+  explicit io_context_runner(asio::io_context &io_context)
+      : io_context_(io_context),
+        work_(std::make_unique<asio::io_context::work>(io_context_)),
+        thread_([this] { io_context_.run(); }) {}
+
+  ~io_context_runner() {
+    work_.reset();
+    io_context_.stop();
+    thread_.join();
+  }
+
+ private:
+  asio::io_context &io_context_;
+  std::unique_ptr<asio::io_context::work> work_;
+  std::thread thread_;
+};
+
+#if defined(__linux__)
+size_t count_file_descriptors_for_file(int source_fd) {
+  struct stat source_stat {};
+  if (::fstat(source_fd, &source_stat) != 0) {
+    return 0;
+  }
+
+  size_t count = 0;
+  for (const auto &entry : fs::directory_iterator("/proc/self/fd")) {
+    struct stat candidate_stat {};
+    if (::stat(entry.path().c_str(), &candidate_stat) == 0 &&
+        candidate_stat.st_dev == source_stat.st_dev &&
+        candidate_stat.st_ino == source_stat.st_ino) {
+      ++count;
+    }
+  }
+  return count;
+}
+#endif
+
+template <coro_io::execution_type execute_type>
+void check_inflight_operation_retains_handle() {
+  const std::string content = "shared file handle in-flight read";
+  test_file source("shared_file_handle_inflight.tmp", content);
+  test_file pressure("shared_file_handle_pressure.tmp", "other file");
+
+  auto [open_ec, handle] =
+      coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  REQUIRE_FALSE(open_ec);
+  REQUIRE(handle.valid());
+  const int fd = handle.native_handle();
+
+  asio::io_context io_context;
+  auto file = std::make_unique<coro_io::basic_random_coro_file<execute_type>>(
+      handle, io_context.get_executor(), source.path());
+  REQUIRE(file->is_open());
+
+  std::array<char, 64> buffer{};
+  std::pair<std::error_code, size_t> result;
+  bool completed = false;
+  file->async_read_at(0, buffer.data(), content.size())
+      .start([&](auto &&value) {
+        result = value.value();
+        completed = true;
+      });
+
+  file.reset();
+  handle = {};
+  REQUIRE(is_fd_open(fd));
+  CHECK_FALSE(completed);
+
+  std::vector<int> pressure_fds;
+  for (size_t index = 0; index < 64; ++index) {
+    int pressure_fd = ::open(pressure.path().c_str(), O_RDONLY);
+    REQUIRE(pressure_fd >= 0);
+    CHECK(pressure_fd != fd);
+    pressure_fds.push_back(pressure_fd);
+  }
+
+  io_context.run();
+  REQUIRE(completed);
+  CHECK_FALSE(result.first);
+  CHECK(result.second == content.size());
+  CHECK(std::string_view(buffer.data(), content.size()) == content);
+  CHECK_FALSE(is_fd_open(fd));
+
+  for (int pressure_fd : pressure_fds) {
+    ::close(pressure_fd);
+  }
+}
+
+TEST_CASE("shared_file_handle lifetime and factories") {
+  test_file source("shared_file_handle_factories.tmp", "shared handle");
+
+  SUBCASE("open and weak handle") {
+    auto [ec, handle] =
+        coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+    REQUIRE_FALSE(ec);
+    REQUIRE(handle.valid());
+
+    const int fd = handle.native_handle();
+    auto weak = handle.weak();
+    {
+      auto copy = handle;
+      CHECK(copy.native_handle() == fd);
+      CHECK(weak.lock().native_handle() == fd);
+    }
+
+    CHECK(is_fd_open(fd));
+    handle = {};
+    CHECK(weak.expired());
+    CHECK_FALSE(is_fd_open(fd));
+  }
+
+  SUBCASE("adopt") {
+    int fd = ::open(source.path().c_str(), O_RDONLY);
+    REQUIRE(fd >= 0);
+    {
+      auto handle = coro_io::shared_file_handle::adopt(fd);
+      REQUIRE(handle.valid());
+      CHECK(handle.native_handle() == fd);
+    }
+    CHECK_FALSE(is_fd_open(fd));
+  }
+
+  SUBCASE("duplicate") {
+    int fd = ::open(source.path().c_str(), O_RDONLY);
+    REQUIRE(fd >= 0);
+    auto [ec, handle] = coro_io::shared_file_handle::duplicate(fd);
+    REQUIRE_FALSE(ec);
+    REQUIRE(handle.valid());
+    const int duplicated_fd = handle.native_handle();
+    CHECK(duplicated_fd != fd);
+
+    ::close(fd);
+    CHECK(is_fd_open(duplicated_fd));
+    handle = {};
+    CHECK_FALSE(is_fd_open(duplicated_fd));
+  }
+
+  SUBCASE("open failure") {
+    auto [ec, handle] = coro_io::shared_file_handle::open(
+        "shared_file_handle_missing/file", O_RDONLY);
+    CHECK(ec);
+    CHECK_FALSE(handle.valid());
+  }
+}
+
+TEST_CASE("thread pool wrappers share one file descriptor") {
+  const std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
+  test_file source("shared_file_handle_thread_pool.tmp", content);
+  auto [open_ec, handle] =
+      coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  REQUIRE_FALSE(open_ec);
+  const int fd = handle.native_handle();
+
+  asio::io_context io_context;
+  io_context_runner runner(io_context);
+
+  coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> first(
+      handle, io_context.get_executor(), source.path());
+  coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> second(
+      handle, io_context.get_executor(), source.path());
+#if defined(__linux__)
+  CHECK(count_file_descriptors_for_file(fd) == 1);
+#endif
+  handle = {};
+
+  std::array<char, 6> first_buffer{};
+  auto first_result = async_simple::coro::syncAwait(
+      first.async_read_at(0, first_buffer.data(), first_buffer.size()));
+  CHECK_FALSE(first_result.first);
+  CHECK(std::string_view(first_buffer.data(), first_buffer.size()) == "012345");
+
+  first.close();
+  CHECK(is_fd_open(fd));
+
+  std::array<char, 6> second_buffer{};
+  auto second_result = async_simple::coro::syncAwait(
+      second.async_read_at(6, second_buffer.data(), second_buffer.size()));
+  CHECK_FALSE(second_result.first);
+  CHECK(std::string_view(second_buffer.data(), second_buffer.size()) ==
+        "6789ab");
+
+  second.close();
+  CHECK_FALSE(is_fd_open(fd));
+}
+
+TEST_CASE("closed random_coro_file rejects new operations") {
+  test_file source("shared_file_handle_closed.tmp", "closed");
+  auto [open_ec, handle] =
+      coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  REQUIRE_FALSE(open_ec);
+
+  coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> file(
+      handle);
+  file.close();
+
+  char buffer{};
+  auto [read_ec, read_size] =
+      async_simple::coro::syncAwait(file.async_read_at(0, &buffer, 1));
+  CHECK(read_ec == std::errc::bad_file_descriptor);
+  CHECK(read_size == 0);
+}
+
+TEST_CASE("thread pool operation retains handle after wrapper destruction") {
+  check_inflight_operation_retains_handle<
+      coro_io::execution_type::thread_pool>();
+}
+
+#if defined(ASIO_HAS_FILE)
+TEST_CASE("native async wrappers share one file descriptor") {
+  constexpr size_t wrapper_count = 8;
+  constexpr size_t read_size = 32;
+  std::string content;
+  for (size_t index = 0; index < wrapper_count; ++index) {
+    content.append(read_size, static_cast<char>('A' + index));
+  }
+  test_file source("shared_file_handle_native_async.tmp", content);
+
+  auto [open_ec, handle] =
+      coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  REQUIRE_FALSE(open_ec);
+  const int fd = handle.native_handle();
+
+  asio::io_context io_context;
+  io_context_runner runner(io_context);
+
+  using random_file =
+      coro_io::basic_random_coro_file<coro_io::execution_type::native_async>;
+  std::vector<std::unique_ptr<random_file>> files;
+  std::vector<std::string> buffers(wrapper_count,
+                                   std::string(read_size, '\0'));
+  std::vector<
+      async_simple::coro::Lazy<std::pair<std::error_code, size_t>>>
+      operations;
+  for (size_t index = 0; index < wrapper_count; ++index) {
+    files.push_back(std::make_unique<random_file>(
+        handle, io_context.get_executor(), source.path()));
+    REQUIRE(files.back()->is_open());
+    operations.push_back(files.back()->async_read_at(
+        index * read_size, buffers[index].data(), read_size));
+  }
+#if defined(__linux__)
+  CHECK(count_file_descriptors_for_file(fd) == 1);
+#endif
+
+  auto results =
+      async_simple::coro::syncAwait(async_simple::coro::collectAll(
+          std::move(operations)));
+  REQUIRE(results.size() == wrapper_count);
+  for (size_t index = 0; index < wrapper_count; ++index) {
+    auto [read_ec, bytes_read] = results[index].value();
+    CHECK_FALSE(read_ec);
+    CHECK(bytes_read == read_size);
+    CHECK(buffers[index] ==
+          std::string(read_size, static_cast<char>('A' + index)));
+  }
+
+  files.front()->close();
+  CHECK(is_fd_open(fd));
+  files.clear();
+  CHECK(is_fd_open(fd));
+  handle = {};
+  CHECK_FALSE(is_fd_open(fd));
+}
+
+TEST_CASE("native async operation retains handle after wrapper destruction") {
+  check_inflight_operation_retains_handle<
+      coro_io::execution_type::native_async>();
+}
+#endif
+
+}  // namespace
+#endif

--- a/src/coro_io/tests/test_shared_file_handle.cpp
+++ b/src/coro_io/tests/test_shared_file_handle.cpp
@@ -1,9 +1,11 @@
 #include <async_simple/coro/Collect.h>
 #include <async_simple/coro/SyncAwait.h>
 #include <doctest.h>
+#include <fcntl.h>
 
 #include <array>
 #include <asio/io_context.hpp>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -11,19 +13,29 @@
 #include <string_view>
 #include <system_error>
 #include <thread>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include <ylt/coro_io/coro_file.hpp>
 #include <ylt/coro_io/shared_file_handle.hpp>
 
-#if !defined(ASIO_WINDOWS)
-#include <fcntl.h>
+#if defined(ASIO_WINDOWS)
+#include <io.h>
+#include <windows.h>
+#else
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
 
 namespace {
 
 namespace fs = std::filesystem;
+
+#if defined(ASIO_WINDOWS)
+constexpr int read_only_flag = _O_RDONLY;
+#else
+constexpr int read_only_flag = O_RDONLY;
+#endif
 
 class test_file {
  public:
@@ -44,7 +56,58 @@ class test_file {
   std::string path_;
 };
 
-bool is_fd_open(int fd) { return ::fcntl(fd, F_GETFD) != -1; }
+int open_read_only(const std::string &path) {
+#if defined(ASIO_WINDOWS)
+  return ::_open(path.c_str(), read_only_flag);
+#else
+  return ::open(path.c_str(), read_only_flag);
+#endif
+}
+
+void close_fd(int fd) {
+#if defined(ASIO_WINDOWS)
+  ::_close(fd);
+#else
+  ::close(fd);
+#endif
+}
+
+class file_descriptor_probe {
+ public:
+  explicit file_descriptor_probe(int fd)
+#if defined(ASIO_WINDOWS)
+      : handle_(::_get_osfhandle(fd)) {
+  }
+
+  bool is_open() const {
+    DWORD flags = 0;
+    return ::GetHandleInformation(reinterpret_cast<HANDLE>(handle_), &flags) !=
+           0;
+  }
+
+ private:
+  std::intptr_t handle_;
+#else
+      : fd_(fd) {
+  }
+
+  bool is_open() const { return ::fcntl(fd_, F_GETFD) != -1; }
+
+ private:
+  int fd_;
+#endif
+};
+
+#if defined(ASIO_WINDOWS)
+using windows_native_async_file =
+    coro_io::basic_random_coro_file<coro_io::execution_type::native_async>;
+using windows_thread_pool_file =
+    coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool>;
+static_assert(!std::is_constructible_v<windows_native_async_file,
+                                       coro_io::shared_file_handle>);
+static_assert(std::is_constructible_v<windows_thread_pool_file,
+                                      coro_io::shared_file_handle>);
+#endif
 
 class io_context_runner {
  public:
@@ -93,11 +156,13 @@ void check_inflight_operation_retains_handle() {
   test_file source("shared_file_handle_inflight.tmp", content);
   test_file pressure("shared_file_handle_pressure.tmp", "other file");
 
-  auto open_result = coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  auto open_result =
+      coro_io::shared_file_handle::open(source.path(), read_only_flag);
   REQUIRE_FALSE(open_result.first);
   auto handle = std::move(open_result.second);
   REQUIRE(handle.valid());
   const int fd = handle.native_handle();
+  const file_descriptor_probe fd_probe(fd);
 
   asio::io_context io_context;
   auto file = std::make_unique<coro_io::basic_random_coro_file<execute_type>>(
@@ -115,12 +180,12 @@ void check_inflight_operation_retains_handle() {
 
   file.reset();
   handle = {};
-  REQUIRE(is_fd_open(fd));
+  REQUIRE(fd_probe.is_open());
   CHECK_FALSE(completed);
 
   std::vector<int> pressure_fds;
   for (size_t index = 0; index < 64; ++index) {
-    int pressure_fd = ::open(pressure.path().c_str(), O_RDONLY);
+    int pressure_fd = open_read_only(pressure.path());
     REQUIRE(pressure_fd >= 0);
     CHECK(pressure_fd != fd);
     pressure_fds.push_back(pressure_fd);
@@ -131,10 +196,10 @@ void check_inflight_operation_retains_handle() {
   CHECK_FALSE(result.first);
   CHECK(result.second == content.size());
   CHECK(std::string_view(buffer.data(), content.size()) == content);
-  CHECK_FALSE(is_fd_open(fd));
+  CHECK_FALSE(fd_probe.is_open());
 
   for (int pressure_fd : pressure_fds) {
-    ::close(pressure_fd);
+    close_fd(pressure_fd);
   }
 }
 
@@ -143,12 +208,13 @@ TEST_CASE("shared_file_handle lifetime and factories") {
 
   SUBCASE("open and weak handle") {
     auto open_result =
-        coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+        coro_io::shared_file_handle::open(source.path(), read_only_flag);
     REQUIRE_FALSE(open_result.first);
     auto handle = std::move(open_result.second);
     REQUIRE(handle.valid());
 
     const int fd = handle.native_handle();
+    const file_descriptor_probe fd_probe(fd);
     auto weak = handle.weak();
     {
       auto copy = handle;
@@ -156,42 +222,44 @@ TEST_CASE("shared_file_handle lifetime and factories") {
       CHECK(weak.lock().native_handle() == fd);
     }
 
-    CHECK(is_fd_open(fd));
+    CHECK(fd_probe.is_open());
     handle = {};
     CHECK(weak.expired());
-    CHECK_FALSE(is_fd_open(fd));
+    CHECK_FALSE(fd_probe.is_open());
   }
 
   SUBCASE("adopt") {
-    int fd = ::open(source.path().c_str(), O_RDONLY);
+    int fd = open_read_only(source.path());
     REQUIRE(fd >= 0);
+    const file_descriptor_probe fd_probe(fd);
     {
       auto handle = coro_io::shared_file_handle::adopt(fd);
       REQUIRE(handle.valid());
       CHECK(handle.native_handle() == fd);
     }
-    CHECK_FALSE(is_fd_open(fd));
+    CHECK_FALSE(fd_probe.is_open());
   }
 
   SUBCASE("duplicate") {
-    int fd = ::open(source.path().c_str(), O_RDONLY);
+    int fd = open_read_only(source.path());
     REQUIRE(fd >= 0);
     auto duplicate_result = coro_io::shared_file_handle::duplicate(fd);
     REQUIRE_FALSE(duplicate_result.first);
     auto handle = std::move(duplicate_result.second);
     REQUIRE(handle.valid());
     const int duplicated_fd = handle.native_handle();
+    const file_descriptor_probe duplicated_fd_probe(duplicated_fd);
     CHECK(duplicated_fd != fd);
 
-    ::close(fd);
-    CHECK(is_fd_open(duplicated_fd));
+    close_fd(fd);
+    CHECK(duplicated_fd_probe.is_open());
     handle = {};
-    CHECK_FALSE(is_fd_open(duplicated_fd));
+    CHECK_FALSE(duplicated_fd_probe.is_open());
   }
 
   SUBCASE("open failure") {
     auto open_result = coro_io::shared_file_handle::open(
-        "shared_file_handle_missing/file", O_RDONLY);
+        "shared_file_handle_missing/file", read_only_flag);
     CHECK(open_result.first);
     CHECK_FALSE(open_result.second.valid());
   }
@@ -200,10 +268,12 @@ TEST_CASE("shared_file_handle lifetime and factories") {
 TEST_CASE("thread pool wrappers share one file descriptor") {
   const std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
   test_file source("shared_file_handle_thread_pool.tmp", content);
-  auto open_result = coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  auto open_result =
+      coro_io::shared_file_handle::open(source.path(), read_only_flag);
   REQUIRE_FALSE(open_result.first);
   auto handle = std::move(open_result.second);
   const int fd = handle.native_handle();
+  const file_descriptor_probe fd_probe(fd);
 
   asio::io_context io_context;
   io_context_runner runner(io_context);
@@ -224,7 +294,7 @@ TEST_CASE("thread pool wrappers share one file descriptor") {
   CHECK(std::string_view(first_buffer.data(), first_buffer.size()) == "012345");
 
   first.close();
-  CHECK(is_fd_open(fd));
+  CHECK(fd_probe.is_open());
 
   std::array<char, 6> second_buffer{};
   auto second_result = async_simple::coro::syncAwait(
@@ -234,12 +304,13 @@ TEST_CASE("thread pool wrappers share one file descriptor") {
         "6789ab");
 
   second.close();
-  CHECK_FALSE(is_fd_open(fd));
+  CHECK_FALSE(fd_probe.is_open());
 }
 
 TEST_CASE("closed random_coro_file rejects new operations") {
   test_file source("shared_file_handle_closed.tmp", "closed");
-  auto open_result = coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  auto open_result =
+      coro_io::shared_file_handle::open(source.path(), read_only_flag);
   REQUIRE_FALSE(open_result.first);
   auto handle = std::move(open_result.second);
 
@@ -259,7 +330,7 @@ TEST_CASE("thread pool operation retains handle after wrapper destruction") {
       coro_io::execution_type::thread_pool>();
 }
 
-#if defined(ASIO_HAS_FILE)
+#if defined(ASIO_HAS_FILE) && !defined(ASIO_WINDOWS)
 TEST_CASE("native async wrappers share one file descriptor") {
   constexpr size_t wrapper_count = 8;
   constexpr size_t read_size = 32;
@@ -269,10 +340,12 @@ TEST_CASE("native async wrappers share one file descriptor") {
   }
   test_file source("shared_file_handle_native_async.tmp", content);
 
-  auto open_result = coro_io::shared_file_handle::open(source.path(), O_RDONLY);
+  auto open_result =
+      coro_io::shared_file_handle::open(source.path(), read_only_flag);
   REQUIRE_FALSE(open_result.first);
   auto handle = std::move(open_result.second);
   const int fd = handle.native_handle();
+  const file_descriptor_probe fd_probe(fd);
 
   asio::io_context io_context;
   io_context_runner runner(io_context);
@@ -306,11 +379,11 @@ TEST_CASE("native async wrappers share one file descriptor") {
   }
 
   files.front()->close();
-  CHECK(is_fd_open(fd));
+  CHECK(fd_probe.is_open());
   files.clear();
-  CHECK(is_fd_open(fd));
+  CHECK(fd_probe.is_open());
   handle = {};
-  CHECK_FALSE(is_fd_open(fd));
+  CHECK_FALSE(fd_probe.is_open());
 }
 
 TEST_CASE("native async operation retains handle after wrapper destruction") {
@@ -320,4 +393,3 @@ TEST_CASE("native async operation retains handle after wrapper destruction") {
 #endif
 
 }  // namespace
-#endif

--- a/src/coro_io/tests/test_shared_file_handle.cpp
+++ b/src/coro_io/tests/test_shared_file_handle.cpp
@@ -279,9 +279,15 @@ TEST_CASE("thread pool wrappers share one file descriptor") {
   io_context_runner runner(io_context);
 
   coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> first(
-      handle, io_context.get_executor(), source.path());
+      handle, io_context.get_executor());
   coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> second(
       handle, io_context.get_executor(), source.path());
+  CHECK(first.file_path().empty());
+  CHECK(first.file_size() == content.size());
+  std::error_code file_size_error =
+      std::make_error_code(std::errc::invalid_argument);
+  CHECK(first.file_size(file_size_error) == content.size());
+  CHECK_FALSE(file_size_error);
 #if defined(__linux__)
   CHECK(count_file_descriptors_for_file(fd) == 1);
 #endif

--- a/src/coro_io/tests/test_shared_file_handle.cpp
+++ b/src/coro_io/tests/test_shared_file_handle.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -321,14 +322,34 @@ TEST_CASE("closed random_coro_file rejects new operations") {
   auto handle = std::move(open_result.second);
 
   coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> file(
-      handle);
+      handle, coro_io::get_global_block_executor(), source.path());
   file.close();
+
+  std::error_code file_size_error =
+      std::make_error_code(std::errc::invalid_argument);
+  CHECK(file.file_size(file_size_error) == 6);
+  CHECK_FALSE(file_size_error);
+  CHECK(file.file_size() == 6);
 
   char buffer{};
   auto read_result =
       async_simple::coro::syncAwait(file.async_read_at(0, &buffer, 1));
   CHECK(read_result.first == std::errc::bad_file_descriptor);
   CHECK(read_result.second == 0);
+}
+
+TEST_CASE("random_coro_file reports native handle size errors") {
+  auto handle = coro_io::shared_file_handle::adopt(
+      std::numeric_limits<
+          coro_io::shared_file_handle::native_handle_type>::max());
+  REQUIRE(handle.valid());
+
+  coro_io::basic_random_coro_file<coro_io::execution_type::thread_pool> file(
+      handle);
+  std::error_code ec;
+  CHECK(file.file_size(ec) == static_cast<size_t>(-1));
+  CHECK(ec == std::errc::bad_file_descriptor);
+  CHECK_THROWS_AS(file.file_size(), std::system_error);
 }
 
 TEST_CASE("thread pool operation retains handle after wrapper destruction") {


### PR DESCRIPTION
## Why

Allow multiple `random_coro_file` wrappers to safely share one native file descriptor without duplicating ownership or closing the descriptor while asynchronous I/O is still in flight.

## What is changing

- Add `shared_file_handle` and `weak_file_handle` RAII wrappers with open, adopt, duplicate, and lifetime-sharing support.
- Refactor `basic_random_coro_file` to retain immutable file state for in-flight operations and atomically detach that state on close.
- Support atomic `shared_ptr` state access in both C++17 and C++20.
- Keep the underlying Asio file object alive until pending native async operations finish.
- Hide direct access to the internal random-access stream handle.
- Add lifecycle, concurrent-close, weak-handle, duplicate, and error-path tests.

## Testing

- C++17 and C++20 `coro_io` unit tests passed on Linux with io_uring.
- Multi-wrapper native async benchmark: 10 files × 32 wrappers per file, 320 total coroutines, QD320.
- All 36 benchmark runs completed with `errors=0` and expected file-descriptor counts.
- At 32 I/O threads, shared/path-open median throughput differed by 0.25%, while shared mode reduced file descriptors from 320 to 10.

Refs #1217